### PR TITLE
ci: use GitHub-hosted runner for baseline init (remove self-hosted de…

### DIFF
--- a/.github/workflows/ci-freeze.yml
+++ b/.github/workflows/ci-freeze.yml
@@ -60,7 +60,7 @@ jobs:
 
   init_perf_baseline:
     if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.init_perf_baseline == 'true' }}
-    runs-on: [self-hosted, linux, x64, aykenos-perf01]
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
       CI: "true"


### PR DESCRIPTION
…pendency)

# Freeze PR Template

## Gate Run

- Run ID:
- Evidence Path (`evidence/run-<id>/`):

## Gate Verdicts

- ABI (`ci-gate-abi`):
- Boundary (`ci-gate-boundary`):
- Workspace (`ci-gate-workspace`):
- Hygiene (`ci-gate-hygiene`):
- Performance (`ci-gate-performance`):
- Summary (`ci-summarize`):

## Contract Change

- Changed contracts: `yes/no`
- If yes, exact paths:

## RFC / Waiver

- RFC link (if required):
- Waiver link (if required):

## Claim Check

If this PR claims `Completed/Production-ready`, all must be true:
1. `summary.json` verdict is `PASS`
2. test + benchmark evidence linked
3. related docs updated
4. architecture review note linked

## Notes

- Planned gates may be hard-fail stubs during freeze hardening.
- Do not merge feature work into mainline during active freeze.
