### PR TITLE
ci(perf): add mtools dependency for EFI image build

### DIFF
--- a/.github/workflows/perf-baseline-init.yml
+++ b/.github/workflows/perf-baseline-init.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y qemu-system-x86 clang lld nasm jq
+          sudo apt-get install -y qemu-system-x86 clang lld nasm jq mtools
       
       - name: Resolve baseline init digest
         run: |


### PR DESCRIPTION
- Add mtools package to baseline init workflow dependencies
- Required for mformat command in make_efi_img.sh
- Fixes EFI.img build failure in baseline initialization
- Does not affect baseline authority or constitutional compliance

# Freeze PR Template

## Gate Run

- Run ID:
- Evidence Path (`evidence/run-<id>/`):

## Gate Verdicts

- ABI (`ci-gate-abi`):
- Boundary (`ci-gate-boundary`):
- Tooling Isolation (`ci-gate-tooling-isolation`):
- Constitutional (`ci-gate-constitutional`):
- Workspace (`ci-gate-workspace`):
- Hygiene (`ci-gate-hygiene`):
- Performance (`ci-gate-performance`):
- Summary (`ci-summarize`):

## Tooling Isolation Guard

- Perf/preempt tooling touched in this PR: `yes/no`
- If yes, `kernel touch = 0`: `yes/no`
- Tooling isolation evidence path (`evidence/run-<id>/gates/tooling-isolation/`):

## Contract Change

- Changed contracts: `yes/no`
- If yes, exact paths:

## RFC / Waiver

- RFC link (if required):
- Waiver link (if required):

## Claim Check

If this PR claims `Completed/Production-ready`, all must be true:
1. `summary.json` verdict is `PASS`
2. test + benchmark evidence linked
3. related docs updated
4. architecture review note linked

## Notes

- Planned gates may be hard-fail stubs during freeze hardening.
- Do not merge feature work into mainline during active freeze.
