### PR TITLE
fix(ci): baseline init now overwrites existing baseline

### DIFF
--- a/.github/workflows/ci-freeze.yml
+++ b/.github/workflows/ci-freeze.yml
@@ -266,6 +266,21 @@ jobs:
           set -euo pipefail
           ls -la scripts/ci/perf-baseline.lock.json
           sed -n '1,120p' scripts/ci/perf-baseline.lock.json
+      - name: Validate baseline lock matches checked out commit
+        run: |
+          set -euo pipefail
+          BASELINE_SHA="$(jq -r '.git_sha // empty' scripts/ci/perf-baseline.lock.json)"
+          HEAD_SHA="$(git rev-parse HEAD)"
+          if [ -z "${BASELINE_SHA}" ]; then
+            echo "ERROR: Baseline lock is missing git_sha"
+            exit 1
+          fi
+          if [ "${BASELINE_SHA}" != "${HEAD_SHA}" ]; then
+            echo "ERROR: Baseline lock git_sha does not match checkout HEAD"
+            echo "baseline.git_sha=${BASELINE_SHA}"
+            echo "checkout.HEAD=${HEAD_SHA}"
+            exit 1
+          fi
       - name: Debug artifact paths before upload
         if: ${{ always() }}
         run: |

--- a/scripts/ci/gate_performance.sh
+++ b/scripts/ci/gate_performance.sh
@@ -625,7 +625,21 @@ PY
 # 8) Baseline policy and compare.
 DRIFT_ALLOWLIST_BYPASS_COUNT=0
 
-if [[ -f "${BASELINE_FILE}" ]]; then
+if [[ "${INIT_BASELINE}" -eq 1 ]]; then
+  IS_CI="0"
+  if [[ "${CI:-}" == "1" || "${CI:-}" == "true" || "${CI:-}" == "TRUE" ]]; then
+    IS_CI="1"
+  fi
+  if [[ "${REQUIRE_CI_FOR_BASELINE_INIT}" -eq 1 && "${IS_CI}" -ne 1 ]]; then
+    record_violation "baseline_init_requires_ci:CI env is not true/1"
+  elif [[ "${IS_CI}" -eq 1 ]] && ! is_pinned_ci_digest "${CI_IMAGE_DIGEST}" "${BASELINE_AUTHORITY}"; then
+    record_violation "baseline_init_requires_ci_image_digest:PERF_CI_IMAGE_DIGEST must be pinned (authority=${BASELINE_AUTHORITY}, digest=${CI_IMAGE_DIGEST})"
+  else
+    mkdir -p "$(dirname "${BASELINE_FILE}")"
+    cp -f "${ACTUAL_LOCK_JSON}" "${BASELINE_FILE}"
+    record_violation "baseline_initialized_requires_commit:${BASELINE_FILE}"
+  fi
+elif [[ -f "${BASELINE_FILE}" ]]; then
   BASELINE_REL=""
   if [[ "${BASELINE_FILE}" == "${ROOT}/"* ]]; then
     BASELINE_REL="${BASELINE_FILE#${ROOT}/}"
@@ -752,29 +766,13 @@ PY
     fi
   fi
 else
-  if [[ "${INIT_BASELINE}" -eq 1 ]]; then
-    IS_CI="0"
-    if [[ "${CI:-}" == "1" || "${CI:-}" == "true" || "${CI:-}" == "TRUE" ]]; then
-      IS_CI="1"
-    fi
-    if [[ "${REQUIRE_CI_FOR_BASELINE_INIT}" -eq 1 && "${IS_CI}" -ne 1 ]]; then
-      record_violation "baseline_init_requires_ci:CI env is not true/1"
-    elif [[ "${IS_CI}" -eq 1 ]] && ! is_pinned_ci_digest "${CI_IMAGE_DIGEST}" "${BASELINE_AUTHORITY}"; then
-      record_violation "baseline_init_requires_ci_image_digest:PERF_CI_IMAGE_DIGEST must be pinned (authority=${BASELINE_AUTHORITY}, digest=${CI_IMAGE_DIGEST})"
-    else
-      mkdir -p "$(dirname "${BASELINE_FILE}")"
-      cp -f "${ACTUAL_LOCK_JSON}" "${BASELINE_FILE}"
-      record_violation "baseline_initialized_requires_commit:${BASELINE_FILE}"
-    fi
+  # Baseline missing
+  if [[ "${BASELINE_MODE}" == "provisional" ]]; then
+    # Provisional mode: baseline missing is acceptable, skip gate
+    echo "WARN: Baseline missing in provisional mode, skipping enforcement" >&2
   else
-    # Baseline missing
-    if [[ "${BASELINE_MODE}" == "provisional" ]]; then
-      # Provisional mode: baseline missing is acceptable, skip gate
-      echo "WARN: Baseline missing in provisional mode, skipping enforcement" >&2
-    else
-      # Constitutional mode: baseline missing is a violation
-      record_violation "baseline_missing:${BASELINE_FILE}"
-    fi
+    # Constitutional mode: baseline missing is a violation
+    record_violation "baseline_missing:${BASELINE_FILE}"
   fi
 fi
 


### PR DESCRIPTION
## Problem

Baseline init workflow was producing stale artifacts:
- `INIT_BASELINE=1` was ignored when baseline file existed
- Script entered 'baseline exists' branch instead of 'init' branch
- Artifact always contained old baseline (git_sha: 218a8c4b)

## Root Cause

`gate_performance.sh` checked `if [[ -f "${BASELINE_FILE}" ]]` before checking `INIT_BASELINE` flag, so init logic was never reached.

## Fix

1. **Moved INIT_BASELINE check to top priority** (line 628)
   - Now checks `INIT_BASELINE=1` first
   - Overwrites existing baseline when in init mode

2. **Added workflow guard** (line 269)
   - Validates `baseline.git_sha == checkout.HEAD`
   - Fails job if mismatch detected

## Validation

- ✅ `bash -n gate_performance.sh`: PASS
- ✅ YAML parse: PASS
- ✅ Logic flow verified

## Impact

- Baseline init workflow will now produce correct baseline for current commit
- No more stale artifact issues
- Constitutional baseline update process restored

## Next Steps

After merge:
1. Run baseline init workflow
2. Verify artifact contains correct git_sha (fedfbba1)
3. Commit baseline update
4. Revert to constitutional mode