### PR TITLE
perf(baseline): update baseline for Phase10 deterministic validation

### DIFF
--- a/scripts/ci/perf-baseline.lock.json
+++ b/scripts/ci/perf-baseline.lock.json
@@ -1,10 +1,10 @@
 {
-  "created_at_utc": "2026-03-01T21:17:42Z",
+  "created_at_utc": "2026-03-05T20:11:56Z",
   "env": {
     "baseline_authority": "github-hosted-ubuntu-24.04-x64",
-    "ci_image_digest": "gha-ubuntu24-20260224.36.1-X64",
+    "ci_image_digest": "gha-ubuntu24-20260302.42.1-X64",
     "clang_version": "Ubuntu clang version 18.1.3 (1ubuntu1)",
-    "env_hash": "ff9a79dbdc12cb59c67d62a82d12931a600f453c78ee23d70edbe8b66081a524",
+    "env_hash": "d2d850b4b2ab26361c116fb36decc8888d636068c1b3613c820e91b1ed9f416d",
     "host_arch": "x86_64",
     "host_os": "Linux",
     "kernel_profile": "validation",
@@ -22,14 +22,14 @@
     },
     "nasm_version": "NASM version 2.16.01",
     "qemu_timeout_seconds": 30,
-    "qemu_version": "QEMU emulator version 8.2.2 (Debian 1:8.2.2+ds-0ubuntu1.12)",
+    "qemu_version": "QEMU emulator version 8.2.2 (Debian 1:8.2.2+ds-0ubuntu1.13)",
     "target_triple": "x86_64-elf"
   },
-  "git_sha": "218a8c4b83985fa9f3e61dff61388d7b6826fe38",
+  "git_sha": "ddb72712223a32c7a17648e4fa800cb50b8e05eb",
   "metrics": {
-    "boot_time_ms": 10784,
-    "context_switch_latency_ms_proxy": 166.83871,
-    "syscall_latency_ms_proxy": 166.83871
+    "boot_time_ms": 10165,
+    "context_switch_latency_ms_proxy": 161.887097,
+    "syscall_latency_ms_proxy": 161.887097
   },
   "policy": {
     "baseline_authority": "github-hosted-ubuntu-24.04-x64",
@@ -52,14 +52,14 @@
     }
   },
   "raw_metrics": {
-    "boot_time_ms": 10784,
-    "context_switch_latency_ms_proxy": 166.83871,
+    "boot_time_ms": 10165,
+    "context_switch_latency_ms_proxy": 161.887097,
     "preempt_iret_count": 62,
-    "preempt_qemu_run_time_ms": 10344,
-    "preempt_run_time_ms": 10344,
+    "preempt_qemu_run_time_ms": 10037,
+    "preempt_run_time_ms": 10037,
     "preempt_sw_count": 62,
-    "preempt_wall_time_ms": 12607,
-    "syscall_latency_ms_proxy": 166.83871
+    "preempt_wall_time_ms": 11773,
+    "syscall_latency_ms_proxy": 161.887097
   },
   "schema_version": 1
 }


### PR DESCRIPTION
## Summary

Updates performance baseline to Phase10 deterministic validation commit.

## Baseline Details

**Previous:**
- git_sha: `218a8c4b`
- created_at: 2026-03-01T21:17:42Z
- ci_image: gha-ubuntu24-20260224.36.1-X64

**New:**
- git_sha: `ddb72712` (Phase10 fix)
- created_at: 2026-03-05T20:11:56Z
- ci_image: gha-ubuntu24-20260302.42.1-X64

## Metrics

Deterministic preempt harness:
- `preempt_sw_count`: 62 ✅
- `preempt_iret_count`: 62 ✅
- `boot_time_ms`: 10165
- `context_switch_latency_ms_proxy`: 161.887097

## Authority

- Environment: `github-hosted-ubuntu-24.04-x64`
- Workflow run: 22734694544
- Generated: 2026-03-05T20:11:56Z

## Impact

- Performance gate will now use correct baseline
- CI freeze can return to constitutional mode
- Phase10-A2 baseline locked

## Next Steps

After merge:
1. Revert workflow to constitutional mode
2. Phase10-A2 CLOSED
3. Begin Phase10-B work