### PR TITLE
ci: revert to constitutional mode

### DIFF
--- a/.github/workflows/ci-freeze.yml
+++ b/.github/workflows/ci-freeze.yml
@@ -39,7 +39,7 @@ jobs:
     env:
       CI: "true"
       RUN_ID: "gh-${{ github.run_id }}-${{ github.run_attempt }}"
-      PERF_BASELINE_MODE: "provisional"  # Temporary: baseline update in progress
+      PERF_BASELINE_MODE: "constitutional"  # Baseline-locked, fail on regression
       PERF_REQUIRE_CI_FOR_BASELINE_INIT: "1"
       PERF_QEMU_TIMEOUT: "30"
       PERF_KERNEL_PROFILE: "validation"


### PR DESCRIPTION
## Summary

Re-enable constitutional CI mode after Phase10 baseline update.

## Changes

- `.github/workflows/ci-freeze.yml`: `PERF_BASELINE_MODE: provisional` → `constitutional`

## Rationale

**Previous State (Provisional Mode):**
- Baseline update in progress
- Performance gate in measurement-only mode
- Temporary relaxation for baseline initialization

**Current State (Constitutional Mode):**
- Baseline locked at `4658e99a` (Phase10 deterministic validation)
- Performance gate enforces fail-on-regression
- Full freeze discipline restored

## Baseline Lock

```json
{
  "git_sha": "4658e99a",
  "phase": "Phase10-A2",
  "authority": "CI runner (GitHub Actions)",
  "locked": true
}
```

## Constitutional Compliance

- ✅ Rule 5 (Determinism Requirement): Baseline locked, CI reproducibility enforced
- ✅ Rule 4 (Evidence Integrity): Baseline immutable without RFC
- ✅ ARCHITECTURE_FREEZE.md: Fail-closed enforcement active

## Testing

- CI freeze gates will validate constitutional mode
- Performance regression detection active
- Baseline authority check enforced

## Phase10-A2 Status

**READY FOR CLOSURE** - Constitutional mode restored, deterministic validation complete.
