### PR TITLE
fix(ci): normalize github-hosted perf baseline env

### DIFF
--- a/scripts/ci/gate_performance.sh
+++ b/scripts/ci/gate_performance.sh
@@ -378,7 +378,13 @@ payload = {
         "preempt_expected_qemu_exit_set": os.environ["PREEMPT_EXPECTED_QEMU_EXIT_SET_ENV"],
     },
 }
-canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+hash_payload = dict(payload)
+if str(payload.get("baseline_authority", "")).startswith("github-hosted-"):
+    # GitHub-hosted ubuntu labels can rotate between image build digests even
+    # when the effective toolchain surface stays identical. Keep the digest for
+    # audit, but hash the stable authority + explicit tool versions instead.
+    hash_payload.pop("ci_image_digest", None)
+canonical = json.dumps(hash_payload, sort_keys=True, separators=(",", ":"))
 payload["env_hash"] = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 with open(out, "w", encoding="utf-8") as fh:
     json.dump(payload, fh, indent=2, sort_keys=True)
@@ -701,7 +707,13 @@ if b_authority != a_authority:
 
 b_ci_image = baseline.get("env", {}).get("ci_image_digest")
 a_ci_image = actual.get("env", {}).get("ci_image_digest")
-if b_ci_image != a_ci_image:
+digest_is_blocking = not (
+    isinstance(b_authority, str)
+    and isinstance(a_authority, str)
+    and b_authority.startswith("github-hosted-")
+    and a_authority.startswith("github-hosted-")
+)
+if b_ci_image != a_ci_image and digest_is_blocking:
     diffs.append(f"ci_image_digest_mismatch: baseline={b_ci_image} actual={a_ci_image}")
 
 def check_metric(key):

--- a/scripts/ci/perf-baseline.lock.json
+++ b/scripts/ci/perf-baseline.lock.json
@@ -4,7 +4,7 @@
     "baseline_authority": "github-hosted-ubuntu-24.04-x64",
     "ci_image_digest": "gha-ubuntu24-20260302.42.1-X64",
     "clang_version": "Ubuntu clang version 18.1.3 (1ubuntu1)",
-    "env_hash": "d2d850b4b2ab26361c116fb36decc8888d636068c1b3613c820e91b1ed9f416d",
+    "env_hash": "3e27c53c19161b644374d8151f8084cf542a3d66d42a7bc94b0cb9a842944409",
     "host_arch": "x86_64",
     "host_os": "Linux",
     "kernel_profile": "validation",


### PR DESCRIPTION
## Summary
Normalize the performance baseline environment contract for GitHub-hosted runners so image build digest flapping does not produce false baseline mismatches.

## Changes
- Exclude  from  when baseline authority is 
- Keep  as an audit field, but stop treating GitHub-hosted digest drift as a blocking mismatch
- Refresh  to the normalized env hash

## Why
GitHub-hosted  runners are rotating between different image digests while exposing the same effective toolchain surface, which makes  flap on  without a real metric regression.

## Validation
- 
- Replayed the failing run  performance artifact against the new normalization logic and confirmed it no longer produces baseline diffs