### PR TITLE
ci(freeze): upload performance evidence on success

### DIFF
--- a/.github/workflows/ci-freeze.yml
+++ b/.github/workflows/ci-freeze.yml
@@ -148,6 +148,14 @@ jobs:
         with:
           path: .ci-state
           key: drift-state-${{ steps.drift_auth.outputs.authority_hash }}
+      - name: Upload performance evidence on success
+        if: ${{ success() && github.event_name != 'pull_request' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: performance-evidence-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: error
+          path: |
+            evidence/run-*/gates/performance/**
       - name: Dump gate violations on failure
         if: failure()
         run: |


### PR DESCRIPTION
## Summary
- upload performance gate evidence artifacts on successful non-PR ci-freeze runs
- keep PR success runs artifact-free to avoid unnecessary artifact volume
- preserve existing failure-path freeze evidence upload

## Why
The first 5 post-merge ci-freeze PASS runs on main produced no artifacts, which meant the performance learning pipeline could not harvest canonical CI performance reports.

## Validation
- workflow patch is minimal and isolated to ci-freeze.yml
- branch validation run triggered: 23984363323
