### PR TITLE
ci(perf): add learning comment workflow

### DIFF
--- a/.github/workflows/perf-learning-comment.yml
+++ b/.github/workflows/perf-learning-comment.yml
@@ -1,0 +1,102 @@
+name: perf-learning-comment
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_ids:
+        description: "Comma-separated successful ci-freeze run IDs"
+        required: true
+      post_pr_comment:
+        description: "Post comment to a PR"
+        type: boolean
+        required: true
+        default: false
+      pr_number:
+        description: "PR number for comment posting"
+        required: false
+        default: ""
+
+jobs:
+  analyze:
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install deps
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y jq python3
+
+      - name: Make scripts executable
+        run: |
+          set -euo pipefail
+          chmod +x scripts/ci/threshold_generator.py
+          chmod +x scripts/ci/render_threshold_comment.py
+          chmod +x scripts/ci/update_threshold_timeline.py
+          chmod +x scripts/ci/harvest_performance_artifacts.sh
+
+      - name: Harvest performance artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          IFS=',' read -r -a RUN_IDS <<< "${{ github.event.inputs.run_ids }}"
+          scripts/ci/harvest_performance_artifacts.sh out "${RUN_IDS[@]}"
+
+      - name: Generate threshold policy
+        run: |
+          set -euo pipefail
+          mkdir -p out/reports
+          python3 scripts/ci/threshold_generator.py \
+            --learning-summary out/evidence/run-learning-batch/gates/performance-learning/summary.json \
+            --output out/reports/threshold_policy.json
+
+      - name: Render PR comment
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/render_threshold_comment.py \
+            --threshold-policy out/reports/threshold_policy.json \
+            --output out/reports/threshold_comment.md
+
+      - name: Update timeline
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/update_threshold_timeline.py \
+            --threshold-policy out/reports/threshold_policy.json \
+            --timeline out/reports/threshold_timeline.json \
+            --run-id "learning-${{ github.run_id }}-${{ github.run_attempt }}" \
+            --git-sha "$(git rev-parse HEAD)" \
+            --created-at-utc "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+      - name: Upload outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-learning-outputs-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: error
+          path: |
+            out/evidence/run-learning-batch/gates/performance-learning/**
+            out/reports/threshold_policy.json
+            out/reports/threshold_comment.md
+            out/reports/threshold_timeline.json
+
+      - name: Post PR comment
+        if: ${{ github.event.inputs.post_pr_comment == 'true' && github.event.inputs.pr_number != '' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('out/reports/threshold_comment.md', 'utf8');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number('${{ github.event.inputs.pr_number }}'),
+              body
+            });

--- a/scripts/ci/harvest_performance_artifacts.sh
+++ b/scripts/ci/harvest_performance_artifacts.sh
@@ -30,8 +30,14 @@ for id in "${RUN_IDS[@]}"; do
   if [[ -z "${id}" ]]; then
     continue
   fi
+  artifact_name="$(gh api "repos/:owner/:repo/actions/runs/${id}/artifacts" --jq \
+    ".artifacts[] | select(.name | startswith(\"performance-evidence-${id}-\")) | .name" | head -n1)"
+  if [[ -z "${artifact_name}" ]]; then
+    echo "ERROR: missing performance artifact for run ${id}" >&2
+    exit 1
+  fi
   mkdir -p "${BATCH_DIR}/${id}"
-  gh run download "${id}" --name "performance-evidence-${id}-1" --dir "${BATCH_DIR}/${id}"
+  gh run download "${id}" --name "${artifact_name}" --dir "${BATCH_DIR}/${id}"
 done
 
 scripts/ci/gate_performance_learning_review.sh \

--- a/scripts/ci/harvest_performance_artifacts.sh
+++ b/scripts/ci/harvest_performance_artifacts.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT}"
+
+if [[ "$#" -lt 2 ]]; then
+  echo "usage: $0 <output-root> <run-id-1> [run-id-2 ...]" >&2
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: required tool missing (gh)" >&2
+  exit 1
+fi
+
+OUT_ROOT="$1"
+shift
+RUN_IDS=("$@")
+
+BATCH_DIR="${OUT_ROOT}/learning-batch"
+EVIDENCE_DIR="${OUT_ROOT}/evidence"
+LEARNING_RUN_DIR="${EVIDENCE_DIR}/run-learning-batch/gates/performance-learning"
+
+rm -rf "${BATCH_DIR}" "${LEARNING_RUN_DIR}"
+mkdir -p "${BATCH_DIR}" "${LEARNING_RUN_DIR}"
+
+for id in "${RUN_IDS[@]}"; do
+  id="${id//[[:space:]]/}"
+  if [[ -z "${id}" ]]; then
+    continue
+  fi
+  mkdir -p "${BATCH_DIR}/${id}"
+  gh run download "${id}" --name "performance-evidence-${id}-1" --dir "${BATCH_DIR}/${id}"
+done
+
+scripts/ci/gate_performance_learning_review.sh \
+  --evidence-dir "${LEARNING_RUN_DIR}" \
+  --source-glob "${BATCH_DIR}/*/run-gh-*/gates/performance/report.json"

--- a/scripts/ci/render_threshold_comment.py
+++ b/scripts/ci/render_threshold_comment.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+
+
+ORDERED_METRICS = [
+    "entry_latency_ticks",
+    "syscall_gate_return_latency_ticks",
+    "syscall_latency_ticks_pure",
+]
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def fmt_num(value) -> str:
+    if isinstance(value, int):
+        return f"{value:,}"
+    if isinstance(value, float):
+        if value >= 1000:
+            return f"{value:,.1f}"
+        return f"{value:.4f}"
+    return str(value)
+
+
+def build_row(metric: str, payload: dict) -> str:
+    return (
+        f"| `{metric}`"
+        f" | {payload.get('sample_count', '-')}"
+        f" | {fmt_num(payload.get('median', '-'))}"
+        f" | {fmt_num(payload.get('median_abs_deviation', '-'))}"
+        f" | {fmt_num(payload.get('p95', '-'))}"
+        f" | {fmt_num(payload.get('recommended_threshold_ticks', '-'))}"
+        f" | {fmt_num(payload.get('variance_ratio', '-'))}"
+        f" | `{payload.get('enforcement', '-')}`"
+        f" | `{payload.get('status', '-')}` |"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Render markdown PR comment from threshold policy JSON."
+    )
+    parser.add_argument("--threshold-policy", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    policy = load_json(Path(args.threshold_policy))
+    recommendations = policy.get("recommendations", {})
+    authority = policy.get("source", {}).get("authority", "unknown")
+    summary_path = policy.get("source", {}).get("learning_summary_path", "unknown")
+
+    lines = [
+        "## Performance Threshold Recommendation",
+        "",
+        f"- authority: `{authority}`",
+        f"- source: `{summary_path}`",
+        "- note: non-authoritative recommendation only; no baseline or threshold mutation",
+        "",
+        "| Metric | n | median | MAD | p95 | threshold | variance | enforcement | status |",
+        "|---|---:|---:|---:|---:|---:|---:|---|---|",
+    ]
+
+    for metric in ORDERED_METRICS:
+        payload = recommendations.get(metric)
+        if isinstance(payload, dict):
+            lines.append(build_row(metric, payload))
+
+    note_lines = []
+    for metric in ORDERED_METRICS:
+        payload = recommendations.get(metric)
+        if not isinstance(payload, dict):
+            continue
+        for note in payload.get("notes", []):
+            note_lines.append(f"- `{metric}`: {note}")
+
+    if note_lines:
+        lines.extend(["", "### Notes"])
+        lines.extend(note_lines)
+
+    Path(args.output).write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/threshold_generator.py
+++ b/scripts/ci/threshold_generator.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+
+
+METRIC_POLICY = {
+    "entry_latency_ticks": {
+        "mad_multiplier": 10.0,
+        "enforcement": "soft",
+        "minimum_sample_count": 5,
+    },
+    "syscall_gate_return_latency_ticks": {
+        "mad_multiplier": 8.0,
+        "enforcement": "medium",
+        "minimum_sample_count": 5,
+    },
+    "syscall_latency_ticks_pure": {
+        "mad_multiplier": 6.0,
+        "enforcement": "hard",
+        "minimum_sample_count": 10,
+    },
+}
+
+VARIANCE_RATIO_GUARD = 0.10
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def build_metric_policy(metric_name: str, summary: dict) -> dict:
+    policy = METRIC_POLICY[metric_name]
+    sample_count = int(summary.get("sample_count", 0))
+    median = float(summary.get("median", 0.0))
+    mad = float(summary.get("median_abs_deviation", 0.0))
+    p95 = float(summary.get("p95", median))
+    variance_ratio = (mad / median) if median > 0 else 0.0
+    recommended_threshold = max(p95, median + (policy["mad_multiplier"] * mad))
+
+    status = "ready"
+    enforcement = policy["enforcement"]
+    notes = []
+
+    if sample_count < policy["minimum_sample_count"]:
+        status = "insufficient_samples"
+        enforcement = "none"
+        notes.append(
+            f"sample_count {sample_count} is below minimum {policy['minimum_sample_count']}"
+        )
+
+    if variance_ratio > VARIANCE_RATIO_GUARD:
+        status = "variance_guard_blocked"
+        enforcement = "none"
+        notes.append(
+            f"variance_ratio {variance_ratio:.6f} exceeds guard {VARIANCE_RATIO_GUARD:.2f}"
+        )
+
+    return {
+        "metric": metric_name,
+        "sample_count": sample_count,
+        "median": median,
+        "median_abs_deviation": mad,
+        "p95": p95,
+        "recommended_threshold_ticks": recommended_threshold,
+        "variance_ratio": variance_ratio,
+        "mad_multiplier": policy["mad_multiplier"],
+        "formula": f"max(p95, median + {policy['mad_multiplier']:.0f}*MAD)",
+        "minimum_sample_count": policy["minimum_sample_count"],
+        "variance_ratio_guard": VARIANCE_RATIO_GUARD,
+        "enforcement": enforcement,
+        "status": status,
+        "notes": notes,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate non-authoritative split-metric threshold policy candidates from "
+            "performance-learning summary output."
+        )
+    )
+    parser.add_argument(
+        "--learning-summary",
+        required=True,
+        help="Path to gates/performance-learning/summary.json",
+    )
+    parser.add_argument(
+        "--output",
+        help="Optional output path for generated threshold policy JSON",
+    )
+    args = parser.parse_args()
+
+    summary_path = Path(args.learning_summary)
+    payload = load_json(summary_path)
+
+    authority = payload.get("authority")
+    metrics = payload.get("metrics", {})
+
+    recommendations = {}
+    for metric_name in METRIC_POLICY:
+        summary = metrics.get(metric_name)
+        if not isinstance(summary, dict):
+            continue
+        recommendations[metric_name] = build_metric_policy(metric_name, summary)
+
+    output = {
+        "schema_version": 1,
+        "source": {
+            "learning_summary_path": str(summary_path),
+            "authority": authority,
+        },
+        "policy_matrix": {
+            metric_name: {
+                "enforcement_target": policy["enforcement"],
+                "mad_multiplier": policy["mad_multiplier"],
+                "minimum_sample_count": policy["minimum_sample_count"],
+            }
+            for metric_name, policy in METRIC_POLICY.items()
+        },
+        "recommendations": recommendations,
+    }
+
+    rendered = json.dumps(output, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/update_threshold_timeline.py
+++ b/scripts/ci/update_threshold_timeline.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+
+
+METRICS = [
+    "entry_latency_ticks",
+    "syscall_gate_return_latency_ticks",
+    "syscall_latency_ticks_pure",
+]
+
+
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_timeline(path: Path) -> list:
+    if not path.exists():
+        return []
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Append threshold recommendation snapshot to timeline JSON."
+    )
+    parser.add_argument("--threshold-policy", required=True)
+    parser.add_argument("--timeline", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--git-sha", required=True)
+    parser.add_argument("--created-at-utc", required=True)
+    args = parser.parse_args()
+
+    threshold_policy = load_json(Path(args.threshold_policy))
+    timeline_path = Path(args.timeline)
+    timeline = load_timeline(timeline_path)
+
+    entry = {
+        "run_id": args.run_id,
+        "git_sha": args.git_sha,
+        "created_at_utc": args.created_at_utc,
+        "authority": threshold_policy.get("source", {}).get("authority"),
+        "metrics": {},
+    }
+
+    recommendations = threshold_policy.get("recommendations", {})
+    for metric in METRICS:
+        payload = recommendations.get(metric)
+        if not isinstance(payload, dict):
+            continue
+        entry["metrics"][metric] = {
+            "sample_count": payload.get("sample_count"),
+            "median": payload.get("median"),
+            "median_abs_deviation": payload.get("median_abs_deviation"),
+            "p95": payload.get("p95"),
+            "recommended_threshold_ticks": payload.get("recommended_threshold_ticks"),
+            "variance_ratio": payload.get("variance_ratio"),
+            "enforcement": payload.get("enforcement"),
+            "status": payload.get("status"),
+        }
+
+    timeline.append(entry)
+    timeline_path.parent.mkdir(parents=True, exist_ok=True)
+    timeline_path.write_text(json.dumps(timeline, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add  as the non-authoritative split-metric policy generator
- add helper scripts to render PR comments, update a timeline JSON, and harvest CI performance artifacts
- add a manual  workflow that downloads successful  artifacts, runs learning review, generates threshold recommendations, uploads outputs, and optionally posts a PR comment

## Scope
- non-authoritative only
- no baseline mutation
- no threshold commit
- no enforcement activation

## Validation
- 
- 
- 
- harvest smoke: performance-learning-review: PASS
See: /tmp/harvest-smoke/evidence/run-learning-batch/gates/performance-learning/report.json
- generator/comment/timeline smoke run against the 10-run learning summary
