### PR TITLE
ci(perf): add default-off enforcement scaffold

### DIFF
--- a/.github/workflows/ci-freeze.yml
+++ b/.github/workflows/ci-freeze.yml
@@ -30,6 +30,31 @@ on:
         description: "Pinned runner image/build digest (required for baseline init, ex: gha-ubuntu22-20260212.1-x64)"
         required: false
         default: ""
+      enable_perf_split_metrics_shadow:
+        description: "Enable non-authoritative split-metric shadow evaluation"
+        type: boolean
+        required: true
+        default: false
+      enable_perf_split_metrics_enforcement:
+        description: "Enable split-metric enforcement scaffold"
+        type: boolean
+        required: true
+        default: false
+      enable_perf_enforce_entry:
+        description: "Enable entry split-metric checks when scaffold enforcement is on"
+        type: boolean
+        required: true
+        default: false
+      enable_perf_enforce_return:
+        description: "Enable return split-metric checks when scaffold enforcement is on"
+        type: boolean
+        required: true
+        default: false
+      enable_perf_enforce_pure:
+        description: "Enable pure syscall split-metric checks when scaffold enforcement is on"
+        type: boolean
+        required: true
+        default: false
 
 jobs:
   freeze:
@@ -46,6 +71,11 @@ jobs:
       PERF_AUTHORITY_SALT: "${{ github.repository }}"  # Fork-safe drift authority namespace
       PERF_ENV_MISMATCH_POLICY: "fail"  # Constitutional mode: strict enforcement
       PERF_REGRESSION_POLICY: "fail"    # Constitutional mode: strict enforcement
+      PERF_SPLIT_METRICS_SHADOW: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.enable_perf_split_metrics_shadow == 'true' && '1' || '0' }}
+      PERF_SPLIT_METRICS_ENFORCEMENT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.enable_perf_split_metrics_enforcement == 'true' && '1' || '0' }}
+      PERF_ENFORCE_ENTRY: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.enable_perf_enforce_entry == 'true' && '1' || '0' }}
+      PERF_ENFORCE_RETURN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.enable_perf_enforce_return == 'true' && '1' || '0' }}
+      PERF_ENFORCE_PURE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.enable_perf_enforce_pure == 'true' && '1' || '0' }}
       GOVERNANCE_POLICY_KERNEL_PROFILE: "validation"
       PHASE10C_ENFORCE: "1"
       PHASE10C_C2_STRICT: "1"

--- a/scripts/ci/gate_performance.sh
+++ b/scripts/ci/gate_performance.sh
@@ -6,6 +6,11 @@ CI_TOOLS="${ROOT}/tools/ci"
 source "${CI_TOOLS}/lib.sh"
 source "${ROOT}/scripts/ci/lib-drift-persistence.sh"
 source "${ROOT}/scripts/ci/lib-drift-allowlist.sh"
+if [[ -f "${ROOT}/scripts/ci/perf_flags.env" ]]; then
+  # Default-off split-metric enforcement scaffold. Env overrides remain authoritative.
+  # shellcheck disable=SC1091
+  source "${ROOT}/scripts/ci/perf_flags.env"
+fi
 
 usage() {
   cat <<'USAGE'
@@ -74,6 +79,16 @@ PREEMPT_RING3_ENTRY_GUARD="${PERF_PREEMPT_RING3_ENTRY_GUARD:-}"
 PREEMPT_BUILD_DEBUG_SCHED="${PERF_PREEMPT_BUILD_DEBUG_SCHED:-}"
 PREEMPT_BUILD_DEBUG_IRQ="${PERF_PREEMPT_BUILD_DEBUG_IRQ:-}"
 PREEMPT_EXPECTED_QEMU_EXIT_SET="${PERF_PREEMPT_EXPECTED_QEMU_EXIT_SET:-0,1}"
+SPLIT_METRICS_SHADOW="${PERF_SPLIT_METRICS_SHADOW:-0}"
+SPLIT_METRICS_ENFORCEMENT="${PERF_SPLIT_METRICS_ENFORCEMENT:-0}"
+ENFORCE_ENTRY="${PERF_ENFORCE_ENTRY:-0}"
+ENFORCE_RETURN="${PERF_ENFORCE_RETURN:-0}"
+ENFORCE_PURE="${PERF_ENFORCE_PURE:-0}"
+VARIANCE_GUARD="${PERF_VARIANCE_GUARD:-0.10}"
+CONSECUTIVE_VIOLATION_LIMIT="${PERF_CONSECUTIVE_VIOLATION_LIMIT:-2}"
+GLOBAL_DISABLE_METRIC_VIOLATION_LIMIT="${PERF_GLOBAL_DISABLE_METRIC_VIOLATION_LIMIT:-2}"
+SPLIT_POLICY_JSON="${PERF_SPLIT_POLICY_JSON:-scripts/ci/perf-threshold-policy.json}"
+PERF_ENFORCEMENT_STATE_FILE="${PERF_ENFORCEMENT_STATE_FILE:-.ci-state/perf-enforcement-state.json}"
 MEASUREMENT_CONTRACT="deterministic_preempt_harness"
 SCHED_FALLBACK="${AYKEN_SCHED_FALLBACK:-0}"
 BOOT_OK_MARKER="[K][BOOT_OK] Phase 4.4 minimal boot reached"
@@ -208,6 +223,22 @@ case "${PREEMPT_RING3_ENTRY_GUARD}" in
     ;;
 esac
 
+for split_flag in \
+  "${SPLIT_METRICS_SHADOW}" \
+  "${SPLIT_METRICS_ENFORCEMENT}" \
+  "${ENFORCE_ENTRY}" \
+  "${ENFORCE_RETURN}" \
+  "${ENFORCE_PURE}"; do
+  case "${split_flag}" in
+    0|1)
+      ;;
+    *)
+      echo "ERROR: split-metric perf flags must be 0 or 1" >&2
+      exit 3
+      ;;
+  esac
+done
+
 if [[ -n "${PREEMPT_BUILD_DEBUG_SCHED}" ]] && [[ "${PREEMPT_BUILD_DEBUG_SCHED}" != "0" && "${PREEMPT_BUILD_DEBUG_SCHED}" != "1" ]]; then
   echo "ERROR: PERF_PREEMPT_BUILD_DEBUG_SCHED must be 0 or 1 when set" >&2
   exit 3
@@ -284,6 +315,27 @@ for threshold_value in "${BOOT_THRESHOLD_PERCENT}" "${CONTEXT_THRESHOLD_PERCENT}
     exit 3
   fi
 done
+
+for threshold_value in "${VARIANCE_GUARD}"; do
+  if ! is_nonnegative_number "${threshold_value}"; then
+    echo "ERROR: PERF_VARIANCE_GUARD must be a non-negative number" >&2
+    exit 3
+  fi
+done
+
+for integer_value in "${CONSECUTIVE_VIOLATION_LIMIT}" "${GLOBAL_DISABLE_METRIC_VIOLATION_LIMIT}"; do
+  if [[ ! "${integer_value}" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: split-metric violation limits must be non-negative integers" >&2
+    exit 3
+  fi
+done
+
+if [[ ! "${SPLIT_POLICY_JSON}" = /* ]]; then
+  SPLIT_POLICY_JSON="${ROOT}/${SPLIT_POLICY_JSON}"
+fi
+if [[ ! "${PERF_ENFORCEMENT_STATE_FILE}" = /* ]]; then
+  PERF_ENFORCEMENT_STATE_FILE="${ROOT}/${PERF_ENFORCEMENT_STATE_FILE}"
+fi
 
 for tool in git make python3 qemu-system-x86_64 jq; do
   if ! command -v "${tool}" >/dev/null 2>&1; then
@@ -364,6 +416,7 @@ VIOLATIONS_TXT="${EVIDENCE_DIR}/violations.txt"
 ALLOWLIST_BYPASS_TXT="${EVIDENCE_DIR}/allowlist_bypass.txt"
 META_TXT="${EVIDENCE_DIR}/meta.txt"
 REPORT_JSON="${EVIDENCE_DIR}/report.json"
+SPLIT_ENFORCEMENT_JSON="${EVIDENCE_DIR}/split_metric_enforcement.json"
 
 : > "${ENV_JSON}"
 : > "${RESULTS_JSON}"
@@ -377,6 +430,7 @@ REPORT_JSON="${EVIDENCE_DIR}/report.json"
 : > "${BASELINE_DIFF_TXT}"
 : > "${VIOLATIONS_TXT}"
 : > "${ALLOWLIST_BYPASS_TXT}"
+: > "${SPLIT_ENFORCEMENT_JSON}"
 
 record_violation() {
   echo "$1" >> "${VIOLATIONS_TXT}"
@@ -1412,6 +1466,53 @@ else
   fi
 fi
 
+# 9) Split-metric enforcement scaffold (default-off, non-authoritative).
+if ! \
+  PERF_SPLIT_METRICS_SHADOW="${SPLIT_METRICS_SHADOW}" \
+  PERF_SPLIT_METRICS_ENFORCEMENT="${SPLIT_METRICS_ENFORCEMENT}" \
+  PERF_ENFORCE_ENTRY="${ENFORCE_ENTRY}" \
+  PERF_ENFORCE_RETURN="${ENFORCE_RETURN}" \
+  PERF_ENFORCE_PURE="${ENFORCE_PURE}" \
+  PERF_VARIANCE_GUARD="${VARIANCE_GUARD}" \
+  PERF_CONSECUTIVE_VIOLATION_LIMIT="${CONSECUTIVE_VIOLATION_LIMIT}" \
+  PERF_GLOBAL_DISABLE_METRIC_VIOLATION_LIMIT="${GLOBAL_DISABLE_METRIC_VIOLATION_LIMIT}" \
+  python3 "${ROOT}/scripts/ci/perf_enforcement_state.py" \
+    --results-json "${RESULTS_JSON}" \
+    --env-json "${ENV_JSON}" \
+    --policy-json "${SPLIT_POLICY_JSON}" \
+    --state-path "${PERF_ENFORCEMENT_STATE_FILE}" \
+    --output-json "${SPLIT_ENFORCEMENT_JSON}" >/dev/null 2>&1
+then
+  SPLIT_ENFORCEMENT_JSON_ENV="${SPLIT_ENFORCEMENT_JSON}" \
+  SPLIT_POLICY_JSON_ENV="${SPLIT_POLICY_JSON}" \
+  PERF_ENFORCEMENT_STATE_FILE_ENV="${PERF_ENFORCEMENT_STATE_FILE}" \
+  python3 - <<'PY'
+import json
+import os
+payload = {
+    "schema_version": 1,
+    "gate": "performance-split-enforcement",
+    "mode": "disabled",
+    "policy_path": os.environ["SPLIT_POLICY_JSON_ENV"],
+    "policy_present": False,
+    "global": {
+        "shadow_requested": False,
+        "enforcement_requested": False,
+        "enforcement_enabled": False,
+        "disabled_reason": "tool_error",
+        "shadow_violation_count": 0,
+        "blocking_violation_count": 0,
+    },
+    "metrics": {},
+    "note": "Split-metric enforcement helper failed; gate remains fail-closed disabled.",
+    "state_path": os.environ["PERF_ENFORCEMENT_STATE_FILE_ENV"],
+}
+with open(os.environ["SPLIT_ENFORCEMENT_JSON_ENV"], "w", encoding="utf-8") as fh:
+    json.dump(payload, fh, indent=2, sort_keys=True)
+    fh.write("\n")
+PY
+fi
+
 VIOLATIONS_COUNT="$(wc -l < "${VIOLATIONS_TXT}" | tr -d ' ' || echo 0)"
 
 # Compute drift authority hash for evidence
@@ -1471,6 +1572,16 @@ DRIFT_AUTHORITY_HASH="$(compute_authority_hash)"
   echo "preempt_observed_mb_selftest=${PREEMPT_OBSERVED_MB_SELFTEST:-missing}"
   echo "preempt_observed_deterministic_exit=${PREEMPT_OBSERVED_DETERMINISTIC_EXIT:-missing}"
   echo "preempt_observed_ring3_entry_guard=${PREEMPT_OBSERVED_RING3_ENTRY_GUARD:-missing}"
+  echo "split_metrics_shadow=${SPLIT_METRICS_SHADOW}"
+  echo "split_metrics_enforcement=${SPLIT_METRICS_ENFORCEMENT}"
+  echo "split_metric_policy_json=${SPLIT_POLICY_JSON}"
+  echo "split_metric_state_file=${PERF_ENFORCEMENT_STATE_FILE}"
+  echo "split_metric_variance_guard=${VARIANCE_GUARD}"
+  echo "split_metric_consecutive_violation_limit=${CONSECUTIVE_VIOLATION_LIMIT}"
+  echo "split_metric_multi_metric_disable_limit=${GLOBAL_DISABLE_METRIC_VIOLATION_LIMIT}"
+  echo "split_metric_enforce_entry=${ENFORCE_ENTRY}"
+  echo "split_metric_enforce_return=${ENFORCE_RETURN}"
+  echo "split_metric_enforce_pure=${ENFORCE_PURE}"
   echo "env_hash=${ENV_HASH}"
   echo "drift_authority_hash=${DRIFT_AUTHORITY_HASH}"
   echo "drift_allowlist_file=${DRIFT_ALLOWLIST_FILE}"
@@ -1528,6 +1639,7 @@ out = {
     "meta": meta,
     "env": read_json("env.json"),
     "results": read_json("results.json"),
+    "split_metric_enforcement": read_json("split_metric_enforcement.json"),
     "baseline_diff": read_lines("baseline.diff.txt"),
     "violations": read_lines("violations.txt"),
     "drift_counters": read_lines("drift_counters.txt"),

--- a/scripts/ci/perf_enforcement_state.py
+++ b/scripts/ci/perf_enforcement_state.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+from pathlib import Path
+
+
+METRIC_FLAGS = {
+    "entry_latency_ticks": "PERF_ENFORCE_ENTRY",
+    "syscall_gate_return_latency_ticks": "PERF_ENFORCE_RETURN",
+    "syscall_latency_ticks_pure": "PERF_ENFORCE_PURE",
+}
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_optional_json(path: Path) -> dict | None:
+    if not path.exists():
+        return None
+    return load_json(path)
+
+
+def env_flag(name: str, default: str = "0") -> bool:
+    return os.environ.get(name, default) == "1"
+
+
+def env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name, str(default))
+    return int(raw)
+
+
+def env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name, str(default))
+    return float(raw)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Evaluate split-metric enforcement state in default-off/shadow mode."
+    )
+    parser.add_argument("--results-json", required=True)
+    parser.add_argument("--env-json", required=True)
+    parser.add_argument("--policy-json", required=True)
+    parser.add_argument("--state-path", required=True)
+    parser.add_argument("--output-json", required=True)
+    args = parser.parse_args()
+
+    results_path = Path(args.results_json)
+    env_path = Path(args.env_json)
+    policy_path = Path(args.policy_json)
+    state_path = Path(args.state_path)
+    output_path = Path(args.output_json)
+
+    results = load_json(results_path)
+    env_payload = load_json(env_path)
+    previous_state = load_optional_json(state_path) or {}
+    policy_payload = load_optional_json(policy_path)
+
+    shadow_requested = env_flag("PERF_SPLIT_METRICS_SHADOW", "0")
+    enforcement_requested = env_flag("PERF_SPLIT_METRICS_ENFORCEMENT", "0")
+    variance_guard = env_float("PERF_VARIANCE_GUARD", 0.10)
+    consecutive_limit = env_int("PERF_CONSECUTIVE_VIOLATION_LIMIT", 2)
+    multi_metric_limit = env_int("PERF_GLOBAL_DISABLE_METRIC_VIOLATION_LIMIT", 2)
+
+    authority = env_payload.get("baseline_authority")
+    env_hash = env_payload.get("env_hash")
+
+    policy_present = policy_payload is not None
+    policy_authority = None
+    if policy_payload is not None:
+        policy_authority = policy_payload.get("source", {}).get("authority")
+
+    global_disabled_reason = ""
+    if previous_state.get("authority") and previous_state.get("authority") != authority:
+        global_disabled_reason = "authority_changed"
+    elif previous_state.get("env_hash") and previous_state.get("env_hash") != env_hash:
+        global_disabled_reason = "env_hash_changed"
+    elif policy_present and policy_authority and policy_authority != authority:
+        global_disabled_reason = "policy_authority_mismatch"
+
+    evaluate_requested = shadow_requested or enforcement_requested
+
+    shadow_violation_count = 0
+    blocking_violation_count = 0
+    multi_metric_triggered = False
+    metrics_out: dict[str, dict] = {}
+
+    for metric_name, flag_name in METRIC_FLAGS.items():
+        metric_result = results.get(metric_name, {})
+        metric_policy = (
+            (policy_payload or {}).get("recommendations", {}).get(metric_name)
+            if policy_payload is not None
+            else None
+        )
+        previous_metric = (previous_state.get("metrics") or {}).get(metric_name, {})
+
+        available = bool(metric_result.get("available", False))
+        value = float(metric_result.get("ticks", 0.0))
+        requested = env_flag(flag_name, "0")
+        policy_status = None
+        threshold = None
+        variance_ratio = None
+        notes: list[str] = []
+
+        if metric_policy is not None:
+            policy_status = metric_policy.get("status")
+            threshold = metric_policy.get("recommended_threshold_ticks")
+            variance_ratio = metric_policy.get("variance_ratio")
+
+        status = "inactive"
+        if evaluate_requested:
+            if not available:
+                status = "metric_unavailable"
+                notes.append("split metric unavailable")
+            elif not policy_present:
+                status = "policy_missing"
+                notes.append("threshold policy JSON missing")
+            elif not isinstance(metric_policy, dict):
+                status = "policy_metric_missing"
+                notes.append("metric missing from threshold policy")
+            elif policy_status != "ready":
+                status = f"policy_{policy_status or 'missing'}"
+                notes.append(f"policy status is {policy_status or 'missing'}")
+            elif variance_ratio is not None and float(variance_ratio) > variance_guard:
+                status = "variance_guard_blocked"
+                notes.append(
+                    f"variance_ratio {float(variance_ratio):.6f} exceeds guard {variance_guard:.2f}"
+                )
+            elif threshold is not None and value > float(threshold):
+                status = "violation"
+                notes.append(
+                    f"value {value:.1f} exceeds threshold {float(threshold):.1f}"
+                )
+            else:
+                status = "ok"
+
+        consecutive_violations = 0
+        if status == "violation":
+            consecutive_violations = int(previous_metric.get("consecutive_violations", 0)) + 1
+        elif status == "ok":
+            consecutive_violations = 0
+
+        rollback_active = bool(previous_metric.get("rollback_active", False))
+        rollback_reason = str(previous_metric.get("rollback_reason", ""))
+        rollback_triggered = False
+
+        if not enforcement_requested or not requested:
+            rollback_active = False
+            rollback_reason = ""
+
+        enforcement_enabled = (
+            enforcement_requested
+            and requested
+            and not bool(global_disabled_reason)
+            and not rollback_active
+        )
+
+        if enforcement_enabled and status == "violation":
+            shadow_violation_count += 1
+            blocking_violation_count += 1
+            if consecutive_violations >= consecutive_limit:
+                rollback_active = True
+                rollback_reason = "consecutive_violations"
+                rollback_triggered = True
+                enforcement_enabled = False
+                notes.append(
+                    f"metric rollback triggered after {consecutive_violations} consecutive violations"
+                )
+        elif status == "violation":
+            shadow_violation_count += 1
+
+        metrics_out[metric_name] = {
+            "value_ticks": value,
+            "available": available,
+            "policy_present": policy_present,
+            "policy_status": policy_status,
+            "threshold_ticks": threshold,
+            "variance_ratio": variance_ratio,
+            "requested": requested,
+            "enforcement_enabled": enforcement_enabled,
+            "status": status,
+            "consecutive_violations": consecutive_violations,
+            "rollback_active": rollback_active,
+            "rollback_reason": rollback_reason,
+            "rollback_triggered": rollback_triggered,
+            "notes": notes,
+        }
+
+    if enforcement_requested and not global_disabled_reason:
+        enabled_violation_count = sum(
+            1
+            for metric_payload in metrics_out.values()
+            if metric_payload.get("status") == "violation"
+            and metric_payload.get("enforcement_enabled")
+        )
+        if enabled_violation_count >= multi_metric_limit:
+            global_disabled_reason = "multi_metric_violation"
+            multi_metric_triggered = True
+            for metric_payload in metrics_out.values():
+                if metric_payload.get("enforcement_enabled"):
+                    metric_payload["enforcement_enabled"] = False
+                    metric_payload["notes"].append(
+                        "global disable triggered by multi-metric violation limit"
+                    )
+
+    global_enforcement_enabled = enforcement_requested and not bool(global_disabled_reason)
+
+    output = {
+        "schema_version": 1,
+        "gate": "performance-split-enforcement",
+        "mode": (
+            "enforce"
+            if enforcement_requested
+            else "shadow"
+            if shadow_requested
+            else "disabled"
+        ),
+        "policy_path": str(policy_path),
+        "policy_present": policy_present,
+        "policy_authority": policy_authority,
+        "current_authority": authority,
+        "current_env_hash": env_hash,
+        "global": {
+            "shadow_requested": shadow_requested,
+            "enforcement_requested": enforcement_requested,
+            "enforcement_enabled": global_enforcement_enabled,
+            "disabled_reason": global_disabled_reason,
+            "variance_guard": variance_guard,
+            "consecutive_violation_limit": consecutive_limit,
+            "multi_metric_violation_limit": multi_metric_limit,
+            "shadow_violation_count": shadow_violation_count,
+            "blocking_violation_count": blocking_violation_count,
+            "multi_metric_triggered": multi_metric_triggered,
+        },
+        "metrics": metrics_out,
+        "note": "Default-off scaffold only. This surface is non-authoritative until a later activation PR explicitly consumes it.",
+    }
+
+    state_out = {
+        "schema_version": 1,
+        "authority": authority,
+        "env_hash": env_hash,
+        "global": output["global"],
+        "metrics": {
+            metric_name: {
+                "consecutive_violations": metric_payload["consecutive_violations"],
+                "last_status": metric_payload["status"],
+                "rollback_active": metric_payload["rollback_active"],
+                "rollback_reason": metric_payload["rollback_reason"],
+                "last_threshold_ticks": metric_payload["threshold_ticks"],
+                "last_value_ticks": metric_payload["value_ticks"],
+                "last_variance_ratio": metric_payload["variance_ratio"],
+            }
+            for metric_name, metric_payload in metrics_out.items()
+        },
+    }
+
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(state_out, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    output_path.write_text(json.dumps(output, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/perf_flags.env
+++ b/scripts/ci/perf_flags.env
@@ -1,0 +1,16 @@
+: "${PERF_SPLIT_METRICS_SHADOW:=0}"
+: "${PERF_SPLIT_METRICS_ENFORCEMENT:=0}"
+
+: "${PERF_ENFORCE_ENTRY:=0}"
+: "${PERF_ENFORCE_RETURN:=0}"
+: "${PERF_ENFORCE_PURE:=0}"
+
+: "${PERF_VARIANCE_GUARD:=0.10}"
+: "${PERF_CONSECUTIVE_VIOLATION_LIMIT:=2}"
+: "${PERF_GLOBAL_DISABLE_METRIC_VIOLATION_LIMIT:=2}"
+
+# Default path only. A future non-authoritative threshold policy PR may add this file.
+: "${PERF_SPLIT_POLICY_JSON:=scripts/ci/perf-threshold-policy.json}"
+
+# Cached state for anomaly tracking and automatic local disable signals.
+: "${PERF_ENFORCEMENT_STATE_FILE:=.ci-state/perf-enforcement-state.json}"


### PR DESCRIPTION
## Summary
- add scripts/ci/perf_flags.env with default-off split-metric enforcement flags
- add scripts/ci/perf_enforcement_state.py to compute non-authoritative shadow/enforcement state and rollback signals
- hook gate_performance.sh to emit split_metric_enforcement diagnostics without changing current verdict behavior
- add optional workflow_dispatch toggles in ci-freeze.yml for future shadow/enforcement experiments

## Safety
- default OFF
- non-authoritative only
- no baseline mutation
- no threshold commit
- no current CI verdict change from split metrics

## Validation
- python3 -m py_compile scripts/ci/perf_enforcement_state.py scripts/ci/threshold_generator.py scripts/ci/render_threshold_comment.py scripts/ci/update_threshold_timeline.py
- bash -n scripts/ci/gate_performance.sh
- bash -n scripts/ci/harvest_performance_artifacts.sh
- YAML parse for ci-freeze.yml and perf-learning-comment.yml
- smoke: perf_enforcement_state.py in disabled, shadow, and enforce-requested modes against official threshold policy + CI performance artifacts
