### PR TITLE
ci(perf): verify policy source lineage

### DIFF
--- a/scripts/ci/build_perf_env_manifest.py
+++ b/scripts/ci/build_perf_env_manifest.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build the canonical performance environment manifest and runtime env hash."
+    )
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--kernel-profile", required=True)
+    parser.add_argument("--qemu-timeout-seconds", required=True, type=int)
+    parser.add_argument("--clang-version", required=True)
+    parser.add_argument("--ld-version", required=True)
+    parser.add_argument("--nasm-version", required=True)
+    parser.add_argument("--qemu-version", required=True)
+    parser.add_argument("--host-os", required=True)
+    parser.add_argument("--host-arch", required=True)
+    parser.add_argument("--baseline-authority", required=True)
+    parser.add_argument("--ci-image-digest", required=True)
+    parser.add_argument("--boot-ok-marker", required=True)
+    parser.add_argument("--preempt-sw-count-pattern", required=True)
+    parser.add_argument("--preempt-iret-count-pattern", required=True)
+    parser.add_argument("--measurement-contract", required=True)
+    parser.add_argument("--preempt-user-minimal-mode", required=True)
+    parser.add_argument("--preempt-bootstrap-policy", required=True, type=int)
+    parser.add_argument("--preempt-mb-selftest", required=True, type=int)
+    parser.add_argument("--preempt-deterministic-exit", required=True, type=int)
+    parser.add_argument("--preempt-ring3-entry-guard", required=True, type=int)
+    parser.add_argument("--preempt-expected-qemu-exit-set", required=True)
+    args = parser.parse_args()
+
+    payload = {
+        "kernel_profile": args.kernel_profile,
+        "target_triple": "x86_64-elf",
+        "qemu_timeout_seconds": args.qemu_timeout_seconds,
+        "clang_version": args.clang_version,
+        "ld_version": args.ld_version,
+        "nasm_version": args.nasm_version,
+        "qemu_version": args.qemu_version,
+        "host_os": args.host_os,
+        "host_arch": args.host_arch,
+        "baseline_authority": args.baseline_authority,
+        "ci_image_digest": args.ci_image_digest,
+        "marker_contract": {
+            "boot_ok_marker": args.boot_ok_marker,
+            "preempt_sw_count_pattern": args.preempt_sw_count_pattern,
+            "preempt_iret_count_pattern": args.preempt_iret_count_pattern,
+            "measurement_contract": args.measurement_contract,
+            "preempt_user_minimal_mode": args.preempt_user_minimal_mode,
+            "preempt_bootstrap_policy": args.preempt_bootstrap_policy,
+            "preempt_mb_selftest": args.preempt_mb_selftest,
+            "preempt_deterministic_exit": args.preempt_deterministic_exit,
+            "preempt_ring3_entry_guard": args.preempt_ring3_entry_guard,
+            "preempt_expected_qemu_exit_set": args.preempt_expected_qemu_exit_set,
+        },
+    }
+
+    hash_payload = dict(payload)
+    if str(payload.get("baseline_authority", "")).startswith("github-hosted-"):
+        # Keep digest for audit, but derive the hash from the stable authority surface.
+        hash_payload.pop("ci_image_digest", None)
+    canonical = json.dumps(hash_payload, sort_keys=True, separators=(",", ":"))
+    payload["env_hash"] = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(payload["env_hash"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/gate_performance.sh
+++ b/scripts/ci/gate_performance.sh
@@ -445,76 +445,29 @@ QEMU_VERSION="$(qemu-system-x86_64 --version 2>/dev/null | head -n1 || echo miss
 HOST_OS="$(uname -s 2>/dev/null || echo unknown)"
 HOST_ARCH="$(uname -m 2>/dev/null || echo unknown)"
 
-CLANG_VERSION_ENV="${CLANG_VERSION}" \
-LD_VERSION_ENV="${LD_VERSION}" \
-NASM_VERSION_ENV="${NASM_VERSION}" \
-QEMU_VERSION_ENV="${QEMU_VERSION}" \
-HOST_OS_ENV="${HOST_OS}" \
-HOST_ARCH_ENV="${HOST_ARCH}" \
-KERNEL_PROFILE_ENV="${KERNEL_PROFILE}" \
-QEMU_TIMEOUT_ENV="${QEMU_TIMEOUT}" \
-BASELINE_AUTHORITY_ENV="${BASELINE_AUTHORITY}" \
-CI_IMAGE_DIGEST_ENV="${CI_IMAGE_DIGEST}" \
-BOOT_OK_MARKER_ENV="${BOOT_OK_MARKER}" \
-PREEMPT_SW_COUNT_PATTERN_ENV="${PREEMPT_SW_COUNT_PATTERN}" \
-PREEMPT_IRET_COUNT_PATTERN_ENV="${PREEMPT_IRET_COUNT_PATTERN}" \
-PREEMPT_USER_MINIMAL_MODE_ENV="${PREEMPT_USER_MINIMAL_MODE}" \
-PREEMPT_BOOTSTRAP_POLICY_ENV="${PREEMPT_BOOTSTRAP_POLICY}" \
-PREEMPT_MB_SELFTEST_ENV="${PREEMPT_MB_SELFTEST}" \
-PREEMPT_DETERMINISTIC_EXIT_ENV="${PREEMPT_DETERMINISTIC_EXIT}" \
-PREEMPT_RING3_ENTRY_GUARD_ENV="${PREEMPT_RING3_ENTRY_GUARD}" \
-PREEMPT_EXPECTED_QEMU_EXIT_SET_ENV="${PREEMPT_EXPECTED_QEMU_EXIT_SET}" \
-MEASUREMENT_CONTRACT_ENV="${MEASUREMENT_CONTRACT}" \
-ENV_JSON_ENV="${ENV_JSON}" \
-python3 - <<'PY'
-import hashlib
-import json
-import os
-
-out = os.environ["ENV_JSON_ENV"]
-payload = {
-    "kernel_profile": os.environ["KERNEL_PROFILE_ENV"],
-    "target_triple": "x86_64-elf",
-    "qemu_timeout_seconds": int(os.environ["QEMU_TIMEOUT_ENV"]),
-    "clang_version": os.environ["CLANG_VERSION_ENV"],
-    "ld_version": os.environ["LD_VERSION_ENV"],
-    "nasm_version": os.environ["NASM_VERSION_ENV"],
-    "qemu_version": os.environ["QEMU_VERSION_ENV"],
-    "host_os": os.environ["HOST_OS_ENV"],
-    "host_arch": os.environ["HOST_ARCH_ENV"],
-    "baseline_authority": os.environ["BASELINE_AUTHORITY_ENV"],
-    "ci_image_digest": os.environ["CI_IMAGE_DIGEST_ENV"],
-    "marker_contract": {
-        "boot_ok_marker": os.environ["BOOT_OK_MARKER_ENV"],
-        "preempt_sw_count_pattern": os.environ["PREEMPT_SW_COUNT_PATTERN_ENV"],
-        "preempt_iret_count_pattern": os.environ["PREEMPT_IRET_COUNT_PATTERN_ENV"],
-        "measurement_contract": os.environ["MEASUREMENT_CONTRACT_ENV"],
-        # Performance gate measures deterministic harness mode, not constitutional default.
-        "preempt_user_minimal_mode": os.environ["PREEMPT_USER_MINIMAL_MODE_ENV"],
-        "preempt_bootstrap_policy": int(os.environ["PREEMPT_BOOTSTRAP_POLICY_ENV"]),
-        "preempt_mb_selftest": int(os.environ["PREEMPT_MB_SELFTEST_ENV"]),
-        "preempt_deterministic_exit": int(os.environ["PREEMPT_DETERMINISTIC_EXIT_ENV"]),
-        "preempt_ring3_entry_guard": int(os.environ["PREEMPT_RING3_ENTRY_GUARD_ENV"]),
-        "preempt_expected_qemu_exit_set": os.environ["PREEMPT_EXPECTED_QEMU_EXIT_SET_ENV"],
-    },
-}
-hash_payload = dict(payload)
-if str(payload.get("baseline_authority", "")).startswith("github-hosted-"):
-    # GitHub-hosted ubuntu labels can rotate between image build digests even
-    # when the effective toolchain surface stays identical. Keep the digest for
-    # audit, but hash the stable authority + explicit tool versions instead.
-    hash_payload.pop("ci_image_digest", None)
-canonical = json.dumps(hash_payload, sort_keys=True, separators=(",", ":"))
-payload["env_hash"] = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
-with open(out, "w", encoding="utf-8") as fh:
-    json.dump(payload, fh, indent=2, sort_keys=True)
-    fh.write("\n")
-PY
-
-ENV_HASH="$(python3 - <<'PY' "${ENV_JSON}"
-import json, sys
-print(json.load(open(sys.argv[1], encoding="utf-8"))["env_hash"])
-PY
+ENV_HASH="$(
+  python3 "${ROOT}/scripts/ci/build_perf_env_manifest.py" \
+    --output "${ENV_JSON}" \
+    --kernel-profile "${KERNEL_PROFILE}" \
+    --qemu-timeout-seconds "${QEMU_TIMEOUT}" \
+    --clang-version "${CLANG_VERSION}" \
+    --ld-version "${LD_VERSION}" \
+    --nasm-version "${NASM_VERSION}" \
+    --qemu-version "${QEMU_VERSION}" \
+    --host-os "${HOST_OS}" \
+    --host-arch "${HOST_ARCH}" \
+    --baseline-authority "${BASELINE_AUTHORITY}" \
+    --ci-image-digest "${CI_IMAGE_DIGEST}" \
+    --boot-ok-marker "${BOOT_OK_MARKER}" \
+    --preempt-sw-count-pattern "${PREEMPT_SW_COUNT_PATTERN}" \
+    --preempt-iret-count-pattern "${PREEMPT_IRET_COUNT_PATTERN}" \
+    --measurement-contract "${MEASUREMENT_CONTRACT}" \
+    --preempt-user-minimal-mode "${PREEMPT_USER_MINIMAL_MODE}" \
+    --preempt-bootstrap-policy "${PREEMPT_BOOTSTRAP_POLICY}" \
+    --preempt-mb-selftest "${PREEMPT_MB_SELFTEST}" \
+    --preempt-deterministic-exit "${PREEMPT_DETERMINISTIC_EXIT}" \
+    --preempt-ring3-entry-guard "${PREEMPT_RING3_ENTRY_GUARD}" \
+    --preempt-expected-qemu-exit-set "${PREEMPT_EXPECTED_QEMU_EXIT_SET}"
 )"
 
 # 2) Build the authoritative boot image under the exact preempt contract.
@@ -1470,9 +1423,9 @@ fi
 # 9) Split-metric policy source verification (default-off, non-authoritative).
 if ! bash "${ROOT}/scripts/ci/verify_perf_policy_source.sh" \
     --policy-json "${SPLIT_POLICY_JSON}" \
-    --env-json "${ENV_JSON}" \
     --expected-authority "${BASELINE_AUTHORITY}" \
     --expected-git-sha "${GIT_SHA}" \
+    --expected-env-hash "${ENV_HASH}" \
     --output-json "${SPLIT_POLICY_VERIFICATION_JSON}" >/dev/null 2>&1
 then
   :
@@ -1482,6 +1435,7 @@ if [[ ! -s "${SPLIT_POLICY_VERIFICATION_JSON}" ]]; then
   SPLIT_POLICY_JSON_ENV="${SPLIT_POLICY_JSON}" \
   BASELINE_AUTHORITY_ENV="${BASELINE_AUTHORITY}" \
   GIT_SHA_ENV="${GIT_SHA}" \
+  ENV_HASH_ENV="${ENV_HASH}" \
   python3 - <<'PY'
 import json
 import os
@@ -1493,7 +1447,8 @@ payload = {
     "expected": {
         "authority": os.environ["BASELINE_AUTHORITY_ENV"],
         "git_sha": os.environ["GIT_SHA_ENV"],
-        "env_hash": None,
+        "env_hash": os.environ["ENV_HASH_ENV"],
+        "env_hash_source": "runtime_computed",
     },
     "actual": {},
 }

--- a/scripts/ci/gate_performance.sh
+++ b/scripts/ci/gate_performance.sh
@@ -417,6 +417,7 @@ ALLOWLIST_BYPASS_TXT="${EVIDENCE_DIR}/allowlist_bypass.txt"
 META_TXT="${EVIDENCE_DIR}/meta.txt"
 REPORT_JSON="${EVIDENCE_DIR}/report.json"
 SPLIT_ENFORCEMENT_JSON="${EVIDENCE_DIR}/split_metric_enforcement.json"
+SPLIT_POLICY_VERIFICATION_JSON="${EVIDENCE_DIR}/split_metric_policy_verification.json"
 
 : > "${ENV_JSON}"
 : > "${RESULTS_JSON}"
@@ -1466,7 +1467,43 @@ else
   fi
 fi
 
-# 9) Split-metric enforcement scaffold (default-off, non-authoritative).
+# 9) Split-metric policy source verification (default-off, non-authoritative).
+if ! bash "${ROOT}/scripts/ci/verify_perf_policy_source.sh" \
+    --policy-json "${SPLIT_POLICY_JSON}" \
+    --env-json "${ENV_JSON}" \
+    --expected-authority "${BASELINE_AUTHORITY}" \
+    --expected-git-sha "${GIT_SHA}" \
+    --output-json "${SPLIT_POLICY_VERIFICATION_JSON}" >/dev/null 2>&1
+then
+  :
+fi
+if [[ ! -s "${SPLIT_POLICY_VERIFICATION_JSON}" ]]; then
+  SPLIT_POLICY_VERIFICATION_JSON_ENV="${SPLIT_POLICY_VERIFICATION_JSON}" \
+  SPLIT_POLICY_JSON_ENV="${SPLIT_POLICY_JSON}" \
+  BASELINE_AUTHORITY_ENV="${BASELINE_AUTHORITY}" \
+  GIT_SHA_ENV="${GIT_SHA}" \
+  python3 - <<'PY'
+import json
+import os
+payload = {
+    "schema_version": 1,
+    "trusted": False,
+    "reason": "verification_tool_error",
+    "policy_path": os.environ["SPLIT_POLICY_JSON_ENV"],
+    "expected": {
+        "authority": os.environ["BASELINE_AUTHORITY_ENV"],
+        "git_sha": os.environ["GIT_SHA_ENV"],
+        "env_hash": None,
+    },
+    "actual": {},
+}
+with open(os.environ["SPLIT_POLICY_VERIFICATION_JSON_ENV"], "w", encoding="utf-8") as fh:
+    json.dump(payload, fh, indent=2, sort_keys=True)
+    fh.write("\n")
+PY
+fi
+
+# 10) Split-metric enforcement scaffold (default-off, non-authoritative).
 if ! \
   PERF_SPLIT_METRICS_SHADOW="${SPLIT_METRICS_SHADOW}" \
   PERF_SPLIT_METRICS_ENFORCEMENT="${SPLIT_METRICS_ENFORCEMENT}" \
@@ -1480,11 +1517,13 @@ if ! \
     --results-json "${RESULTS_JSON}" \
     --env-json "${ENV_JSON}" \
     --policy-json "${SPLIT_POLICY_JSON}" \
+    --policy-verification-json "${SPLIT_POLICY_VERIFICATION_JSON}" \
     --state-path "${PERF_ENFORCEMENT_STATE_FILE}" \
     --output-json "${SPLIT_ENFORCEMENT_JSON}" >/dev/null 2>&1
 then
   SPLIT_ENFORCEMENT_JSON_ENV="${SPLIT_ENFORCEMENT_JSON}" \
   SPLIT_POLICY_JSON_ENV="${SPLIT_POLICY_JSON}" \
+  SPLIT_POLICY_VERIFICATION_JSON_ENV="${SPLIT_POLICY_VERIFICATION_JSON}" \
   PERF_ENFORCEMENT_STATE_FILE_ENV="${PERF_ENFORCEMENT_STATE_FILE}" \
   python3 - <<'PY'
 import json
@@ -1494,6 +1533,7 @@ payload = {
     "gate": "performance-split-enforcement",
     "mode": "disabled",
     "policy_path": os.environ["SPLIT_POLICY_JSON_ENV"],
+    "policy_verification_path": os.environ["SPLIT_POLICY_VERIFICATION_JSON_ENV"],
     "policy_present": False,
     "global": {
         "shadow_requested": False,
@@ -1575,6 +1615,7 @@ DRIFT_AUTHORITY_HASH="$(compute_authority_hash)"
   echo "split_metrics_shadow=${SPLIT_METRICS_SHADOW}"
   echo "split_metrics_enforcement=${SPLIT_METRICS_ENFORCEMENT}"
   echo "split_metric_policy_json=${SPLIT_POLICY_JSON}"
+  echo "split_metric_policy_verification_json=${SPLIT_POLICY_VERIFICATION_JSON}"
   echo "split_metric_state_file=${PERF_ENFORCEMENT_STATE_FILE}"
   echo "split_metric_variance_guard=${VARIANCE_GUARD}"
   echo "split_metric_consecutive_violation_limit=${CONSECUTIVE_VIOLATION_LIMIT}"
@@ -1639,6 +1680,7 @@ out = {
     "meta": meta,
     "env": read_json("env.json"),
     "results": read_json("results.json"),
+    "split_metric_policy_verification": read_json("split_metric_policy_verification.json"),
     "split_metric_enforcement": read_json("split_metric_enforcement.json"),
     "baseline_diff": read_lines("baseline.diff.txt"),
     "violations": read_lines("violations.txt"),

--- a/scripts/ci/gate_performance_learning_review.sh
+++ b/scripts/ci/gate_performance_learning_review.sh
@@ -227,15 +227,23 @@ for source in source_paths:
     )
 
 
-git_shas = sorted({run["git_sha"] for run in eligible_runs if run.get("git_sha") and run.get("git_sha") != "unknown"})
-env_hashes = sorted({run["env_hash"] for run in eligible_runs if run.get("env_hash")})
+git_sha_values = [run.get("git_sha") for run in eligible_runs]
+env_hash_values = [run.get("env_hash") for run in eligible_runs]
+git_sha_missing_count = sum(1 for value in git_sha_values if not value or value == "unknown")
+env_hash_missing_count = sum(1 for value in env_hash_values if not value)
+git_shas = sorted({value for value in git_sha_values if value and value != "unknown"})
+env_hashes = sorted({value for value in env_hash_values if value})
+git_sha_consistent = git_sha_missing_count == 0 and len(git_shas) == 1 and bool(git_shas)
+env_hash_consistent = env_hash_missing_count == 0 and len(env_hashes) == 1 and bool(env_hashes)
 source_lineage = {
     "authority": authority,
     "eligible_run_count": len(eligible_runs),
-    "git_sha": git_shas[0] if len(git_shas) == 1 else None,
-    "git_sha_consistent": len(git_shas) == 1 and bool(git_shas),
-    "env_hash": env_hashes[0] if len(env_hashes) == 1 else None,
-    "env_hash_consistent": len(env_hashes) == 1 and bool(env_hashes),
+    "git_sha": git_shas[0] if git_sha_consistent else None,
+    "git_sha_consistent": git_sha_consistent,
+    "git_sha_missing_count": git_sha_missing_count,
+    "env_hash": env_hashes[0] if env_hash_consistent else None,
+    "env_hash_consistent": env_hash_consistent,
+    "env_hash_missing_count": env_hash_missing_count,
 }
 
 

--- a/scripts/ci/gate_performance_learning_review.sh
+++ b/scripts/ci/gate_performance_learning_review.sh
@@ -219,11 +219,24 @@ for source in source_paths:
         {
             "run_id": meta.get("run_id", Path(source).parts[-4] if len(Path(source).parts) >= 4 else Path(source).stem),
             "git_sha": meta.get("git_sha", "unknown"),
+            "env_hash": env.get("env_hash"),
             "authority": source_authority,
             "source_report": source,
             "metrics": run_metrics,
         }
     )
+
+
+git_shas = sorted({run["git_sha"] for run in eligible_runs if run.get("git_sha") and run.get("git_sha") != "unknown"})
+env_hashes = sorted({run["env_hash"] for run in eligible_runs if run.get("env_hash")})
+source_lineage = {
+    "authority": authority,
+    "eligible_run_count": len(eligible_runs),
+    "git_sha": git_shas[0] if len(git_shas) == 1 else None,
+    "git_sha_consistent": len(git_shas) == 1 and bool(git_shas),
+    "env_hash": env_hashes[0] if len(env_hashes) == 1 else None,
+    "env_hash_consistent": len(env_hashes) == 1 and bool(env_hashes),
+}
 
 
 history_payload = {
@@ -293,6 +306,7 @@ for metric_name, config in recommendation_config.items():
 summary_payload = {
     "schema_version": 1,
     "authority": authority,
+    "source": source_lineage,
     "metrics": summary_metrics,
 }
 summary_json.write_text(json.dumps(summary_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -300,6 +314,7 @@ summary_json.write_text(json.dumps(summary_payload, indent=2, sort_keys=True) + 
 recommendations_payload = {
     "schema_version": 1,
     "authority": authority,
+    "source": source_lineage,
     "recommendations": recommendations,
 }
 recommendations_json.write_text(json.dumps(recommendations_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -310,6 +325,7 @@ report_payload = {
     "authority": authority,
     "eligible_run_count": len(eligible_runs),
     "excluded_run_count": len(excluded_runs),
+    "source": source_lineage,
     "minimum_enforcement_sample_count": MIN_ENFORCEMENT_SAMPLE_COUNT,
     "eligibility_policy": history_payload["eligibility_policy"],
     "output_files": {

--- a/scripts/ci/perf_enforcement_state.py
+++ b/scripts/ci/perf_enforcement_state.py
@@ -43,6 +43,7 @@ def main() -> int:
     parser.add_argument("--results-json", required=True)
     parser.add_argument("--env-json", required=True)
     parser.add_argument("--policy-json", required=True)
+    parser.add_argument("--policy-verification-json", required=True)
     parser.add_argument("--state-path", required=True)
     parser.add_argument("--output-json", required=True)
     args = parser.parse_args()
@@ -50,6 +51,7 @@ def main() -> int:
     results_path = Path(args.results_json)
     env_path = Path(args.env_json)
     policy_path = Path(args.policy_json)
+    policy_verification_path = Path(args.policy_verification_json)
     state_path = Path(args.state_path)
     output_path = Path(args.output_json)
 
@@ -57,6 +59,7 @@ def main() -> int:
     env_payload = load_json(env_path)
     previous_state = load_optional_json(state_path) or {}
     policy_payload = load_optional_json(policy_path)
+    policy_verification = load_optional_json(policy_verification_path) or {}
 
     shadow_requested = env_flag("PERF_SPLIT_METRICS_SHADOW", "0")
     enforcement_requested = env_flag("PERF_SPLIT_METRICS_ENFORCEMENT", "0")
@@ -71,12 +74,16 @@ def main() -> int:
     policy_authority = None
     if policy_payload is not None:
         policy_authority = policy_payload.get("source", {}).get("authority")
+    policy_trusted = bool(policy_verification.get("trusted", False))
+    policy_trust_reason = str(policy_verification.get("reason", "policy_missing"))
 
     global_disabled_reason = ""
     if previous_state.get("authority") and previous_state.get("authority") != authority:
         global_disabled_reason = "authority_changed"
     elif previous_state.get("env_hash") and previous_state.get("env_hash") != env_hash:
         global_disabled_reason = "env_hash_changed"
+    elif policy_present and not policy_trusted:
+        global_disabled_reason = policy_trust_reason
     elif policy_present and policy_authority and policy_authority != authority:
         global_disabled_reason = "policy_authority_mismatch"
 
@@ -220,6 +227,10 @@ def main() -> int:
         "policy_path": str(policy_path),
         "policy_present": policy_present,
         "policy_authority": policy_authority,
+        "policy_trusted": policy_trusted,
+        "policy_trust_reason": policy_trust_reason,
+        "policy_verification_path": str(policy_verification_path),
+        "policy_verification": policy_verification,
         "current_authority": authority,
         "current_env_hash": env_hash,
         "global": {

--- a/scripts/ci/render_threshold_comment.py
+++ b/scripts/ci/render_threshold_comment.py
@@ -49,14 +49,17 @@ def main() -> int:
 
     policy = load_json(Path(args.threshold_policy))
     recommendations = policy.get("recommendations", {})
-    authority = policy.get("source", {}).get("authority", "unknown")
-    summary_path = policy.get("source", {}).get("learning_summary_path", "unknown")
+    source = policy.get("source", {})
+    authority = source.get("authority", "unknown")
+    summary_path = source.get("learning_summary_path", "unknown")
 
     lines = [
         "## Performance Threshold Recommendation",
         "",
         f"- authority: `{authority}`",
         f"- source: `{summary_path}`",
+        f"- policy git sha: `{source.get('git_sha', 'unknown')}`",
+        f"- policy env hash: `{source.get('env_hash', 'unknown')}`",
         "- note: non-authoritative recommendation only; no baseline or threshold mutation",
         "",
         "| Metric | n | median | MAD | p95 | threshold | variance | enforcement | status |",

--- a/scripts/ci/threshold_generator.py
+++ b/scripts/ci/threshold_generator.py
@@ -96,6 +96,7 @@ def main() -> int:
     payload = load_json(summary_path)
 
     authority = payload.get("authority")
+    source_payload = payload.get("source", {})
     metrics = payload.get("metrics", {})
 
     recommendations = {}
@@ -110,6 +111,11 @@ def main() -> int:
         "source": {
             "learning_summary_path": str(summary_path),
             "authority": authority,
+            "eligible_run_count": source_payload.get("eligible_run_count"),
+            "git_sha": source_payload.get("git_sha"),
+            "git_sha_consistent": source_payload.get("git_sha_consistent"),
+            "env_hash": source_payload.get("env_hash"),
+            "env_hash_consistent": source_payload.get("env_hash_consistent"),
         },
         "policy_matrix": {
             metric_name: {

--- a/scripts/ci/update_threshold_timeline.py
+++ b/scripts/ci/update_threshold_timeline.py
@@ -41,6 +41,8 @@ def main() -> int:
         "git_sha": args.git_sha,
         "created_at_utc": args.created_at_utc,
         "authority": threshold_policy.get("source", {}).get("authority"),
+        "policy_git_sha": threshold_policy.get("source", {}).get("git_sha"),
+        "policy_env_hash": threshold_policy.get("source", {}).get("env_hash"),
         "metrics": {},
     }
 

--- a/scripts/ci/verify_perf_policy_source.sh
+++ b/scripts/ci/verify_perf_policy_source.sh
@@ -6,17 +6,17 @@ usage() {
 Usage:
   scripts/ci/verify_perf_policy_source.sh \
     --policy-json path/to/threshold_policy.json \
-    --env-json path/to/env.json \
     --expected-authority github-hosted-ubuntu-24.04-x64 \
     --expected-git-sha <git-sha> \
+    --expected-env-hash <runtime-computed-env-hash> \
     --output-json path/to/policy-verification.json
 USAGE
 }
 
 POLICY_JSON=""
-ENV_JSON=""
 EXPECTED_AUTHORITY=""
 EXPECTED_GIT_SHA=""
+EXPECTED_ENV_HASH=""
 OUTPUT_JSON=""
 
 while [[ $# -gt 0 ]]; do
@@ -25,16 +25,16 @@ while [[ $# -gt 0 ]]; do
       POLICY_JSON="$2"
       shift 2
       ;;
-    --env-json)
-      ENV_JSON="$2"
-      shift 2
-      ;;
     --expected-authority)
       EXPECTED_AUTHORITY="$2"
       shift 2
       ;;
     --expected-git-sha)
       EXPECTED_GIT_SHA="$2"
+      shift 2
+      ;;
+    --expected-env-hash)
+      EXPECTED_ENV_HASH="$2"
       shift 2
       ;;
     --output-json)
@@ -53,12 +53,12 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "${POLICY_JSON}" || -z "${ENV_JSON}" || -z "${EXPECTED_AUTHORITY}" || -z "${EXPECTED_GIT_SHA}" || -z "${OUTPUT_JSON}" ]]; then
+if [[ -z "${POLICY_JSON}" || -z "${EXPECTED_AUTHORITY}" || -z "${EXPECTED_GIT_SHA}" || -z "${EXPECTED_ENV_HASH}" || -z "${OUTPUT_JSON}" ]]; then
   usage
   exit 3
 fi
 
-python3 - <<'PY' "${POLICY_JSON}" "${ENV_JSON}" "${EXPECTED_AUTHORITY}" "${EXPECTED_GIT_SHA}" "${OUTPUT_JSON}"
+python3 - <<'PY' "${POLICY_JSON}" "${EXPECTED_AUTHORITY}" "${EXPECTED_GIT_SHA}" "${EXPECTED_ENV_HASH}" "${OUTPUT_JSON}"
 import json
 import sys
 from pathlib import Path
@@ -71,17 +71,12 @@ def load_optional_json(path: Path):
 
 
 policy_path = Path(sys.argv[1])
-env_path = Path(sys.argv[2])
-expected_authority = sys.argv[3]
-expected_git_sha = sys.argv[4]
+expected_authority = sys.argv[2]
+expected_git_sha = sys.argv[3]
+expected_env_hash = sys.argv[4]
 output_path = Path(sys.argv[5])
 
 policy_payload = load_optional_json(policy_path)
-env_payload = load_optional_json(env_path)
-
-expected_env_hash = None
-if isinstance(env_payload, dict):
-    expected_env_hash = env_payload.get("env_hash")
 
 trusted = True
 reason = "ok"
@@ -132,6 +127,7 @@ output = {
         "authority": expected_authority,
         "git_sha": expected_git_sha,
         "env_hash": expected_env_hash,
+        "env_hash_source": "runtime_computed",
     },
     "actual": actual,
 }

--- a/scripts/ci/verify_perf_policy_source.sh
+++ b/scripts/ci/verify_perf_policy_source.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/ci/verify_perf_policy_source.sh \
+    --policy-json path/to/threshold_policy.json \
+    --env-json path/to/env.json \
+    --expected-authority github-hosted-ubuntu-24.04-x64 \
+    --expected-git-sha <git-sha> \
+    --output-json path/to/policy-verification.json
+USAGE
+}
+
+POLICY_JSON=""
+ENV_JSON=""
+EXPECTED_AUTHORITY=""
+EXPECTED_GIT_SHA=""
+OUTPUT_JSON=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --policy-json)
+      POLICY_JSON="$2"
+      shift 2
+      ;;
+    --env-json)
+      ENV_JSON="$2"
+      shift 2
+      ;;
+    --expected-authority)
+      EXPECTED_AUTHORITY="$2"
+      shift 2
+      ;;
+    --expected-git-sha)
+      EXPECTED_GIT_SHA="$2"
+      shift 2
+      ;;
+    --output-json)
+      OUTPUT_JSON="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage
+      exit 3
+      ;;
+  esac
+done
+
+if [[ -z "${POLICY_JSON}" || -z "${ENV_JSON}" || -z "${EXPECTED_AUTHORITY}" || -z "${EXPECTED_GIT_SHA}" || -z "${OUTPUT_JSON}" ]]; then
+  usage
+  exit 3
+fi
+
+python3 - <<'PY' "${POLICY_JSON}" "${ENV_JSON}" "${EXPECTED_AUTHORITY}" "${EXPECTED_GIT_SHA}" "${OUTPUT_JSON}"
+import json
+import sys
+from pathlib import Path
+
+
+def load_optional_json(path: Path):
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+policy_path = Path(sys.argv[1])
+env_path = Path(sys.argv[2])
+expected_authority = sys.argv[3]
+expected_git_sha = sys.argv[4]
+output_path = Path(sys.argv[5])
+
+policy_payload = load_optional_json(policy_path)
+env_payload = load_optional_json(env_path)
+
+expected_env_hash = None
+if isinstance(env_payload, dict):
+    expected_env_hash = env_payload.get("env_hash")
+
+trusted = True
+reason = "ok"
+actual = {
+    "authority": None,
+    "git_sha": None,
+    "env_hash": None,
+    "git_sha_consistent": None,
+    "env_hash_consistent": None,
+}
+
+if not isinstance(policy_payload, dict):
+    trusted = False
+    reason = "policy_missing"
+else:
+    source = policy_payload.get("source", {})
+    actual["authority"] = source.get("authority")
+    actual["git_sha"] = source.get("git_sha")
+    actual["env_hash"] = source.get("env_hash")
+    actual["git_sha_consistent"] = source.get("git_sha_consistent")
+    actual["env_hash_consistent"] = source.get("env_hash_consistent")
+
+    if actual["authority"] != expected_authority:
+        trusted = False
+        reason = "policy_authority_mismatch"
+    elif actual["git_sha_consistent"] is not True:
+        trusted = False
+        reason = "policy_git_sha_inconsistent"
+    elif actual["env_hash_consistent"] is not True:
+        trusted = False
+        reason = "policy_env_hash_inconsistent"
+    elif actual["git_sha"] != expected_git_sha:
+        trusted = False
+        reason = "policy_git_sha_mismatch"
+    elif not expected_env_hash:
+        trusted = False
+        reason = "env_hash_missing"
+    elif actual["env_hash"] != expected_env_hash:
+        trusted = False
+        reason = "policy_env_hash_mismatch"
+
+output = {
+    "schema_version": 1,
+    "trusted": trusted,
+    "reason": reason,
+    "policy_path": str(policy_path),
+    "expected": {
+        "authority": expected_authority,
+        "git_sha": expected_git_sha,
+        "env_hash": expected_env_hash,
+    },
+    "actual": actual,
+}
+
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(output, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+raise SystemExit(0 if trusted else 1)
+PY


### PR DESCRIPTION
## Purpose
Add a fail-closed policy source verification layer for split-metric enforcement scaffolding.

## Scope
- propagate authority/git_sha/env_hash provenance into learning summary + threshold policy outputs
- verify policy lineage against current authority, git SHA, and env hash before enforcement state evaluation
- expose policy verification evidence in the performance report

## Safety
- default OFF remains unchanged
- no baseline mutation
- no threshold auto-commit
- no enforcement activation
- untrusted or incomplete policy source disables scaffold evaluation instead of affecting CI verdicts

## Validation
- python3 -m py_compile scripts/ci/perf_enforcement_state.py scripts/ci/threshold_generator.py scripts/ci/render_threshold_comment.py scripts/ci/update_threshold_timeline.py
- bash -n scripts/ci/gate_performance.sh
- bash -n scripts/ci/verify_perf_policy_source.sh
- bash -n scripts/ci/gate_performance_learning_review.sh
- git diff --check
- trusted/untrusted lineage smoke using existing learning artifacts