### PR TITLE
proofd: unify public diagnostics dispatch

### DIFF
--- a/docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md
+++ b/docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md
@@ -77,7 +77,7 @@ These rules are inherited from Phase-13 and MUST be preserved throughout Phase-1
 - Response field audit (PHASE13_FORBIDDEN_FIELDS enforcement)
 - Response schema stability contract for service-owned diagnostics responses
 - Explicit schema coverage declarations (`none` / `root_only` / `full`) for every public diagnostics endpoint
-- Contract-driven dispatch for public computed diagnostics routes
+- Unified contract-driven dispatch for public diagnostics routes (`path -> endpoint_id -> handler -> schema`)
 - Service boundary documentation
 - Read-only contract enforcement property tests
 

--- a/docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md
+++ b/docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md
@@ -55,7 +55,7 @@ This tracker is operational, not historical. Historical closure truth remains in
 |---|---|---|---|---|
 | 3.1 | Read-Only External API Stabilization | MERGED | Versioned diagnostics discovery/header surface and canonical external contract doc are on `main` | Keep contract and tracker surfaces aligned as 3.3 hardening expands |
 | 3.2 | Replay Determinism Stability Hardening | MERGED | Canonical request fingerprint, determinism contract artifacts, internal replay route, and replay consistency gate are on `main` | Preserve replay determinism boundary while 3.3 hardening continues |
-| 3.3 | `proofd` Query/Service Boundary Hardening | VALIDATED_LOCAL | Canonical diagnostics contract registry, runtime forbidden-field enforcement, response schema contract, and partial contract-driven dispatch are implemented and locally validated | Obtain remote `ci-freeze` confirmation, then finish computed-route registry hardening |
+| 3.3 | `proofd` Query/Service Boundary Hardening | MERGED | Canonical diagnostics contract registry, runtime forbidden-field enforcement, response schema contract, explicit schema coverage governance, and unified contract-driven public diagnostics dispatch are on `main` | Preserve the boundary contract while 3.4 graph and UX work expand adjacent read-only surfaces |
 | 3.4 | Cross-Node Observability Graph | TODO | Architectural target exists; current graph surface remains Phase-13-derived | Define Phase-14 graph contract and artifact shape |
 | 3.5 | Observability UX (Human-Readable Layer) | TODO | No implementation started | Define read-only summary surface without introducing scoring or authority semantics |
 
@@ -74,7 +74,7 @@ This tracker is operational, not historical. Historical closure truth remains in
 
 ### 2026-04-05
 
-**Workstream 3.3 advanced from architecture to validated local hardening**
+**Workstream 3.3 completed and merged to `main`**
 - Canonical external diagnostics contract registry added at `userspace/proofd/src/api_contract.rs`
 - `/diagnostics/version`, query allowlists, harness expectations, and forbidden-field scan now derive from a single contract surface
 - Runtime forbidden-field enforcement added for public diagnostics responses with fail-closed `500 forbidden_observability_field_exposed`
@@ -82,13 +82,15 @@ This tracker is operational, not historical. Historical closure truth remains in
 - Service-owned diagnostics responses now fail closed with `500 diagnostics_schema_contract_violation` on missing required fields or required top-level type mismatch
 - Explicit schema coverage declarations now exist for every public diagnostics endpoint (`none`, `root_only`, `full`)
 - `ci-gate-proofd-schema-coverage` added as a pure validation gate over `proofd-service` evidence
-- Public computed diagnostics dispatch is now partially contract-driven for root and run-scoped routes
+- Public diagnostics routing now resolves through a unified `path -> endpoint_id -> handler -> schema` flow
 - External diagnostics contract document updated to record schema coverage and boundary rules
-- Local validation observed:
-  - `cargo test -p proofd` passed (`168` lib tests + `6` main tests)
+- Local and remote validation observed:
+  - `cargo test -p proofd` passed (`171` lib tests + `6` main tests)
   - `ci-gate-observability-routing-separation` passed
   - `ci-gate-proofd-observability-boundary` passed
   - `ci-gate-proofd-service` passed
+  - `ci-gate-proofd-schema-coverage` passed
+  - PR `#93` merged after `ci-freeze` passed on the final dispatch-hardening slice
 
 ### 2026-04-03
 
@@ -146,11 +148,12 @@ This tracker is operational, not historical. Historical closure truth remains in
 | 2026-04-03 | `make ci-gate-determinism-replay-consistency RUN_ID=local-determinism-gate-pure` | PASS | Makefile wiring validated through `proofd-service`, verification-contract, and pure replay-consistency gate |
 | 2026-04-03 | `bash scripts/ci/gate_determinism_replay_consistency.sh --evidence-dir out/evidence/run-local-determinism-gate-direct/gates/determinism-replay-consistency --source-gate-dir out/evidence/run-local-determinism-gate-pure/gates/proofd-service` | PASS | Direct gate run validated existing `proofd-service` artifacts without bootstrapping a new run |
 | 2026-04-03 | `bash scripts/ci/pre_ci_discipline.sh` | FAIL-CLOSED | Stopped at hygiene because tracked files were modified in worktree |
-| 2026-04-05 | `cargo test -p proofd` | PASS | Workstream 3.3 schema contract + runtime boundary hardening passed locally (`168` lib tests + `6` main tests) |
-| 2026-04-05 | `bash scripts/ci/gate_observability_routing_separation.sh --evidence-dir /tmp/proofd-boundary-scan-round3` | PASS | Canonical route/contract separation remained intact after schema layer and registry-driven dispatch changes |
-| 2026-04-05 | `bash scripts/ci/gate_proofd_observability_boundary.sh --evidence-dir /tmp/proofd-observability-boundary-round3` | PASS | Runtime forbidden-field enforcement and public boundary behavior remained valid |
-| 2026-04-05 | `bash scripts/ci/gate_proofd_service.sh --evidence-dir /tmp/proofd-service-contract-round3` | PASS | Service contract harness remained aligned while schema contract metadata was added |
-| 2026-04-05 | `bash scripts/ci/gate_proofd_schema_coverage.sh --evidence-dir /tmp/proofd-schema-coverage-round3 --source-gate-dir /tmp/proofd-service-contract-round3` | PASS | Every public diagnostics endpoint declared explicit schema coverage and current passthrough/service-owned split remained intentional |
+| 2026-04-05 | `cargo test -p proofd` | PASS | Final dispatch-hardening slice passed locally (`171` lib tests + `6` main tests) |
+| 2026-04-05 | `bash scripts/ci/gate_proofd_service.sh --evidence-dir /tmp/proofd-service-final-dispatch` | PASS | Unified public resolver preserved service contract expectations |
+| 2026-04-05 | `bash scripts/ci/gate_proofd_schema_coverage.sh --evidence-dir /tmp/proofd-schema-coverage-final-dispatch --source-gate-dir /tmp/proofd-service-final-dispatch` | PASS | Explicit coverage declarations remained complete after dispatch unification |
+| 2026-04-05 | `bash scripts/ci/gate_proofd_observability_boundary.sh --evidence-dir /tmp/proofd-observability-boundary-final-dispatch` | PASS | Runtime forbidden-field enforcement remained intact after route hardening |
+| 2026-04-05 | `bash scripts/ci/gate_observability_routing_separation.sh --evidence-dir /tmp/proofd-routing-separation-final-dispatch` | PASS | Contract-driven routing preserved observability/scheduling separation |
+| 2026-04-05 | `bash scripts/ci/gate_diagnostics_consumer_non_authoritative_contract.sh --evidence-dir /tmp/diag-consumer-final-dispatch` | PASS | Canonical diagnostics registry remained boundary-only and did not regress into consumer misuse |
 
 ---
 
@@ -169,16 +172,16 @@ This tracker is operational, not historical. Historical closure truth remains in
 ## 7. Open Items
 
 1. Should service-owned response schema coverage expand to artifact-backed passthrough endpoints, or remain intentionally limited to `proofd`-computed/index responses in v1?
-2. What is the narrowest remaining slice to make computed diagnostics dispatch fully registry-driven without over-coupling handler logic to route metadata?
+2. Should non-GET diagnostics method rejection eventually move from namespace prefix logic into the same endpoint registry layer, or remain a separate boundary check?
 
 ---
 
 ## 8. Next Steps
 
-1. Obtain remote `ci-freeze` confirmation for the current 3.3 schema contract + runtime boundary hardening slice.
-2. Finish moving remaining computed diagnostics endpoints to registry-driven dispatch.
-3. Decide whether v1 should intentionally keep artifact-backed passthrough endpoints outside structural schema enforcement.
-4. Only after that, evaluate whether a new dedicated gate is necessary or the existing proofd gates remain sufficient.
+1. Keep artifact-backed passthrough endpoints intentionally outside structural schema enforcement unless a narrower v2 rule is defined.
+2. Decide whether non-GET diagnostics method rejection should be folded into endpoint-registry-driven dispatch or remain an explicit namespace boundary.
+3. Open Workstream 3.4 without weakening the 3.3 diagnostics contract boundary.
+4. Only after adjacent read-only surfaces settle, evaluate whether another proofd boundary gate is necessary.
 
 ---
 

--- a/docs/specs/phase14-distributed-observability/PROOFD_EXTERNAL_DIAGNOSTICS_CONTRACT_v1.md
+++ b/docs/specs/phase14-distributed-observability/PROOFD_EXTERNAL_DIAGNOSTICS_CONTRACT_v1.md
@@ -6,6 +6,10 @@ This document defines the canonical external diagnostics contract for `proofd`.
 It exists so the public query surface, router behavior, and CI harness
 expectations derive from a single truth surface.
 
+For public diagnostics routing, the v1 execution model is:
+
+`path -> endpoint_id -> handler -> schema`
+
 ## Scope
 
 This contract covers:
@@ -187,6 +191,8 @@ The canonical implementation source for this contract is:
 The following surfaces MUST derive from that module:
 
 - `/diagnostics/version` endpoint declarations
+- public diagnostics route resolution
+- endpoint identifier selection for public diagnostics handlers
 - GET query validation for public diagnostics
 - artifact-backed public route lookup for eligible passthrough endpoints
 - `proofd_gate_harness` endpoint expectations

--- a/docs/specs/phase14-distributed-observability/README.md
+++ b/docs/specs/phase14-distributed-observability/README.md
@@ -93,7 +93,7 @@ Workstream numbering in this document MUST align with the Phase-14 development t
 - Response field audit (PHASE13_FORBIDDEN_FIELDS enforcement)
 - Response schema stability contract for service-owned diagnostics responses
 - Explicit schema coverage declarations (`none` / `root_only` / `full`) for every public diagnostics endpoint
-- Contract-driven dispatch for public computed diagnostics routes
+- Unified contract-driven dispatch for public diagnostics routes (`path -> endpoint_id -> handler -> schema`)
 - Service boundary documentation
 - Read-only contract enforcement tests
 

--- a/userspace/proofd/src/api_contract.rs
+++ b/userspace/proofd/src/api_contract.rs
@@ -50,6 +50,20 @@ pub struct DiagnosticsEndpointContract {
     pub scope: EndpointScope,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DiagnosticsPathParams {
+    pub run_id: Option<String>,
+    pub incident_id: Option<String>,
+    pub fp: Option<String>,
+    pub artifact_path: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedDiagnosticsEndpoint {
+    pub contract: &'static DiagnosticsEndpointContract,
+    pub params: DiagnosticsPathParams,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ForbiddenObservabilityField {
     pub normalized_field: &'static str,
@@ -516,30 +530,42 @@ pub fn allowed_query_keys_for_path(path: &str) -> Option<&'static [&'static str]
         return Some(NO_QUERY_KEYS);
     }
 
-    if let Some(endpoint) = public_endpoint_contract_for_path(path) {
-        return Some(endpoint.allowed_query_keys);
+    if let Some(resolved) = resolve_public_endpoint(path) {
+        return Some(resolved.contract.allowed_query_keys);
     }
     None
 }
 
 pub fn root_endpoint_contract_for_path(path: &str) -> Option<&'static DiagnosticsEndpointContract> {
-    ROOT_DIAGNOSTICS_ENDPOINTS
-        .iter()
-        .find(|endpoint| path_matches_template(path, endpoint.path_template))
+    resolve_root_endpoint(path).map(|resolved| resolved.contract)
 }
 
 pub fn run_scoped_endpoint_contract_for_path(
     path: &str,
 ) -> Option<&'static DiagnosticsEndpointContract> {
-    RUN_SCOPED_DIAGNOSTICS_ENDPOINTS
-        .iter()
-        .find(|endpoint| path_matches_template(path, endpoint.path_template))
+    resolve_run_scoped_endpoint(path).map(|resolved| resolved.contract)
 }
 
 pub fn public_endpoint_contract_for_path(
     path: &str,
 ) -> Option<&'static DiagnosticsEndpointContract> {
-    root_endpoint_contract_for_path(path).or_else(|| run_scoped_endpoint_contract_for_path(path))
+    resolve_public_endpoint(path).map(|resolved| resolved.contract)
+}
+
+pub fn resolve_root_endpoint(path: &str) -> Option<ResolvedDiagnosticsEndpoint> {
+    ROOT_DIAGNOSTICS_ENDPOINTS
+        .iter()
+        .find_map(|contract| resolve_endpoint_contract(path, contract))
+}
+
+pub fn resolve_run_scoped_endpoint(path: &str) -> Option<ResolvedDiagnosticsEndpoint> {
+    RUN_SCOPED_DIAGNOSTICS_ENDPOINTS
+        .iter()
+        .find_map(|contract| resolve_endpoint_contract(path, contract))
+}
+
+pub fn resolve_public_endpoint(path: &str) -> Option<ResolvedDiagnosticsEndpoint> {
+    resolve_root_endpoint(path).or_else(|| resolve_run_scoped_endpoint(path))
 }
 
 pub fn root_passthrough_contract_for_path(
@@ -556,10 +582,19 @@ pub fn run_scoped_passthrough_contract_for_path(
     run_scoped_endpoint_contract_for_path(path).filter(|endpoint| endpoint.artifact_file.is_some())
 }
 
-fn path_matches_template(path: &str, path_template: &str) -> bool {
+fn resolve_endpoint_contract(
+    path: &str,
+    contract: &'static DiagnosticsEndpointContract,
+) -> Option<ResolvedDiagnosticsEndpoint> {
+    resolve_path_params(path, contract.path_template)
+        .map(|params| ResolvedDiagnosticsEndpoint { contract, params })
+}
+
+fn resolve_path_params(path: &str, path_template: &str) -> Option<DiagnosticsPathParams> {
     let path_segments = split_segments(path);
     let template_segments = split_segments(path_template);
 
+    let mut params = DiagnosticsPathParams::default();
     let mut path_index = 0usize;
     let mut template_index = 0usize;
 
@@ -567,30 +602,91 @@ fn path_matches_template(path: &str, path_template: &str) -> bool {
         let template_segment = template_segments[template_index];
 
         if template_segment == "{artifact_path}" {
-            return path_index < path_segments.len();
+            if path_index >= path_segments.len() {
+                return None;
+            }
+            params.artifact_path = Some(path_segments[path_index..].join("/"));
+            return (template_index + 1 == template_segments.len()).then_some(params);
         }
 
         if path_index >= path_segments.len() {
-            return false;
+            return None;
         }
 
         let path_segment = path_segments[path_index];
         let is_placeholder = template_segment.starts_with('{') && template_segment.ends_with('}');
-        if !is_placeholder && template_segment != path_segment {
-            return false;
+        if is_placeholder {
+            if !capture_path_param(&mut params, template_segment, path_segment) {
+                return None;
+            }
+        } else if template_segment != path_segment {
+            return None;
         }
 
         template_index += 1;
         path_index += 1;
     }
 
-    path_index == path_segments.len()
+    (path_index == path_segments.len()).then_some(params)
+}
+
+fn capture_path_param(params: &mut DiagnosticsPathParams, key: &str, value: &str) -> bool {
+    match key {
+        "{run_id}" => params.run_id = Some(value.to_string()),
+        "{incident_id}" => params.incident_id = Some(value.to_string()),
+        "{fp}" => params.fp = Some(value.to_string()),
+        _ => return false,
+    }
+    true
 }
 
 fn split_segments(path: &str) -> Vec<&str> {
     path.split('/')
         .filter(|segment| !segment.is_empty())
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_public_endpoint, DiagnosticsEndpointId};
+
+    #[test]
+    fn resolver_captures_root_diagnostics_params() {
+        let incident = resolve_public_endpoint("/diagnostics/incidents/sha256:incident")
+            .expect("incident endpoint should resolve");
+        assert_eq!(incident.contract.id, DiagnosticsEndpointId::IncidentById);
+        assert_eq!(
+            incident.params.incident_id.as_deref(),
+            Some("sha256:incident")
+        );
+
+        let fingerprint = resolve_public_endpoint(
+            "/diagnostics/fingerprints/sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+        .expect("fingerprint endpoint should resolve");
+        assert_eq!(
+            fingerprint.contract.id,
+            DiagnosticsEndpointId::FingerprintBoundary
+        );
+        assert_eq!(
+            fingerprint.params.fp.as_deref(),
+            Some("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        );
+    }
+
+    #[test]
+    fn resolver_captures_run_scoped_artifact_path() {
+        let resolved = resolve_public_endpoint(
+            "/diagnostics/runs/run-20260310-1/artifacts/receipts/verification_receipt.json",
+        )
+        .expect("artifact endpoint should resolve");
+        assert_eq!(resolved.contract.id, DiagnosticsEndpointId::RunArtifactFile);
+        assert_eq!(resolved.params.run_id.as_deref(), Some("run-20260310-1"));
+        assert_eq!(
+            resolved.params.artifact_path.as_deref(),
+            Some("receipts/verification_receipt.json")
+        );
+    }
 }
 
 fn scan_forbidden_observability_fields_inner(

--- a/userspace/proofd/src/lib.rs
+++ b/userspace/proofd/src/lib.rs
@@ -36,9 +36,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::api_contract::{
-    allowed_query_keys_for_path, root_endpoint_contract_for_path,
-    run_scoped_endpoint_contract_for_path, scan_forbidden_observability_fields,
-    DiagnosticsEndpointContract, DiagnosticsEndpointId, ALLOWED_INCIDENT_FILTERS,
+    allowed_query_keys_for_path, resolve_public_endpoint, scan_forbidden_observability_fields,
+    DiagnosticsEndpointId, ResolvedDiagnosticsEndpoint, ALLOWED_INCIDENT_FILTERS,
 };
 use crate::api_schema::validate_response_schema_for_path;
 use crate::determinism::artifacts::{
@@ -553,10 +552,8 @@ pub fn route_request_with_body(
                         "mode": "verification_execution_and_read_only_diagnostics",
                     }),
                 )
-            } else if let Some(contract) = root_endpoint_contract_for_path(&target.path) {
-                handle_root_endpoint(contract, &target, evidence_dir)
-            } else if target.path.starts_with("/diagnostics/runs/") {
-                handle_run_endpoint(&target.path, evidence_dir)
+            } else if let Some(resolved) = resolve_public_endpoint(&target.path) {
+                handle_diagnostics_endpoint(resolved, &target, evidence_dir)
             } else {
                 json_response(404, json!({ "error": "not_found" }))
             }
@@ -591,14 +588,15 @@ fn validate_get_query(target: &RequestTarget) -> Result<(), ServiceError> {
     Err(ServiceError::BadRequest("unsupported_query_parameter"))
 }
 
-fn handle_root_endpoint(
-    contract: &DiagnosticsEndpointContract,
+fn handle_diagnostics_endpoint(
+    resolved: ResolvedDiagnosticsEndpoint,
     target: &RequestTarget,
     evidence_dir: &Path,
 ) -> DiagnosticsResponse {
+    let contract = resolved.contract;
     match contract.id {
         DiagnosticsEndpointId::Version => observability_json_response(
-            contract.path_template,
+            &target.path,
             200,
             json!({
                 "api_version": API_VERSION,
@@ -614,75 +612,149 @@ fn handle_root_endpoint(
             }),
         ),
         DiagnosticsEndpointId::Runs => match list_runs(evidence_dir) {
-            Ok(value) => observability_json_response(contract.path_template, 200, value),
+            Ok(value) => observability_json_response(&target.path, 200, value),
             Err(error) => error_response(error),
         },
         DiagnosticsEndpointId::Federation => {
             match build_global_federation_diagnostics(evidence_dir) {
-                Ok(value) => observability_json_response(contract.path_template, 200, value),
+                Ok(value) => observability_json_response(&target.path, 200, value),
                 Err(error) => error_response(error),
             }
         }
         DiagnosticsEndpointId::Context => match build_global_context_diagnostics(evidence_dir) {
-            Ok(value) => observability_json_response(contract.path_template, 200, value),
+            Ok(value) => observability_json_response(&target.path, 200, value),
             Err(error) => error_response(error),
         },
         DiagnosticsEndpointId::Trust => match build_global_trust_diagnostics(evidence_dir) {
-            Ok(value) => observability_json_response(contract.path_template, 200, value),
+            Ok(value) => observability_json_response(&target.path, 200, value),
             Err(error) => error_response(error),
         },
         DiagnosticsEndpointId::ParityContextRelation => {
             match build_parity_context_relation(evidence_dir) {
-                Ok(value) => observability_json_response(contract.path_template, 200, value),
+                Ok(value) => observability_json_response(&target.path, 200, value),
                 Err(error) => error_response(error),
             }
         }
         DiagnosticsEndpointId::Incidents => {
             match load_incident_report(evidence_dir, target.query.as_deref()) {
-                Ok(value) => observability_json_response(contract.path_template, 200, value),
+                Ok(value) => observability_json_response(&target.path, 200, value),
                 Err(error) => error_response(error),
             }
         }
         DiagnosticsEndpointId::IncidentById => {
-            let incident_id = target
-                .path
-                .trim_start_matches("/diagnostics/incidents/")
-                .to_string();
+            let Some(incident_id) = resolved.params.incident_id.as_deref() else {
+                return json_response(404, json!({ "error": "not_found" }));
+            };
             match load_single_incident(evidence_dir, &incident_id) {
                 Ok(value) => observability_json_response(&target.path, 200, value),
                 Err(error) => error_response(error),
             }
         }
         DiagnosticsEndpointId::FingerprintBoundary => {
-            let fp = target
-                .path
-                .trim_start_matches("/diagnostics/fingerprints/")
-                .to_string();
-            if fp.is_empty() || fp.contains('/') {
+            let Some(fp) = resolved.params.fp.as_deref() else {
                 return json_response(404, json!({ "error": "not_found" }));
-            }
-            match build_fingerprint_boundary_diagnostics(&fp, evidence_dir) {
+            };
+            match build_fingerprint_boundary_diagnostics(fp, evidence_dir) {
                 Ok(value) => observability_json_response(&target.path, 200, value),
                 Err(error) => error_response(error),
             }
         }
         DiagnosticsEndpointId::ReplicatedBoundary => {
             match build_replicated_boundary_status(evidence_dir) {
-                Ok(value) => observability_json_response(contract.path_template, 200, value),
+                Ok(value) => observability_json_response(&target.path, 200, value),
                 Err(error) => error_response(error),
             }
         }
-        DiagnosticsEndpointId::Parity
-        | DiagnosticsEndpointId::AuthoritySuppression
-        | DiagnosticsEndpointId::AuthorityTopology
-        | DiagnosticsEndpointId::Graph
-        | DiagnosticsEndpointId::Drift
-        | DiagnosticsEndpointId::Convergence
-        | DiagnosticsEndpointId::FailureMatrix => {
+        DiagnosticsEndpointId::RunSummary => {
+            let (run_id, run_dir) = match resolve_run_scope(&resolved, evidence_dir) {
+                Ok(parts) => parts,
+                Err(response) => return response,
+            };
+            match build_run_summary(run_id, &run_dir) {
+                Ok(summary) => observability_json_response(&target.path, 200, summary),
+                Err(error) => error_response(error),
+            }
+        }
+        DiagnosticsEndpointId::RunArtifactsIndex => {
+            let (run_id, run_dir) = match resolve_run_scope(&resolved, evidence_dir) {
+                Ok(parts) => parts,
+                Err(response) => return response,
+            };
+            match build_run_artifact_index(run_id, &run_dir) {
+                Ok(index) => observability_json_response(&target.path, 200, index),
+                Err(error) => error_response(error),
+            }
+        }
+        DiagnosticsEndpointId::RunArtifactFile => {
+            let (_, run_dir) = match resolve_run_scope(&resolved, evidence_dir) {
+                Ok(parts) => parts,
+                Err(response) => return response,
+            };
+            let Some(artifact_path) = resolved.params.artifact_path.as_deref() else {
+                return json_response(404, json!({ "error": "not_found" }));
+            };
+            let artifact_path = match parse_run_artifact_path(artifact_path) {
+                Ok(path) => path,
+                Err(error) => return error_response(error),
+            };
+            match resolve_run_artifact_path(&run_dir, artifact_path) {
+                Ok(path) => serve_artifact_file(path, artifact_content_type(artifact_path)),
+                Err(error) => error_response(error),
+            }
+        }
+        DiagnosticsEndpointId::RunFederation => {
+            let (run_id, run_dir) = match resolve_run_scope(&resolved, evidence_dir) {
+                Ok(parts) => parts,
+                Err(response) => return response,
+            };
+            match build_run_federation_diagnostics(run_id, &run_dir) {
+                Ok(value) => observability_json_response(&target.path, 200, value),
+                Err(error) => error_response(error),
+            }
+        }
+        DiagnosticsEndpointId::RunContext => {
+            let (run_id, run_dir) = match resolve_run_scope(&resolved, evidence_dir) {
+                Ok(parts) => parts,
+                Err(response) => return response,
+            };
+            match build_run_context_diagnostics(run_id, &run_dir) {
+                Ok(value) => observability_json_response(&target.path, 200, value),
+                Err(error) => error_response(error),
+            }
+        }
+        DiagnosticsEndpointId::RunRegistry => {
+            let (run_id, run_dir) = match resolve_run_scope(&resolved, evidence_dir) {
+                Ok(parts) => parts,
+                Err(response) => return response,
+            };
+            match build_run_registry_diagnostics(run_id, &run_dir) {
+                Ok(value) => observability_json_response(&target.path, 200, value),
+                Err(error) => error_response(error),
+            }
+        }
+        DiagnosticsEndpointId::RunBoundary => {
+            let (run_id, run_dir) = match resolve_run_scope(&resolved, evidence_dir) {
+                Ok(parts) => parts,
+                Err(response) => return response,
+            };
+            match build_run_boundary_diagnostics(run_id, &run_dir, evidence_dir) {
+                Ok(value) => observability_json_response(&target.path, 200, value),
+                Err(error) => error_response(error),
+            }
+        }
+        _ if contract.artifact_file.is_some() => {
+            let base_dir = if resolved.params.run_id.is_some() {
+                match resolve_run_scope(&resolved, evidence_dir) {
+                    Ok((_, run_dir)) => run_dir,
+                    Err(response) => return response,
+                }
+            } else {
+                evidence_dir.to_path_buf()
+            };
             let artifact = contract
                 .artifact_file
-                .expect("root passthrough artifact missing");
-            serve_observability_json_file(&target.path, evidence_dir.join(artifact))
+                .expect("passthrough artifact missing");
+            serve_observability_json_file(&target.path, base_dir.join(artifact))
         }
         _ => json_response(404, json!({ "error": "not_found" })),
     }
@@ -730,85 +802,17 @@ fn list_runs(evidence_dir: &Path) -> Result<Value, ServiceError> {
     }))
 }
 
-fn handle_run_endpoint(path: &str, evidence_dir: &Path) -> DiagnosticsResponse {
-    let parts = path
-        .split('/')
-        .filter(|part| !part.is_empty())
-        .collect::<Vec<_>>();
-    if parts.len() < 3 {
-        return json_response(404, json!({ "error": "invalid_run_path" }));
-    }
-
-    let run_id = parts[2];
-    if !is_safe_path_segment(run_id) {
-        return json_response(404, json!({ "error": "invalid_run_id" }));
-    }
-
-    let run_dir = evidence_dir.join(run_id);
-    let Some(contract) = run_scoped_endpoint_contract_for_path(path) else {
-        return json_response(404, json!({ "error": "not_found" }));
+fn resolve_run_scope<'a>(
+    resolved: &'a ResolvedDiagnosticsEndpoint,
+    evidence_dir: &Path,
+) -> Result<(&'a str, PathBuf), DiagnosticsResponse> {
+    let Some(run_id) = resolved.params.run_id.as_deref() else {
+        return Err(json_response(404, json!({ "error": "not_found" })));
     };
-
-    match contract.id {
-        DiagnosticsEndpointId::RunSummary => match build_run_summary(run_id, &run_dir) {
-            Ok(summary) => observability_json_response(path, 200, summary),
-            Err(error) => error_response(error),
-        },
-        DiagnosticsEndpointId::RunArtifactsIndex => {
-            match build_run_artifact_index(run_id, &run_dir) {
-                Ok(index) => observability_json_response(path, 200, index),
-                Err(error) => error_response(error),
-            }
-        }
-        DiagnosticsEndpointId::RunArtifactFile => {
-            let artifact_path = match parse_run_artifact_path(&parts[4..]) {
-                Ok(path) => path,
-                Err(error) => return error_response(error),
-            };
-            match resolve_run_artifact_path(&run_dir, &artifact_path) {
-                Ok(path) => serve_artifact_file(path, artifact_content_type(&artifact_path)),
-                Err(error) => error_response(error),
-            }
-        }
-        DiagnosticsEndpointId::RunFederation => {
-            match build_run_federation_diagnostics(run_id, &run_dir) {
-                Ok(value) => observability_json_response(path, 200, value),
-                Err(error) => error_response(error),
-            }
-        }
-        DiagnosticsEndpointId::RunContext => {
-            match build_run_context_diagnostics(run_id, &run_dir) {
-                Ok(value) => observability_json_response(path, 200, value),
-                Err(error) => error_response(error),
-            }
-        }
-        DiagnosticsEndpointId::RunRegistry => {
-            match build_run_registry_diagnostics(run_id, &run_dir) {
-                Ok(value) => observability_json_response(path, 200, value),
-                Err(error) => error_response(error),
-            }
-        }
-        DiagnosticsEndpointId::RunBoundary => {
-            match build_run_boundary_diagnostics(run_id, &run_dir, evidence_dir) {
-                Ok(value) => observability_json_response(path, 200, value),
-                Err(error) => error_response(error),
-            }
-        }
-        DiagnosticsEndpointId::RunIncidents
-        | DiagnosticsEndpointId::RunParity
-        | DiagnosticsEndpointId::RunAuthoritySuppression
-        | DiagnosticsEndpointId::RunAuthorityTopology
-        | DiagnosticsEndpointId::RunGraph
-        | DiagnosticsEndpointId::RunDrift
-        | DiagnosticsEndpointId::RunConvergence
-        | DiagnosticsEndpointId::RunFailureMatrix => {
-            let artifact = contract
-                .artifact_file
-                .expect("run-scoped passthrough artifact missing");
-            serve_observability_json_file(path, run_dir.join(artifact))
-        }
-        _ => json_response(404, json!({ "error": "not_found" })),
+    if !is_safe_path_segment(run_id) {
+        return Err(json_response(404, json!({ "error": "invalid_run_id" })));
     }
+    Ok((run_id, evidence_dir.join(run_id)))
 }
 
 fn build_run_summary(run_id: &str, run_dir: &Path) -> Result<Value, ServiceError> {
@@ -3264,18 +3268,18 @@ fn list_run_artifact_descriptors(
         .collect())
 }
 
-fn parse_run_artifact_path(segments: &[&str]) -> Result<String, ServiceError> {
-    if segments.is_empty() {
+fn parse_run_artifact_path<'a>(artifact_path: &'a str) -> Result<&'a str, ServiceError> {
+    if artifact_path.is_empty() {
         return Err(ServiceError::Forbidden("artifact_path_not_allowed"));
     }
     // Task 4.3: ".." and "." segments must be rejected with 403 (path traversal guard)
-    if segments
-        .iter()
+    if artifact_path
+        .split('/')
         .any(|segment| !is_safe_path_segment(segment))
     {
         return Err(ServiceError::Forbidden("artifact_path_not_allowed"));
     }
-    Ok(segments.join("/"))
+    Ok(artifact_path)
 }
 
 fn resolve_run_artifact_path(run_dir: &Path, artifact_path: &str) -> Result<PathBuf, ServiceError> {


### PR DESCRIPTION
## Purpose
Complete the final Phase 14 3.3 dispatch-hardening slice by moving public diagnostics routing to a unified contract-driven resolver.

## What Changed
- add unified public diagnostics path resolver with captured route params
- route public diagnostics through endpoint_id -> handler -> schema
- remove remaining root/run route re-parsing seams from proofd public diagnostics dispatch
- keep artifact-backed generic dispatch via contract metadata
- sync Phase 14 docs/tracker to merged 3.3 truth

## Validation
- cargo test --manifest-path userspace/proofd/Cargo.toml
- bash scripts/ci/gate_proofd_service.sh --evidence-dir /tmp/proofd-service-final-dispatch
- bash scripts/ci/gate_proofd_schema_coverage.sh --evidence-dir /tmp/proofd-schema-coverage-final-dispatch --source-gate-dir /tmp/proofd-service-final-dispatch
- bash scripts/ci/gate_proofd_observability_boundary.sh --evidence-dir /tmp/proofd-observability-boundary-final-dispatch
- bash scripts/ci/gate_observability_routing_separation.sh --evidence-dir /tmp/proofd-routing-separation-final-dispatch
- bash scripts/ci/gate_diagnostics_consumer_non_authoritative_contract.sh --evidence-dir /tmp/diag-consumer-final-dispatch

## Notes
- /healthz remains intentionally special-cased
- artifact-backed passthrough endpoints remain outside structural schema freeze in v1
- non-GET diagnostics method rejection still uses the namespace boundary path