### PR TITLE
Phase 17 Step 3: Add marker capture helper (write-only)

### DIFF
--- a/kernel/sys/execution_slot.c
+++ b/kernel/sys/execution_slot.c
@@ -283,6 +283,30 @@ static __attribute__((noreturn)) void execution_slot_runtime_panic(const char *s
     }
 }
 
+#if AYKEN_EXECUTION_MARKER_VALIDATION_ENABLE
+/*
+ * execution_slot_marker_capture_locked - Capture execution marker (write-only)
+ * 
+ * @slot: Execution slot
+ * @marker: Marker to capture
+ * 
+ * Pure write operation - NO validation, NO error handling, NO failure path.
+ * Validation happens later in Step 5 (pre-commit guard).
+ * 
+ * Rule: WRITE FIRST → VALIDATE LATER
+ * 
+ * This helper is NOT called yet (Step 4 adds call sites).
+ */
+static inline void execution_slot_marker_capture_locked(
+    exec_slot_t *slot,
+    execution_marker_t marker)
+{
+    slot->marker_bitmap |= (uint8_t)(1u << marker);
+    slot->last_marker = (uint8_t)marker;
+    slot->marker_count++;
+}
+#endif
+
 static void execution_slot_zero_slot(exec_slot_t *slot)
 {
     uint32_t i;


### PR DESCRIPTION
## Summary
Add execution_slot_marker_capture_locked() helper for write-only marker capture.

## Changes
- Add static inline helper in execution_slot.c
- Pure write operation: bitmap, last_marker, count
- NO validation, NO error handling, NO failure path
- Validation deferred to Step 5 (pre-commit guard)

## Design Rule
**WRITE FIRST → VALIDATE LATER**

## Constitutional Compliance
- MEMORY.CONTRACT.VIOLATION=PASS (no unsafe operations)
- Phase: P4.4 (Development)

## Dependencies
- Depends on: #129 (Step 2 - header definitions)

## Next Steps
- Step 4: Add call sites (ENTRY, EXIT, YIELD)
- Step 5: Add pre-commit validation guard

## Tracking
#phase17-step3