### PR TITLE
fix(phase17): correct marker call site state names

### DIFF
--- a/PHASE17_STEP4_DESIGN.md
+++ b/PHASE17_STEP4_DESIGN.md
@@ -18,7 +18,7 @@ MARKER_WAIT_OK              → Wait completed
 
 ### 1. MARKER_EXEC_START
 **Location:** `execution_slot_transition_locked()`
-- **When:** Transition to `EXEC_SLOT_EXECUTING`
+- **When:** Transition to `EXEC_SLOT_RUNNING`
 - **Rationale:** Execution phase begins
 
 ### 2. MARKER_EXEC_OUTPUT_WRITTEN
@@ -28,7 +28,7 @@ MARKER_WAIT_OK              → Wait completed
 
 ### 3. MARKER_EXEC_COMPLETE_OK
 **Location:** `execution_slot_finish_locked()`
-- **When:** Transition to `EXEC_SLOT_EXECUTED`
+- **When:** Transition to `EXEC_SLOT_COMPLETED`
 - **Rationale:** Execution phase complete
 
 ### 4. MARKER_VERIFY_START
@@ -48,7 +48,7 @@ MARKER_WAIT_OK              → Wait completed
 
 ### 7. MARKER_WAIT_OK
 **Location:** `execution_slot_finish_locked()`
-- **When:** Transition to `EXEC_SLOT_COMPLETED`
+- **When:** Transition to `EXEC_SLOT_RESULT_MAPPED`
 - **Rationale:** Full lifecycle complete
 
 ## Implementation Rules

--- a/kernel/sys/execution_slot.c
+++ b/kernel/sys/execution_slot.c
@@ -729,9 +729,9 @@ int execution_slot_finish_locked(exec_slot_t *slot, exec_slot_state_t next_state
 
 #if AYKEN_EXECUTION_MARKER_VALIDATION_ENABLE
     /* Capture lifecycle markers based on target state */
-    if (next_state == EXEC_SLOT_EXECUTED) {
+    if (next_state == EXEC_SLOT_COMPLETED) {
         execution_slot_marker_capture_locked(slot, MARKER_EXEC_COMPLETE_OK);
-    } else if (next_state == EXEC_SLOT_COMPLETED) {
+    } else if (next_state == EXEC_SLOT_RESULT_MAPPED) {
         execution_slot_marker_capture_locked(slot, MARKER_WAIT_OK);
     }
 #endif
@@ -1575,8 +1575,8 @@ int execution_slot_transition_locked(exec_slot_t *slot,
     slot->state = next_state;
 
 #if AYKEN_EXECUTION_MARKER_VALIDATION_ENABLE
-    /* Capture EXEC_START marker when entering EXECUTING state */
-    if (next_state == EXEC_SLOT_EXECUTING) {
+    /* Capture EXEC_START marker when entering RUNNING state */
+    if (next_state == EXEC_SLOT_RUNNING) {
         execution_slot_marker_capture_locked(slot, MARKER_EXEC_START);
     }
 #endif


### PR DESCRIPTION
## Problem

PR #131 merged with incorrect state names in marker call sites, breaking flag-ON builds:
- Used `EXEC_SLOT_EXECUTING` (doesn't exist) instead of `EXEC_SLOT_RUNNING`
- Used `EXEC_SLOT_EXECUTED` (doesn't exist) instead of `EXEC_SLOT_COMPLETED`
- Wrong WAIT_OK condition checked `EXEC_SLOT_COMPLETED` instead of `EXEC_SLOT_RESULT_MAPPED`

Bug was hidden because `AYKEN_EXECUTION_MARKER_VALIDATION_ENABLE` defaults to OFF (=0), so the buggy code wasn't compiled in default CI.

## Solution

Fixed all three state name errors in `kernel/sys/execution_slot.c`:
1. `EXEC_SLOT_EXECUTING` → `EXEC_SLOT_RUNNING` (MARKER_EXEC_START)
2. `EXEC_SLOT_EXECUTED` → `EXEC_SLOT_COMPLETED` (MARKER_EXEC_COMPLETE_OK)
3. `EXEC_SLOT_COMPLETED` → `EXEC_SLOT_RESULT_MAPPED` (MARKER_WAIT_OK)

Also updated `PHASE17_STEP4_DESIGN.md` to reflect correct state names.

## Verification

Flag-ON build now passes:
```bash
make clean
make kernel AYKEN_EXECUTION_MARKER_VALIDATION_ENABLE=1
```

## Impact

- **Severity**: High (breaks flag-ON path)
- **Scope**: Phase 17 marker validation only
- **Risk**: Low (hotfix corrects typos, no logic changes)

## Next Steps

After merge:
1. Verify flag-ON sanity build
2. Proceed to Step 5 (validation guard implementation)