### PR TITLE
ci(perf): renew baseline for runner image update

### DIFF
--- a/scripts/ci/perf-baseline.lock.json
+++ b/scripts/ci/perf-baseline.lock.json
@@ -1,8 +1,8 @@
 {
-  "created_at_utc": "2026-05-24T19:18:20Z",
+  "created_at_utc": "2026-05-30T23:04:14Z",
   "env": {
     "baseline_authority": "github-hosted-ubuntu-24.04-x64",
-    "ci_image_digest": "gha-ubuntu24-20260518.149.1-X64",
+    "ci_image_digest": "gha-ubuntu24-20260525.161.1-X64",
     "clang_version": "Ubuntu clang version 18.1.3 (1ubuntu1)",
     "env_hash": "edbe5bed0e83075ace80b5d9aa09588613afceedd8304e30891a20aae2dc4a67",
     "host_arch": "x86_64",
@@ -26,11 +26,11 @@
     "qemu_version": "QEMU emulator version 8.2.2 (Debian 1:8.2.2+ds-0ubuntu1.16)",
     "target_triple": "x86_64-elf"
   },
-  "git_sha": "404186185823b254d75db320167d9157c8b8830f",
+  "git_sha": "ee1aa4afe55eeec4a4b662802a26f1ef26e79463",
   "metrics": {
-    "boot_time_ms": 10707,
-    "context_switch_latency_ms_proxy": 173.114754,
-    "syscall_latency_ms_proxy": 173.114754
+    "boot_time_ms": 10704,
+    "context_switch_latency_ms_proxy": 170.131148,
+    "syscall_latency_ms_proxy": 170.131148
   },
   "policy": {
     "baseline_authority": "github-hosted-ubuntu-24.04-x64",
@@ -54,30 +54,30 @@
     }
   },
   "raw_metrics": {
-    "boot_time_ms": 10707,
-    "context_switch_latency_ms_proxy": 173.114754,
+    "boot_time_ms": 10704,
+    "context_switch_latency_ms_proxy": 170.131148,
     "entry_latency_ticks": {
       "available": true,
-      "ticks": 22282823
+      "ticks": 25295842
     },
     "mailbox_phase_breakdown_ticks": {
       "consume_trace": {
-        "count": 25,
+        "count": 11,
         "latest": {
-          "candidate_epoch": 5965,
-          "new_last_epoch": 5965,
-          "old_last_epoch": 5391,
+          "candidate_epoch": 14,
+          "new_last_epoch": 14,
+          "old_last_epoch": 13,
           "reason": "timer_validate_accept_consume",
           "site": "timer_validate_irq",
           "tick_valid": 2,
-          "ticks": 25653619825
+          "ticks": 26756469416
         },
         "reason_counts": {
           "gate45_self_keep_running_bypass": 0,
           "gate4_epoch1_pending_bypass": 0,
           "scheduler_keep_running_consume": 0,
           "scheduler_switch_consume": 1,
-          "timer_validate_accept_consume": 24,
+          "timer_validate_accept_consume": 10,
           "timer_validate_accept_deferred": 0
         },
         "site_counts": {
@@ -85,41 +85,41 @@
           "IRQ": 0,
           "START": 0,
           "YIELD": 0,
-          "timer_validate_irq": 24
+          "timer_validate_irq": 10
         }
       },
       "durations": {
         "arbiter": {
           "available": true,
-          "ticks": 8976334
+          "ticks": 10470720
         },
         "arbiter_candidate_lookup": {
           "available": true,
-          "ticks": 407509
+          "ticks": 529698
         },
         "arbiter_decision": {
           "available": true,
-          "ticks": 4266479
+          "ticks": 5086198
         },
         "arbiter_owner_lookup": {
           "available": true,
-          "ticks": 474810
+          "ticks": 554294
         },
         "extract": {
           "available": true,
-          "ticks": 2457032
+          "ticks": 2858310
         },
         "handoff": {
           "available": true,
-          "ticks": 310145
+          "ticks": 366054
         },
         "snapshot": {
           "available": true,
-          "ticks": 480053
+          "ticks": 556608
         },
         "validate": {
           "available": true,
-          "ticks": 1148462
+          "ticks": 1174212
         }
       },
       "events": {
@@ -129,7 +129,7 @@
         },
         "arbiter_candidate_accept_switch": {
           "available": true,
-          "ticks": 25468165213
+          "ticks": 26559877384
         },
         "arbiter_candidate_reject": {
           "available": false,
@@ -137,7 +137,7 @@
         },
         "arbiter_decision_path_fallback": {
           "available": true,
-          "ticks": 25507101887
+          "ticks": 26603373018
         },
         "arbiter_decision_path_keep_running": {
           "available": false,
@@ -149,11 +149,11 @@
         },
         "arbiter_decision_path_switch": {
           "available": true,
-          "ticks": 25467831621
+          "ticks": 26559472096
         },
         "arbiter_keep_running_fallback": {
           "available": true,
-          "ticks": 25507450791
+          "ticks": 26603792294
         },
         "arbiter_ready_head_fallback": {
           "available": false,
@@ -187,8 +187,8 @@
           "epoch_lte_owner_last_epoch_count": 61,
           "epoch_zero_count": 0,
           "latest_candidate_pid": 2,
-          "latest_epoch": 5965,
-          "latest_owner_last_epoch": 5965
+          "latest_epoch": 14,
+          "latest_owner_last_epoch": 14
         }
       },
       "fallback_reasons": {
@@ -215,10 +215,10 @@
           "count": 61,
           "enter_count": 61,
           "exit_count": 61,
-          "max_ticks": 1274025,
-          "mean_ticks": 319294,
-          "min_ticks": 268569,
-          "total_ticks": 19476959
+          "max_ticks": 1392612,
+          "mean_ticks": 400752,
+          "min_ticks": 333242,
+          "total_ticks": 24445928
         },
         "keep_running": {
           "available": false,
@@ -245,10 +245,10 @@
           "count": 1,
           "enter_count": 1,
           "exit_count": 1,
-          "max_ticks": 2240892,
-          "mean_ticks": 2240892,
-          "min_ticks": 2240892,
-          "total_ticks": 2240892
+          "max_ticks": 2663882,
+          "mean_ticks": 2663882,
+          "min_ticks": 2663882,
+          "total_ticks": 2663882
         }
       },
       "raw_markers": {
@@ -258,15 +258,15 @@
         },
         "arbiter_candidate_accept_switch": {
           "tick_valid": true,
-          "ticks": 25468165213
+          "ticks": 26559877384
         },
         "arbiter_candidate_lookup_enter": {
           "tick_valid": true,
-          "ticks": 25465012038
+          "ticks": 26556130862
         },
         "arbiter_candidate_lookup_exit": {
           "tick_valid": true,
-          "ticks": 25465419547
+          "ticks": 26556660560
         },
         "arbiter_candidate_reject": {
           "tick_valid": false,
@@ -274,15 +274,15 @@
         },
         "arbiter_decision_enter": {
           "tick_valid": true,
-          "ticks": 25464598160
+          "ticks": 26555654828
         },
         "arbiter_decision_exit": {
           "tick_valid": true,
-          "ticks": 25468864639
+          "ticks": 26560741026
         },
         "arbiter_decision_path_fallback": {
           "tick_valid": true,
-          "ticks": 25507101887
+          "ticks": 26603373018
         },
         "arbiter_decision_path_keep_running": {
           "tick_valid": false,
@@ -294,27 +294,27 @@
         },
         "arbiter_decision_path_switch": {
           "tick_valid": true,
-          "ticks": 25467831621
+          "ticks": 26559472096
         },
         "arbiter_enter": {
           "tick_valid": true,
-          "ticks": 25460306838
+          "ticks": 26550656120
         },
         "arbiter_exit": {
           "tick_valid": true,
-          "ticks": 25469283172
+          "ticks": 26561126840
         },
         "arbiter_keep_running_fallback": {
           "tick_valid": true,
-          "ticks": 25507450791
+          "ticks": 26603792294
         },
         "arbiter_owner_lookup_enter": {
           "tick_valid": true,
-          "ticks": 25460845176
+          "ticks": 26551314518
         },
         "arbiter_owner_lookup_exit": {
           "tick_valid": true,
-          "ticks": 25461319986
+          "ticks": 26551868812
         },
         "arbiter_ready_head_fallback": {
           "tick_valid": false,
@@ -326,35 +326,35 @@
         },
         "extract_enter": {
           "tick_valid": true,
-          "ticks": 25461810231
+          "ticks": 26552407714
         },
         "extract_exit": {
           "tick_valid": true,
-          "ticks": 25464267263
+          "ticks": 26555266024
         },
         "handoff_enter": {
           "tick_valid": true,
-          "ticks": 25469792993
+          "ticks": 26561706120
         },
         "handoff_exit": {
           "tick_valid": true,
-          "ticks": 25470103138
+          "ticks": 26562072174
         },
         "snapshot_enter": {
           "tick_valid": true,
-          "ticks": 25462175085
+          "ticks": 26552956002
         },
         "snapshot_exit": {
           "tick_valid": true,
-          "ticks": 25462655138
+          "ticks": 26553512610
         },
         "validate_enter": {
           "tick_valid": true,
-          "ticks": 25493947567
+          "ticks": 26588938988
         },
         "validate_exit": {
           "tick_valid": true,
-          "ticks": 25495096029
+          "ticks": 26590113200
         }
       }
     },
@@ -395,89 +395,89 @@
       "durations": {
         "boot_start_to_core_ready": {
           "available": true,
-          "ticks": 122967533
+          "ticks": 142993630
         },
         "core_ready_to_first_sched_activity": {
           "available": true,
-          "ticks": 877223
+          "ticks": 1007968
         },
         "first_sched_activity_to_first_user_entry": {
           "available": true,
-          "ticks": 19798744
+          "ticks": 21935368
         },
         "first_syscall_gate_entry_to_first_syscall_entry": {
           "available": true,
-          "ticks": 1925553
+          "ticks": 2259660
         },
         "first_syscall_gate_entry_to_first_syscall_exit": {
           "available": true,
-          "ticks": 2986722
+          "ticks": 3425838
         },
         "first_syscall_gate_entry_to_first_syscall_gate_return": {
           "available": true,
-          "ticks": 3517539
+          "ticks": 4015336
         },
         "first_user_entry_to_first_syscall_entry": {
           "available": true,
-          "ticks": 24208376
+          "ticks": 27555502
         },
         "first_user_entry_to_first_syscall_exit": {
           "available": true,
-          "ticks": 25269545
+          "ticks": 28721680
         },
         "first_user_entry_to_first_syscall_gate_entry": {
           "available": true,
-          "ticks": 22282823
+          "ticks": 25295842
         }
       },
       "raw_markers": {
         "boot_start": {
           "tick_valid": true,
-          "ticks": 25331373530
+          "ticks": 26401195042
         },
         "core_ready": {
           "tick_valid": true,
-          "ticks": 25454341063
+          "ticks": 26544188672
         },
         "first_sched_activity": {
           "tick_valid": true,
-          "ticks": 25455218286
+          "ticks": 26545196640
         },
         "first_syscall_entry": {
           "tick_valid": true,
-          "ticks": 25499225406
+          "ticks": 26594687510
         },
         "first_syscall_exit": {
           "tick_valid": true,
-          "ticks": 25500286575
+          "ticks": 26595853688
         },
         "first_syscall_gate_entry": {
           "tick_valid": true,
-          "ticks": 25497299853
+          "ticks": 26592427850
         },
         "first_syscall_gate_return": {
           "tick_valid": true,
-          "ticks": 25500817392
+          "ticks": 26596443186
         },
         "first_user_entry": {
           "tick_valid": true,
-          "ticks": 25475017030
+          "ticks": 26567132008
         }
       }
     },
     "preempt_iret_count": 61,
-    "preempt_qemu_run_time_ms": 10560,
-    "preempt_run_time_ms": 10560,
+    "preempt_qemu_run_time_ms": 10378,
+    "preempt_run_time_ms": 10378,
     "preempt_sw_count": 61,
-    "preempt_wall_time_ms": 10738,
+    "preempt_wall_time_ms": 10553,
     "syscall_gate_return_latency_ticks": {
       "available": true,
-      "ticks": 3517539
+      "ticks": 4015336
     },
-    "syscall_latency_ms_proxy": 173.114754,
+    "syscall_latency_ms_proxy": 170.131148,
     "syscall_latency_ticks_pure": {
       "available": true,
-      "ticks": 2986722
+      "ticks": 3425838
     }
   },
   "schema_version": 1


### PR DESCRIPTION
## Summary

- Imports the workflow-generated `scripts/ci/perf-baseline.lock.json` from `perf-baseline-init` run `26697295137`.
- Renews the GitHub-hosted ubuntu-24.04 runner image digest from `gha-ubuntu24-20260518.149.1-X64` to `gha-ubuntu24-20260525.161.1-X64`.
- Keeps the constitutional authority as `github-hosted-ubuntu-24.04-x64` and preserves the same env hash `edbe5bed0e83075ace80b5d9aa09588613afceedd8304e30891a20aae2dc4a67`.

## Trigger

PR #150 exposed a repository-wide Phase-17 PR-4 acceptance failure unrelated to its Makefile-only diff:

`source_ci_image_digest:expected=gha-ubuntu24-20260518.149.1-X64:actual=gha-ubuntu24-20260525.161.1-X64`

## Generated Lock Evidence

- Baseline init run: `26697295137`
- Generation subject SHA: `ee1aa4afe55eeec4a4b662802a26f1ef26e79463`
- Generated digest: `gha-ubuntu24-20260525.161.1-X64`
- `preempt_sw_count=61`
- `preempt_iret_count=61`
- Metrics: `boot_time_ms=10704`, `context_switch_latency_ms_proxy=170.131148`, `syscall_latency_ms_proxy=170.131148`

## Validation

- `git diff --check`
- `git diff --cached --check`
- `jq -e '.env.ci_image_digest == "gha-ubuntu24-20260525.161.1-X64" and .env.env_hash == "edbe5bed0e83075ace80b5d9aa09588613afceedd8304e30891a20aae2dc4a67" and .raw_metrics.preempt_sw_count > 0 and .raw_metrics.preempt_iret_count > 0 and .git_sha == "ee1aa4afe55eeec4a4b662802a26f1ef26e79463"' scripts/ci/perf-baseline.lock.json`
- Verified that PR #150's PASS performance report validates against this imported baseline with `phase17-performance-acceptance: PASS (locked_authority_pass)`.

## Authority Boundary

This imports a generated baseline lock for review under the governed `baseline-update` label. It is not Phase-17 closure, does not claim a performance improvement, and does not change runtime behavior.