### PR TITLE
docs(phase17): refresh closure candidate exact-SHA evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **Oluşturan:** Kenan AY
 **Düzenleyen / Geliştiren / Mimari Sorumlu:** Kenan AY *(bilgilendirme metadata'sı; runtime yetkisi değildir)*
 **Oluşturma Tarihi:** 01.01.2026
-**Son Güncelleme:** 26.05.2026
+**Son Güncelleme:** 31.05.2026
 **Closure Evidence:** `local-freeze-p10p11` + `local-phase11-closure` + `run-local-phase12c-closure-2026-03-11` + `run-local-p13-kill-switch-20260315T000051Z` + `phase15-official-closure` + `phase16-verification-layer-mvp-complete`
 **Evidence Git SHA (Phase-10/11):** `9cb2171b` | **Evidence Git SHA (Phase-12C):** `01d1cb5c` | **Evidence Git SHA (Phase-13):** `40158350` | **Evidence Git SHA (Phase-15):** `48970cd0` | **Evidence Git SHA (Phase-16):** `489868f8`
 **Closure Sync / Remote CI (Phase-10/11):** `fe9031d7` (`ci-freeze#22797401328 = success`)
@@ -24,13 +24,13 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **Remote CI (Phase-16):** Verification Layer MVP complete (2026-04-25)
 **CURRENT_PHASE:** `17` (`Phase-16 OFFICIALLY CLOSED`; Phase-17 aktif, resmi closure henüz kurulmadı)
 **Freeze Zinciri:** `make ci-freeze` = 40 kapılı strict suite (normative spec-purity dahil) | `make ci-freeze-local` = local performance authority
-**Authority Durumu:** Issue #145 tek-maintainer authority kararıyla giderildi; PR #142 ve PR #144 birleşti. Performance workflow authority onarımı PR #148 ile kabul edilen `main` SHA `e0286c7b` üzerinde birleşti ve aynı SHA için gerekli uzak acceptance kontrolleri PASS verdi
+**Authority Durumu:** Issue #145 tek-maintainer authority kararıyla giderildi; PR #142, PR #144, PR #148, PR #149, PR #151 ve PR #150 birleşti. Closure-candidate exact-SHA kanıtı güncel `main` SHA `7a42d312` üzerinde yenilendi ve gerekli uzak acceptance kontrolleri PASS verdi
 **Yakın Hedef:** `reports/phase17_official_closure_candidate/` aday kaydını inceleyip, resmi closure karar kaydı/tag adımını ayrıca ve fail-closed olarak değerlendirmek
 **Ring0 Export Ceiling:** `193 symbols` (current enforced ceiling)
 **Performance Baseline Candidate:** `gha-ubuntu24-20260518.149.1-X64` (authorized run `26370359958` artifact'i PR'a import edildi; SHA `f129d4aa` locked acceptance PASS verdi, ancak tek basina closure authority değildir)
-**Development Status:** Phase-16 OFFICIALLY CLOSED ✅ | Phase-17 ACTIVE / CLOSURE CANDIDATE REVIEW PENDING 🔄 | SINGLE-MAINTAINER AUTHORITY ALIGNED (#145 RESOLVED) ✅ | PR #142/#144/#148 MERGED ✅ | EXACT-SHA REMOTE EVIDENCE PASS ✅ | Phase-18 ROADMAP ONLY
+**Development Status:** Phase-16 OFFICIALLY CLOSED ✅ | Phase-17 ACTIVE / CLOSURE CANDIDATE REVIEW PENDING 🔄 | SINGLE-MAINTAINER AUTHORITY ALIGNED (#145 RESOLVED) ✅ | PR #142/#144/#148/#149/#151/#150 MERGED ✅ | EXACT-SHA REMOTE EVIDENCE PASS ✅ | Phase-18 ROADMAP ONLY
 
-**Proje Durumu:** Core OS Phase 4.5 TAMAMLANDI ✅ | Phase 10-16 kapanış kayıtları mevcut ✅ | Phase 16 Verification Layer MVP OFFICIALLY CLOSED ✅ (2026-04-25) | CURRENT_PHASE=17 🔄 | Phase-17 Step 5 marker guard merged (PR #134) ✅ | Phase-17 resmi kapanış kanıtı yok 🔄 | Architecture Freeze ACTIVE ✅
+**Proje Durumu:** Core OS Phase 4.5 TAMAMLANDI ✅ | Phase 10-16 kapanış kayıtları mevcut ✅ | Phase 16 Verification Layer MVP OFFICIALLY CLOSED ✅ (2026-04-25) | CURRENT_PHASE=17 🔄 | Phase-17 Step 5 marker guard merged (PR #134) ✅ | Phase-17 resmi kapanış tag/kararı yok 🔄 | Architecture Freeze ACTIVE ✅
 **Boot/Kernel Bring-up:** UEFI→kernel handoff doğrulandı ✅ | Ring3 process preparation operasyonel ✅ | ELF64 loader çalışıyor ✅ | User address space creation aktif ✅ | Syscall roundtrip doğrulandı ✅ | IRQ-tail preempt doğrulama hattı mevcut ✅
 **Phase 10 Status:** Runtime determinism officially closed ✅ | remote `ci-freeze` run `22797401328`
 **Phase 11 Status:** Replay + KPL + proof bundle officially closed ✅
@@ -39,10 +39,10 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **Phase 14 Status:** OFFICIALLY CLOSED ✅ | all 5 workstreams merged | `obs-cli` consumer crate complete | Phase-14 observability invariants preserved
 **Phase 15 Status:** OFFICIALLY CLOSED ✅ | tag `phase15-official-closure` at `48970cd0` | remote `ci-freeze` run `24213727039` (PR #104) | BCIB Execution Engine v3: three-layer architecture, 293 tests PASS, 12 property tests PASS | `ayken-cli` v0.1 (Faz A wrapper) shipped | `tools/ayken-cli/`
 **Phase 16 Status:** OFFICIALLY CLOSED ✅ | Verification Layer MVP COMPLETE | Evidence chain integrity verified | Trust anchor established | `make verify-system` → 3 gates → PASS | Constitutional rule enforcement active | Fail-closed behavior confirmed
-**Phase 17 Status:** ACTIVE / OFFICIAL CLOSURE PENDING 🔄 | PR #144 birleşti (`156d721e`) ve PR #148 performance authority onarımı sonrası kabul edilen `main` SHA `e0286c7b` üzerinde full `ci-freeze` (`26421295459`), locked performance (`26421295487`, `26421686338`) ve Phase-17 QEMU evidence lanes (`26421686302`, `26421686320`, `26421686322`, `26421686303`, `26421686331`) PASS | `reports/phase17_official_closure_candidate/` review adayıdır; resmi tag yoktur
+**Phase 17 Status:** ACTIVE / OFFICIAL CLOSURE PENDING 🔄 | Güncel accepted `main` SHA `7a42d312` üzerinde full `ci-freeze` (`26697843452`), locked performance (`26697843425`, `26711867203`) ve Phase-17 QEMU evidence lanes (`26711867223`, `26711867206`, `26711867207`, `26711867217`, `26711867212`) PASS | `reports/phase17_official_closure_candidate/` review adayıdır; resmi tag yoktur
 **Phase 18 Status:** ROADMAP ONLY | Phase-17 resmi closure ve runtime acceptance kurulmadan aktif faz sayılmaz
 **Architecture Quick Map:** `docs/specs/phase12-trust-layer/AYKENOS_GATE_ARCHITECTURE.md`
-**Active Execution Roadmap:** `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` | stabilization-first; kabul edilen `main` SHA'sında bounded uzak evidence PASS; closure-candidate review ve resmi tag kararı halen ayrıdır
+**Active Execution Roadmap:** `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` | stabilization-first; accepted `main` SHA `7a42d312` uzerinde bounded uzak evidence PASS; closure-candidate review ve resmi tag kararı halen ayrıdır
 **Canonical Technical Definition:** AykenOS is a deterministic verification architecture that separates kernel execution, verification semantics, evidence artifacts, and distributed diagnostics into explicit layers. The kernel provides mechanism, userspace verification services produce artifact-bound verdicts and receipts, and parity/topology surfaces expose cross-node observability without elevating diagnostics into authority or consensus.
 
 ⚠️ **CI Mode:** `ci-freeze` workflow varsayılan olarak **CONSTITUTIONAL** modda çalışır (`PERF_BASELINE_MODE=constitutional`); provisional yol yalnız diagnosis/baseline artifact adayıdır ve acceptance/closure otoritesi değildir. Ayrıntı: [Constitutional CI Mode](docs/operations/CONSTITUTIONAL_CI_MODE.md), [Provisional CI Mode](docs/operations/PROVISIONAL_CI_MODE.md) ve [Performance Baseline Policy](docs/operations/PERF_BASELINE_POLICY.md).
@@ -68,7 +68,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 - **Evidence:** A, B, C karakterleri başarıyla syscall üzerinden basıldı
 - **Result:** Ring3 infrastructure PROVEN, syscall path WORKING, instruction retirement VALIDATED
 
-**Next Focus:** Kabul edilen `main` SHA'sına bağlı Phase-17 closure-candidate kaydını incelemek; aday kayıt resmi kapanış değildir ve tag yalnız ayrıca reviewed karar sonrasında değerlendirilebilir
+**Next Focus:** `reports/phase17_official_closure_candidate/` exact-SHA yenilemesini review etmek; aday kayıt resmi kapanış değildir ve tag yalnız ayrıca reviewed karar sonrasında değerlendirilebilir
 
 ## Authority Model
 
@@ -362,7 +362,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 
 ---
 
-**Son Güncelleme:** 26 Mayıs 2026 - Phase-16 resmi kapanış otoritesi korunur; CURRENT_PHASE=17; issue #145 çözüldü; PR #142/#144/#148 kabul edildi; `main` SHA `e0286c7b` üzerinde bounded Phase-17 uzak evidence ve strict freeze PASS verdi; closure-candidate kaydı hazırlanmıştır fakat resmi closure tag/kararı halen beklenmektedir; Phase-18 yalnızca yol haritasıdır.
+**Son Güncelleme:** 31 Mayıs 2026 - Phase-16 resmi kapanış otoritesi korunur; CURRENT_PHASE=17; issue #145 çözüldü; PR #142/#144/#148/#149/#151/#150 kabul edildi; `main` SHA `7a42d312` üzerinde bounded Phase-17 uzak evidence ve strict freeze PASS verdi; closure-candidate exact-SHA kaydı yenilenmiştir fakat resmi closure tag/kararı halen beklenmektedir; Phase-18 yalnızca yol haritasıdır.
 **Düzenleyen / Geliştiren / Oluşturan / Mimari Sorumlu:** Kenan AY *(metadata only; runtime/karar yetkisi değildir).*
 
 **© 2026 Kenan AY — AykenOS Project**

--- a/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
+++ b/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
@@ -85,11 +85,11 @@ Phase-17 kapanis kapisini asamaz.
 |---|---|---|
 | Resmi kapanis otoritesi | Phase-16 son resmi kapanis | Phase-17 closure iddiasi yok |
 | Aktif calisma | Phase-17 execution pipeline | Accepted-main bounded acceptance kaniti mevcut; official closure karari eksik |
-| Marker guard | Step 5 ve stacked runtime paketi PR #144 ile merge; accepted `main` SHA `e0286c7b` | Lifecycle, determinism/negative, public S1.E2E, stub-off fixture completion ve IRQ timeout-race exact-SHA remote PASS |
-| ABI | 12 syscall lock ratified; canonical version drift giderildi | Accepted main strict `ci-freeze` run `26421295459` PASS; ABI genisleme yok |
+| Marker guard | Step 5 ve stacked runtime paketi PR #144 ile merge; closure-candidate exact-SHA refresh accepted `main` SHA `7a42d312` uzerinde yapildi | Lifecycle, determinism/negative, public S1.E2E, stub-off fixture completion ve IRQ timeout-race exact-SHA remote PASS |
+| ABI | 12 syscall lock ratified; canonical version drift giderildi | Accepted main strict `ci-freeze` run `26697843452` PASS; ABI genisleme yok |
 | Governance | Spec-purity, fail-closed marker isolation, validation matrix ve S2 inventory kabul edildi | #145 tek-maintainer authority paritesiyle giderildi; closure yine ayrik reviewed karardir |
 | Review enforcement | `@kenanay` CODEOWNERS accountability metadata'si ve canli `main` required `freeze` protection'i tek-maintainer ADR'iyle hizalandi | Issue #145 RESOLVED; bagimsiz self-review iddiasi veya closure yetkisi kurulmaz |
-| Performance stability | PR-4 local readiness FAIL tarihsel kayit; PR-4A/PR-4B diagnostic; governed renewal ve workflow authority repair accepted | Accepted `main` SHA `e0286c7b`: Performance Gate `26421295487` ve scoped Phase-17 acceptance `26421686338` PASS; closure sayilmaz |
+| Performance stability | PR-4 local readiness FAIL tarihsel kayit; PR-4A/PR-4B diagnostic; governed renewal ve workflow authority repair accepted | Accepted `main` SHA `7a42d312`: Performance Gate `26697843425` ve scoped Phase-17 acceptance `26711867203` PASS; closure sayilmaz |
 | Phase-18 | Roadmap only | Baslatilmaz |
 
 ## 4. Stratejik Karar: Stabilization-First
@@ -149,7 +149,7 @@ otoritesindeki drift'i kapatmak.
 | Integrity/isolation evidence plumbing | Uygulandi | Standalone Make hedefleri kendi report/summary'si ile fail-closed |
 | Normative spec-purity gate | Uygulandi | Strict/local freeze zincirinde fail-closed |
 | Roadmap authority sync | Uygulandi (local changeset) | Index/steering/current docs bu belgeye baglanir |
-| Clean-tree PR CI | ACCEPTED / POST-MERGE PASS | Accepted `main` SHA `e0286c7b`, full `ci-freeze` run `26421295459` PASS |
+| Clean-tree PR CI | ACCEPTED / POST-MERGE PASS | Accepted `main` SHA `7a42d312`, full `ci-freeze` run `26697843452` PASS |
 | Live CODEOWNERS/protection parity | RESOLVED (`#145`) | Tek-maintainer ADR, `@kenanay` accountability mapping ve remote `freeze` protection paritesi kuruldu |
 
 **Merge scope:** Bu paket yeni runtime davranisi veya yeni feature ilan etmez;
@@ -157,23 +157,23 @@ var olan ratified yuzeyleri ve guard'lari tutarli hale getirir.
 
 ### S1 - Phase-17 Runtime Acceptance
 
-**Status:** ACCEPTED-MAIN SHA `e0286c7b` REMOTE RUNTIME/LOCKED PERFORMANCE/FULL FREEZE PASS / CLOSURE-CANDIDATE REVIEW PENDING / FORMAL CLOSURE PENDING
+**Status:** ACCEPTED-MAIN SHA `7a42d312` REMOTE RUNTIME/LOCKED PERFORMANCE/FULL FREEZE PASS / CLOSURE-CANDIDATE REVIEW PENDING / FORMAL CLOSURE PENDING
 **Purpose:** Marker validation'in gercek kernel execution-slot yasam
 dongusunde calistigini kanitlamak.
 
 | Sira | Is paketi | Durum | Required evidence | Degismeyecek sinir |
 |---|---|---|---|---|
-| S1.1 | Marker-enabled minimal QEMU boot | REMOTE PASS (`26421686302`, `e0286c7b`) | Debugcon boot log + gate report | Feature flag production default-off |
-| S1.2 | Tek slot kernel golden lifecycle | REMOTE PASS (`26421686302`, `e0286c7b`) | Queue/pickup/write/verify/result-map ordered trace | Public Ring3 syscall E2E kaniti sayilmaz |
-| S1.E2E | Public Ring3 submit/wait acceptance | REMOTE PASS (`26421686322`, `e0286c7b`) | Ring3 `1003` submit -> scheduler pickup -> `1004` frozen-result read QEMU trace | Validation-only stub; gercek BCIB worker completion sayilmaz |
-| S1.WORKER | Ring3 fixture worker completion acceptance | REMOTE PASS (`26421686303`, `e0286c7b`) | Ring3 delivery -> v1 output -> public `1011` -> `1004` frozen-result QEMU trace | Stub disabled; bounded literal fixture, genel interpreter sayilmaz |
-| S1.3 | Deterministic result repeat | REMOTE PASS (`26421686320`, `e0286c7b`) | Ayni validation input icin iki QEMU boot result fingerprint match | Mechanism-only; logical evidence |
-| S1.4 | Invalid sequence fail-closed | REMOTE PASS (`26421686320`, `e0286c7b`) | Negative trace + hash/mapping oncesi red | Resource rollback veya public syscall kaniti sayilmaz |
-| S1.5 | Interrupt/race isolation | REMOTE PASS (`26421686331`, `e0286c7b`) | Delivered `RUNNING` logical-deadline -> real timer IRQ `TIMEOUT` -> delayed public `1011` reject QEMU trace | Validation-only tek interleaving; exhaustive/SMP race sayilmaz |
-| S1.6 | Performance acceptance | REMOTE PASS (`26421686338`, `e0286c7b`) | Existing locked-baseline timer/preemption hot-path report + scoped PR-4 acceptance report + workflow-generated renewal artifact | Validation payload latency, manual baseline edit veya closure sayilmaz |
+| S1.1 | Marker-enabled minimal QEMU boot | REMOTE PASS (`26711867223`, `7a42d312`) | Debugcon boot log + gate report | Feature flag production default-off |
+| S1.2 | Tek slot kernel golden lifecycle | REMOTE PASS (`26711867223`, `7a42d312`) | Queue/pickup/write/verify/result-map ordered trace | Public Ring3 syscall E2E kaniti sayilmaz |
+| S1.E2E | Public Ring3 submit/wait acceptance | REMOTE PASS (`26711867207`, `7a42d312`) | Ring3 `1003` submit -> scheduler pickup -> `1004` frozen-result read QEMU trace | Validation-only stub; gercek BCIB worker completion sayilmaz |
+| S1.WORKER | Ring3 fixture worker completion acceptance | REMOTE PASS (`26711867217`, `7a42d312`) | Ring3 delivery -> v1 output -> public `1011` -> `1004` frozen-result QEMU trace | Stub disabled; bounded literal fixture, genel interpreter sayilmaz |
+| S1.3 | Deterministic result repeat | REMOTE PASS (`26711867206`, `7a42d312`) | Ayni validation input icin iki QEMU boot result fingerprint match | Mechanism-only; logical evidence |
+| S1.4 | Invalid sequence fail-closed | REMOTE PASS (`26711867206`, `7a42d312`) | Negative trace + hash/mapping oncesi red | Resource rollback veya public syscall kaniti sayilmaz |
+| S1.5 | Interrupt/race isolation | REMOTE PASS (`26711867212`, `7a42d312`) | Delivered `RUNNING` logical-deadline -> real timer IRQ `TIMEOUT` -> delayed public `1011` reject QEMU trace | Validation-only tek interleaving; exhaustive/SMP race sayilmaz |
+| S1.6 | Performance acceptance | REMOTE PASS (`26711867203`, `7a42d312`) | Existing locked-baseline timer/preemption hot-path report + scoped PR-4 acceptance report + workflow-generated renewal artifact | Validation payload latency, manual baseline edit veya closure sayilmaz |
 | S1.7 | Variance source isolation | DIAGNOSTIC LOCAL PASS / ROOT CAUSE PENDING | PASS-reference ile FAIL-repeat raporlarindan variance fingerprint ve ortak outlier siniflandirmasi | Diagnostic PASS acceptance, baseline renewal veya closure sayilmaz |
 | S1.8 | Bounded variance reproduction | DIAGNOSTIC LOCAL PASS / OUTLIER NOT REPRODUCED / ROOT CAUSE PENDING | Ayni PR-4 contract ile image-reuse ve rebuild-per-run stage-localization raporu | Non-reproduction acceptance, kok neden veya closure sayilmaz |
-| S1.9 | Freeze integration timer witness | REMOTE PASS (`26421295459`, `e0286c7b`) | Same-run Phase10-A2 `create -> syscall_entry -> timer_irq` low-half runtime proof | Legacy witness tamiri Phase-17 closure veya yeni runtime feature sayilmaz |
+| S1.9 | Freeze integration timer witness | REMOTE PASS (`26697843452`, `7a42d312`) | Same-run Phase10-A2 `create -> syscall_entry -> timer_irq` low-half runtime proof | Legacy witness tamiri Phase-17 closure veya yeni runtime feature sayilmaz |
 
 `ci-gate-execution-marker-lifecycle`, `AYKEN_EXECUTION_MARKER_VALIDATION_ENABLE=1`
 ve `AYKEN_EXECUTION_MARKER_LIFECYCLE_SELFTEST=1` ile yalniz validation
@@ -239,14 +239,14 @@ PR #142/#144 review-merge sirasi, closure manifesti ve resmi tag yerine
 gecmez. Bu dokumantasyon senkronu yeni commit uretecegi icin merge oncesi
 gerekli kontroller yeni head SHA uzerinde yeniden degerlendirilir.
 Accepted-main restack oncesindeki S2-D head `342deab6` tarihsel kanit olarak
-korunmustur. PR #144 ve performance workflow authority repair PR #148
-birlesmesinden sonra accepted `main` subject SHA
-`e0286c7b64c15e27f810e634713a07652def169c` uzerinde full `ci-freeze`
-`26421295459`, standalone Performance Gate `26421295487` ve Phase-17 scoped
-locked acceptance `26421686338` PASS vermistir. Runtime-specific exact-SHA
-QEMU runs `26421686302`, `26421686320`, `26421686322`, `26421686303` ve
-`26421686331` de PASS'tir. Bu bagli evidence resmi closure degil,
-`reports/phase17_official_closure_candidate/` inceleme girdisidir.
+korunmustur. PR #149, PR #151 ve PR #150 sonrasinda accepted `main` subject
+SHA `7a42d312581b7eacf3a9fbb79b11704e4c5914a3` olmustur. Bu subject uzerinde
+full `ci-freeze` `26697843452`, standalone Performance Gate `26697843425` ve
+Phase-17 scoped locked acceptance `26711867203` PASS vermistir.
+Runtime-specific exact-SHA QEMU runs `26711867223`, `26711867206`,
+`26711867207`, `26711867217` ve `26711867212` de PASS'tir. Bu bagli evidence
+resmi closure degil, `reports/phase17_official_closure_candidate/` inceleme
+girdisidir.
 `ci-gate-phase17-performance-variance-diagnostic`, mevcut local evidence'i
 yeniden olcum yapmadan okur. Ilk PASS stability run'i ile repeat FAIL run'ini
 karsilastirir, ortak outlier/fingerprint kaydi uretir ve upstream FAIL
@@ -343,19 +343,20 @@ nondeterministic verification verdict'i uretmez.
 | PR paketi | Durum | Tek amac | Kod/dokuman yuzeyi | Zorunlu kontrol |
 |---|---|---|---|---|
 | PR-0..PR-4D / S2-D (PR #144) | MERGED (`156d721e`) | Phase-17 bounded execution/runtime, governed baseline ve documentation paketi | Kernel validation lanes, workflows, baseline ve current docs | Accepted-main evidence yeniden baglandi; closure ayridir |
-| S1 lifecycle | REMOTE PASS (`26421686302`, `e0286c7b`) | Marker-enabled QEMU golden boot/lifecycle | Existing validation flag + external harness/evidence | Minimal real lifecycle PASS |
-| S1 determinism/negative | REMOTE PASS (`26421686320`, `e0286c7b`) | Deterministic result and negative sequence | Validation-only test/harness + additive evidence markers | Repeat fingerprint + invalid-order FAIL |
-| S1 public E2E | REMOTE PASS (`26421686322`, `e0286c7b`) | Public Ring3 submit/wait result-publication acceptance | Public ABI payload and external evidence | `1003`/`1004` mapped result witness |
-| S1 worker completion | REMOTE PASS (`26421686303`, `e0286c7b`) | Ring3 fixture worker public completion acceptance | Worker payload and external evidence | Stub-off `1003`/`1011`/`1004` literal-result witness |
-| S1 timeout race | REMOTE PASS (`26421686331`, `e0286c7b`) | IRQ timeout-versus-late-completion fail-closed acceptance | Validation-only deadline and external evidence | IRQ `TIMEOUT` wins; delayed `1011` rejected |
-| S1 performance | REMOTE PASS (`26421686338`, `e0286c7b`) | Locked-baseline timer/preemption hot-path performance acceptance | Scoped validator and remote workflow | Same-SHA runtime evidence; closure ayridir |
+| S1 lifecycle | REMOTE PASS (`26711867223`, `7a42d312`) | Marker-enabled QEMU golden boot/lifecycle | Existing validation flag + external harness/evidence | Minimal real lifecycle PASS |
+| S1 determinism/negative | REMOTE PASS (`26711867206`, `7a42d312`) | Deterministic result and negative sequence | Validation-only test/harness + additive evidence markers | Repeat fingerprint + invalid-order FAIL |
+| S1 public E2E | REMOTE PASS (`26711867207`, `7a42d312`) | Public Ring3 submit/wait result-publication acceptance | Public ABI payload and external evidence | `1003`/`1004` mapped result witness |
+| S1 worker completion | REMOTE PASS (`26711867217`, `7a42d312`) | Ring3 fixture worker public completion acceptance | Worker payload and external evidence | Stub-off `1003`/`1011`/`1004` literal-result witness |
+| S1 timeout race | REMOTE PASS (`26711867212`, `7a42d312`) | IRQ timeout-versus-late-completion fail-closed acceptance | Validation-only deadline and external evidence | IRQ `TIMEOUT` wins; delayed `1011` rejected |
+| S1 performance | REMOTE PASS (`26711867203`, `7a42d312`) | Locked-baseline timer/preemption hot-path performance acceptance | Scoped validator and remote workflow | Same-SHA runtime evidence; closure ayridir |
 | PR-4A (local diagnostic implementation) | LOCAL DIAGNOSTIC PASS / ROOT CAUSE PENDING | PR-4 local stability variance fingerprinting ve kaynak ayrimi | Existing evidence analyzer, Make target ve docs; runtime/baseline mutasyonu yok | Ortak sample siniflandirmasi; acceptance verdict'i degismez |
 | PR-4B (local bounded measurement implementation) | LOCAL DIAGNOSTIC PASS / OUTLIER NOT REPRODUCED / ROOT CAUSE PENDING | PR-4A sapmasini controlled image-reuse/rebuild-per-run kosullarinda yeniden uretme ve stage-localize etme | Existing harness collector/analyzer, Make target ve docs; runtime/baseline/threshold mutasyonu yok | Runtime/counter parity; remote acceptance verdict'i degismez |
-| PR-4C/PR-4D | MERGED IN PR #144 / ACCEPTED-MAIN REVALIDATED | Governed renewal ve legacy timer witness entegrasyonu | Baseline/workflow ve scheduler bounded tamiri | Full `ci-freeze` `26421295459` PASS |
-| S2-A/S2-C/S2-D | MERGED IN PR #144 / ACCEPTED-MAIN REVALIDATED | Validation matrix, gate inventory ve CI-mode doc authority | Matrix, operations, roadmap ve current docs | Full `ci-freeze` `26421295459` PASS |
+| PR-4C/PR-4D | MERGED IN PR #144 / ACCEPTED-MAIN REVALIDATED | Governed renewal ve legacy timer witness entegrasyonu | Baseline/workflow ve scheduler bounded tamiri | Full `ci-freeze` `26697843452` PASS |
+| S2-A/S2-C/S2-D | MERGED IN PR #144 / ACCEPTED-MAIN REVALIDATED | Validation matrix, gate inventory ve CI-mode doc authority | Matrix, operations, roadmap ve current docs | Full `ci-freeze` `26697843452` PASS |
 | S2-B (single-maintainer authority parity) | MERGED / ISSUE #145 RESOLVED | CODEOWNERS accountability metadata'sini canli required-CI protection gercegiyle eslemek | ADR, `@kenanay` ownership mapping ve GitHub governance configuration; runtime/baseline mutasyonu yok | Required remote `freeze`, no self-review claim, live protection proof |
 | PR #148 | MERGED (`e0286c7b`) / POST-MERGE PASS | Standalone Performance Gate workflow'unu locked authority modeliyle hizalamak | Workflow only; runtime/threshold degisikligi yok | Performance `26421295487`, freeze `26421295459` PASS |
-| Closure candidate (bu changeset) | REVIEW PENDING / NOT OFFICIAL CLOSURE | Exact-SHA PASS kanitlarini bounded candidate manifestte baglamak | Candidate manifest/index, validator ve status docs | Candidate integrity + new-head PR CI; official tag ayridir |
+| PR #149/#151/#150 | MERGED (`7a42d312`) / EXACT-SHA REFRESHED | Closure-candidate record, governed baseline renewal ve ci-freeze prerequisite dedup | Candidate package, performance authority and CI prerequisite wiring | Refresh subject `7a42d312`; official tag ayridir |
+| Closure candidate refresh (bu changeset) | REVIEW PENDING / NOT OFFICIAL CLOSURE | Exact-SHA PASS kanitlarini current subject manifestte baglamak | Candidate manifest/index ve status docs | Candidate integrity + new-head PR CI; official tag ayridir |
 
 PR koordinasyon kurallari:
 
@@ -365,7 +366,7 @@ PR koordinasyon kurallari:
 - PR #144 icindeki stacked uygulama sirasi tamamlanmis, PR #148 workflow
   authority onarimi da `main`e kabul edilmistir. Bu merge'ler resmi
   Phase-17 closure veya tag yerine gecmez.
-- Closure candidate, accepted subject SHA `e0286c7b` evidence'ini baglar;
+- Closure candidate, accepted subject SHA `7a42d312` evidence'ini baglar;
   official tag farkli bir commit'e hedeflenirse ilgili remote checks ayni
   subject icin yeniden calistirilir.
 - PR-4A, PR-4 local readiness FAIL'i inceleyen diagnostics-only pakettir;
@@ -968,6 +969,26 @@ yeterli kanittir; official closure degildir. `phase17-official-closure`
 yalniz reviewed karar kaydi ve uygun tag-subject dogrulamasi sonrasinda
 uretilebilir. Phase-18 aktif degildir.
 
+### 2026-05-31 - Current Main Exact-SHA Refresh
+
+**Completed evidence refresh actions:**
+
+- PR #149, PR #151 ve PR #150 sonrasinda current `main` subject
+  `7a42d312581b7eacf3a9fbb79b11704e4c5914a3` oldu.
+- Ayni subject SHA icin full strict `ci-freeze` `26697843452` ve standalone
+  Performance Gate `26697843425` PASS verdi.
+- Ayni subject SHA icin Phase-17 lifecycle `26711867223`,
+  determinism/negative `26711867206`, public E2E `26711867207`, bounded
+  worker completion `26711867217`, timeout-race `26711867212` ve scoped
+  locked performance acceptance `26711867203` PASS verdi.
+- `reports/phase17_official_closure_candidate/` bu current subject evidence
+  setine yenilendi.
+
+**Authority boundary:** Bu refresh official closure degildir. Resmi closure
+decision record ve `phase17-official-closure` tag'i, subject degismedigi
+dogrulanarak ayrica reviewed karar sonrasinda uretilir; subject degisirse
+exact-SHA remote controls yeniden calistirilir.
+
 ## 10. Review Triggers
 
 Bu roadmap su olaylarda guncellenir:
@@ -986,8 +1007,8 @@ Bu roadmap su olaylarda guncellenir:
 12. Issue #145 tek-maintainer authority gideriminin ve canli protection paritesinin korunmasi.
 13. S2-C inventory icindeki duplicate/cost olcumleri veya konsolidasyon karari.
 14. S2-D CI-mode authority dokuman senkronu sonrasi new-head PR CI sonucu.
-15. PR #142/#144/#148 merge ve accepted-main exact-SHA evidence sonucu.
-16. Phase-17 closure candidate review/merge sonucu ve official tag-subject karari.
+15. PR #142/#144/#148/#149/#151/#150 merge ve accepted-main exact-SHA evidence sonucu.
+16. Phase-17 closure candidate exact-SHA refresh review/merge sonucu ve official tag-subject karari.
 17. Yeni feature/ABI/authority surface onerisinin incelenmesi.
 
 ## References

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -2,7 +2,7 @@
 This document is subordinate to `ARCHITECTURE_FREEZE.md`. In case of conflict,
 the freeze contract prevails.
 
-**Last authority sync:** 2026-05-24 (PR-4B bounded local variance isolation update)
+**Last authority sync:** 2026-05-31 (Phase-17 closure-candidate exact-SHA evidence refresh)
 **Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu:** Kenan AY
 **Attribution boundary:** Documentation metadata only; not runtime or merge authority.
 
@@ -26,31 +26,20 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 |---|---|
 | Son resmi kapanis | Phase-16 OFFICIALLY CLOSED (`phase16-official-closure`) |
 | Aktif faz | Phase-17 ACTIVE / FORMAL CLOSURE PENDING |
-| Aktif odak | Stabilization-first: PR-1 lifecycle, PR-2 determinism/negative, PR-2A public S1.E2E, PR-2B stub-off bounded fixture completion ve PR-3 IRQ timeout-race kernel/QEMU local PASS; PR-4 readiness FAIL; PR-4A ortak `sample-6` diagnostic local PASS; PR-4B bounded kampanyada sapma yeniden uretilmedi / kok neden ve remote locked authority pending |
+| Aktif odak | Stabilization-first Phase-17 acceptance evidence accepted on `main`; closure-candidate exact-SHA evidence refreshed on `7a42d312`; official closure decision/tag still pending |
 | ABI | Canonical `1000-1011` / 12 syscall, ABI version `0x00010001` |
 | Phase-18 | ROADMAP ONLY; Phase-17 closure olmadan aktivasyon yok |
 
 ## Active Execution Rule
 
-Phase-17 resmi kapanis kaniti uretilene kadar production roadmap'e yeni
-syscall, yeni platform feature'i, authority-genisleten observability veya AI
-orchestration isi alinmaz. Marker-enabled gercek kernel/QEMU lifecycle ile
-determinism/invalid-order local kaniti 2026-05-23 tarihinde, public Ring3
-submit/wait S1.E2E validation-only kaniti 2026-05-24 tarihinde PASS uretti;
-stub kapali bounded fixture worker public completion kaniti da 2026-05-24
-tarihinde PASS uretti. Validation-only bounded deadline ile gercek timer IRQ
-timeout'u kazanirken gecikmis public `1011` reddi de PR-3 olarak 2026-05-24
-tarihinde local PASS uretti. Mevcut timer/preemption hot-path uzerindeki
-PR-4 local median alt-kapisi PASS uretti, ancak local readiness validator'u
-repeat stability range guard ihlallerini fail-closed `FAIL` olarak kaydetti.
-PR-4A diagnostics-only hedefi bu FAIL raporunu referans PASS raporuyla
-karsilastirip uc proxy'de ortak `sample-6` outlier'i siniflandirdi; PASS
-sonucu yalniz analiz butunlugudur ve feature payload latency'sini veya
-closure'i kanitlamaz. PR-4B, ayni runtime kontratiyla image-reuse ve
-rebuild-per-run bounded kosularinda bu sapmayi yeniden uretmedi; bu da
-onceki readiness FAIL'i veya kok neden belirsizligini kaldirmaz. Clean-tree
-remote runtime kabulü ve locked-baseline performance authority bekler; genel
-BCIB semantic ya da broader race/SMP kapsamı gerekirse ayrik paketlenir.
+Phase-17 resmi kapanis karari ve tag'i uretilene kadar production roadmap'e
+yeni syscall, yeni platform feature'i, authority-genisleten observability veya
+AI orchestration isi alinmaz. Bounded runtime/QEMU lanes, strict `ci-freeze`,
+standalone locked Performance Gate ve scoped Phase-17 performance acceptance
+accepted `main` SHA `7a42d312` uzerinde PASS vermistir. Bu evidence seti
+`reports/phase17_official_closure_candidate/` altinda review girdisidir;
+official closure, Phase-18 activation veya genis BCIB semantic/race/SMP
+kapsami kurmaz.
 
 ## Historical References
 
@@ -65,11 +54,8 @@ current execution priority otoritesi degildir:
 
 ---
 
-**Next action:** `CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`
-altindaki PR-0, locally stacked PR-1, PR-2, PR-2A, PR-2B, PR-3 ve PR-4
-readiness wiring'ini clean-tree PR CI ile kabul ettirmeden once PR-4A'nin
-ortak `sample-6` varyansi icin PR-4B bounded non-reproduction kaydini
-korumak; simdi remote locked performance acceptance sonucunu almak ve sapma
-remote ortamda yinelenirse ayni stage-localization ayrimini orada
-calistirmak. Feature-specific latency, genel BCIB semantic ya da broader
-race/SMP kapsami gerekiyorsa ayrik sinirli paketlerle ilerletilir.
+**Next action:** `reports/phase17_official_closure_candidate/` exact-SHA
+refresh paketini review etmek; resmi closure decision record ve
+`phase17-official-closure` tag'i yalniz reviewed karar sonrasinda, ayni subject
+SHA korunursa ilerletilir. Subject SHA degisirse required remote controls
+yeniden ayni exact-SHA uzerinde calistirilir.

--- a/reports/phase17_official_closure_candidate/README.md
+++ b/reports/phase17_official_closure_candidate/README.md
@@ -1,30 +1,37 @@
 # Phase-17 Official Closure Candidate
 
 **State:** `REMOTE_EVIDENCE_READY_REVIEW_PENDING`
-**Generated at UTC:** `2026-05-25T22:12:18Z`
+**Generated at UTC:** `2026-05-31T11:56:26Z`
 **Evidence subject:** accepted `main` SHA
-`e0286c7b64c15e27f810e634713a07652def169c`
+`7a42d312581b7eacf3a9fbb79b11704e4c5914a3`
 **Recommended tag after reviewed closure decision:** `phase17-official-closure`
 
 This directory is a closure-candidate record. It binds bounded Phase-17
 claims to remote PASS evidence produced on one accepted `main` SHA. It does
 not mark Phase-17 closed, grant merge authority, or activate Phase-18.
 
+The initial candidate subject was
+`e0286c7b64c15e27f810e634713a07652def169c`. After later accepted `main`
+changes, the intended review subject advanced to
+`7a42d312581b7eacf3a9fbb79b11704e4c5914a3`; the required exact-SHA remote
+controls were rerun or confirmed on that refreshed subject before review.
+This refresh is still evidence binding only, not official closure.
+
 ## Bound Evidence
 
 | Workflow | Run | Result | Scope |
 |---|---:|---|---|
-| `ci-freeze` | `26421295459` | PASS | Full strict constitutional chain on accepted `main` |
-| `Performance Gate` | `26421295487` | PASS | Mainline locked performance workflow authority |
-| `ci-gate-execution-marker-lifecycle` | `26421686302` | PASS | Validation-only QEMU lifecycle |
-| `ci-gate-execution-marker-determinism` | `26421686320` | PASS | Repeat fingerprint and invalid-order rejection |
-| `ci-gate-execution-public-e2e` | `26421686322` | PASS | Bounded public `1003 -> 1004` path |
-| `ci-gate-execution-worker-completion` | `26421686303` | PASS | Bounded stub-off `1003 -> 1011 -> 1004` fixture path |
-| `ci-gate-execution-timeout-race` | `26421686331` | PASS | One timer IRQ timeout-wins interleaving |
-| `ci-gate-phase17-performance-acceptance` | `26421686338` | PASS | Scoped locked timer/preemption acceptance |
+| `ci-freeze` | `26697843452` | PASS | Full strict constitutional chain on accepted `main` |
+| `Performance Gate` | `26697843425` | PASS | Mainline locked performance workflow authority |
+| `ci-gate-execution-marker-lifecycle` | `26711867223` | PASS | Validation-only QEMU lifecycle |
+| `ci-gate-execution-marker-determinism` | `26711867206` | PASS | Repeat fingerprint and invalid-order rejection |
+| `ci-gate-execution-public-e2e` | `26711867207` | PASS | Bounded public `1003 -> 1004` path |
+| `ci-gate-execution-worker-completion` | `26711867217` | PASS | Bounded stub-off `1003 -> 1011 -> 1004` fixture path |
+| `ci-gate-execution-timeout-race` | `26711867212` | PASS | One timer IRQ timeout-wins interleaving |
+| `ci-gate-phase17-performance-acceptance` | `26711867203` | PASS | Scoped locked timer/preemption acceptance |
 
 Every run above reports head SHA
-`e0286c7b64c15e27f810e634713a07652def169c`. Details and artifact names
+`7a42d312581b7eacf3a9fbb79b11704e4c5914a3`. Details and artifact names
 are recorded in `evidence_index.json`.
 
 ## Established Boundary
@@ -47,7 +54,8 @@ are recorded in `evidence_index.json`.
 ## Remaining Authority Steps
 
 1. Review and merge this candidate record without widening its claims.
-2. If the intended official tag subject differs from the evidence subject,
+2. If the intended official tag subject differs from
+   `7a42d312581b7eacf3a9fbb79b11704e4c5914a3`,
    rerun the required exact-SHA remote controls and update the decision
    record.
 3. Create the reviewed official closure decision record.

--- a/reports/phase17_official_closure_candidate/closure_manifest.json
+++ b/reports/phase17_official_closure_candidate/closure_manifest.json
@@ -3,20 +3,30 @@
   "phase": 17,
   "closure_class": "official_closure_candidate",
   "closure_state": "REMOTE_EVIDENCE_READY_REVIEW_PENDING",
-  "generated_at_utc": "2026-05-25T22:12:18Z",
+  "generated_at_utc": "2026-05-31T11:56:26Z",
   "current_phase_pointer": "17",
   "recommended_tag": "phase17-official-closure",
   "authority_boundary": "Candidate record only; not official closure, merge authority, or runtime control input.",
   "candidate_subject": {
     "branch": "main",
-    "commit_sha": "e0286c7b64c15e27f810e634713a07652def169c",
+    "commit_sha": "7a42d312581b7eacf3a9fbb79b11704e4c5914a3",
     "accepted_history": [
       "PR #144 merge commit 156d721e02e89041b93bfb8738b0e30ec72b3454",
-      "PR #148 performance authority workflow repair accepted at e0286c7b64c15e27f810e634713a07652def169c"
+      "PR #148 performance authority workflow repair accepted at e0286c7b64c15e27f810e634713a07652def169c",
+      "PR #149 closure-candidate evidence record accepted at ee1aa4afe55eeec4a4b662802a26f1ef26e79463",
+      "PR #151 locked performance baseline renewal accepted at 8cc772a4474407262a81c5b3678926d51f9099f9",
+      "PR #150 ci-freeze prerequisite dedup accepted at 7a42d312581b7eacf3a9fbb79b11704e4c5914a3"
     ]
   },
+  "exact_sha_refresh": {
+    "previous_candidate_subject_sha": "e0286c7b64c15e27f810e634713a07652def169c",
+    "refreshed_candidate_subject_sha": "7a42d312581b7eacf3a9fbb79b11704e4c5914a3",
+    "reason": "Accepted main advanced after the initial closure-candidate package; all required remote controls were rerun or confirmed on the refreshed subject before closure review.",
+    "remote_evidence_state": "ALL_REQUIRED_REMOTE_RUNS_PASS",
+    "authority_boundary": "Exact-SHA evidence refresh only; not official closure, tag authority, phase transition, or runtime control input."
+  },
   "evidence_index_path": "reports/phase17_official_closure_candidate/evidence_index.json",
-  "evidence_index_sha256": "2979c01d6bff38357e17d5cc1abc8ae617bbdecc256d26f53b78283be72c2a59",
+  "evidence_index_sha256": "2d80384d99552ed1b0be5bc400d624d16b4eff97f186d34996501a93469d62f8",
   "required_remote_evidence": {
     "all_required_runs_passed": true,
     "required_workflows": [

--- a/reports/phase17_official_closure_candidate/closure_manifest.sha256
+++ b/reports/phase17_official_closure_candidate/closure_manifest.sha256
@@ -1,1 +1,1 @@
-48337049019d63fc7e7dba9b5672dcab15dcfbef25a59ddca8aefb2f9d3d651c  closure_manifest.json
+01005c216fbcb3360d9490ab996f11b806d981f0954fea796da3a2ed1c1df4ac  closure_manifest.json

--- a/reports/phase17_official_closure_candidate/evidence_index.json
+++ b/reports/phase17_official_closure_candidate/evidence_index.json
@@ -1,101 +1,101 @@
 {
   "schema": "ayken-phase17-remote-evidence-index/1.0",
   "phase": 17,
-  "generated_at_utc": "2026-05-25T22:12:18Z",
+  "generated_at_utc": "2026-05-31T11:56:26Z",
   "evidence_subject": {
     "branch": "main",
-    "head_sha": "e0286c7b64c15e27f810e634713a07652def169c"
+    "head_sha": "7a42d312581b7eacf3a9fbb79b11704e4c5914a3"
   },
   "authority_status": "REMOTE_EVIDENCE_READY_REVIEW_PENDING",
   "all_required_remote_runs_passed": true,
   "runs": [
     {
       "workflow": "ci-freeze",
-      "run_id": "26421295459",
+      "run_id": "26697843452",
       "event": "push",
-      "head_sha": "e0286c7b64c15e27f810e634713a07652def169c",
+      "head_sha": "7a42d312581b7eacf3a9fbb79b11704e4c5914a3",
       "result": "PASS",
-      "completed_at_utc": "2026-05-25T22:02:20Z",
+      "completed_at_utc": "2026-05-30T23:39:56Z",
       "artifacts": [
-        "performance-evidence-26421295459-1",
-        "spec-validation-evidence-26421295459"
+        "performance-evidence-26697843452-1",
+        "spec-validation-evidence-26697843452"
       ]
     },
     {
       "workflow": "Performance Gate",
-      "run_id": "26421295487",
+      "run_id": "26697843425",
       "event": "push",
-      "head_sha": "e0286c7b64c15e27f810e634713a07652def169c",
+      "head_sha": "7a42d312581b7eacf3a9fbb79b11704e4c5914a3",
       "result": "PASS",
-      "completed_at_utc": "2026-05-25T21:56:03Z",
+      "completed_at_utc": "2026-05-30T23:33:11Z",
       "artifacts": [
-        "performance-gate-26421295487"
+        "performance-gate-26697843425"
       ]
     },
     {
       "workflow": "ci-gate-execution-marker-lifecycle",
-      "run_id": "26421686302",
+      "run_id": "26711867223",
       "event": "workflow_dispatch",
-      "head_sha": "e0286c7b64c15e27f810e634713a07652def169c",
+      "head_sha": "7a42d312581b7eacf3a9fbb79b11704e4c5914a3",
       "result": "PASS",
-      "completed_at_utc": "2026-05-25T22:09:17Z",
+      "completed_at_utc": "2026-05-31T11:54:11Z",
       "artifacts": [
-        "ci-gate-execution-marker-lifecycle-26421686302"
+        "ci-gate-execution-marker-lifecycle-26711867223"
       ]
     },
     {
       "workflow": "ci-gate-execution-marker-determinism",
-      "run_id": "26421686320",
+      "run_id": "26711867206",
       "event": "workflow_dispatch",
-      "head_sha": "e0286c7b64c15e27f810e634713a07652def169c",
+      "head_sha": "7a42d312581b7eacf3a9fbb79b11704e4c5914a3",
       "result": "PASS",
-      "completed_at_utc": "2026-05-25T22:09:40Z",
+      "completed_at_utc": "2026-05-31T11:54:35Z",
       "artifacts": [
-        "ci-gate-execution-marker-determinism-26421686320"
+        "ci-gate-execution-marker-determinism-26711867206"
       ]
     },
     {
       "workflow": "ci-gate-execution-public-e2e",
-      "run_id": "26421686322",
+      "run_id": "26711867207",
       "event": "workflow_dispatch",
-      "head_sha": "e0286c7b64c15e27f810e634713a07652def169c",
+      "head_sha": "7a42d312581b7eacf3a9fbb79b11704e4c5914a3",
       "result": "PASS",
-      "completed_at_utc": "2026-05-25T22:09:26Z",
+      "completed_at_utc": "2026-05-31T11:54:35Z",
       "artifacts": [
-        "ci-gate-execution-public-e2e-26421686322"
+        "ci-gate-execution-public-e2e-26711867207"
       ]
     },
     {
       "workflow": "ci-gate-execution-worker-completion",
-      "run_id": "26421686303",
+      "run_id": "26711867217",
       "event": "workflow_dispatch",
-      "head_sha": "e0286c7b64c15e27f810e634713a07652def169c",
+      "head_sha": "7a42d312581b7eacf3a9fbb79b11704e4c5914a3",
       "result": "PASS",
-      "completed_at_utc": "2026-05-25T22:09:16Z",
+      "completed_at_utc": "2026-05-31T11:54:22Z",
       "artifacts": [
-        "ci-gate-execution-worker-completion-26421686303"
+        "ci-gate-execution-worker-completion-26711867217"
       ]
     },
     {
       "workflow": "ci-gate-execution-timeout-race",
-      "run_id": "26421686331",
+      "run_id": "26711867212",
       "event": "workflow_dispatch",
-      "head_sha": "e0286c7b64c15e27f810e634713a07652def169c",
+      "head_sha": "7a42d312581b7eacf3a9fbb79b11704e4c5914a3",
       "result": "PASS",
-      "completed_at_utc": "2026-05-25T22:09:24Z",
+      "completed_at_utc": "2026-05-31T11:54:10Z",
       "artifacts": [
-        "ci-gate-execution-timeout-race-26421686331"
+        "ci-gate-execution-timeout-race-26711867212"
       ]
     },
     {
       "workflow": "ci-gate-phase17-performance-acceptance",
-      "run_id": "26421686338",
+      "run_id": "26711867203",
       "event": "workflow_dispatch",
-      "head_sha": "e0286c7b64c15e27f810e634713a07652def169c",
+      "head_sha": "7a42d312581b7eacf3a9fbb79b11704e4c5914a3",
       "result": "PASS",
-      "completed_at_utc": "2026-05-25T22:09:37Z",
+      "completed_at_utc": "2026-05-31T11:54:27Z",
       "artifacts": [
-        "ci-gate-phase17-performance-acceptance-26421686338"
+        "ci-gate-phase17-performance-acceptance-26711867203"
       ]
     }
   ]

--- a/reports/phase17_official_closure_candidate/evidence_index.sha256
+++ b/reports/phase17_official_closure_candidate/evidence_index.sha256
@@ -1,1 +1,1 @@
-2979c01d6bff38357e17d5cc1abc8ae617bbdecc256d26f53b78283be72c2a59  evidence_index.json
+2d80384d99552ed1b0be5bc400d624d16b4eff97f186d34996501a93469d62f8  evidence_index.json


### PR DESCRIPTION
Summary:
- refresh Phase-17 closure-candidate evidence from e0286c7b to current main 7a42d312581b7eacf3a9fbb79b11704e4c5914a3
- bind ci-freeze 26697843452, Performance Gate 26697843425, and Phase-17 QEMU/acceptance runs 26711867223/26711867206/26711867207/26711867217/26711867212/26711867203
- update manifest digests and current roadmap/status docs without claiming official closure

Validation:
- jq -e reports/phase17_official_closure_candidate/evidence_index.json
- jq -e reports/phase17_official_closure_candidate/closure_manifest.json
- sha256sum -c evidence_index.sha256
- sha256sum -c closure_manifest.sha256
- git diff --check

Authority boundary:
- candidate evidence refresh only
- no phase17-official-closure tag minted
- no Phase-18 activation
- if the intended official tag subject changes again, exact-SHA remote controls must be rerun