### PR TITLE
[codex] docs: define phase18 platform constitution transition

### DIFF
--- a/AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md
+++ b/AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md
@@ -2,21 +2,27 @@
 
 **Durum tarihi:** 2026-05-23
 **Uygulama ek kaydi:** 2026-05-24/26 (Phase-17 S1.E2E, PR-2B fixture worker completion, PR-3 IRQ timeout-race, PR-4 local performance readiness, PR-4A/PR-4B variance isolation, full-freeze timer witness integration repair, validation flag matrix, issue #145 tek-maintainer authority giderimi, PR #142/#144 merge, PR #148 performance authority onarimi, accepted-main exact-SHA remote evidence PASS ve Phase-17 closure-candidate kaydi)
+**Authority sync:** 2026-05-31 (`phase17-official-closure` verified at `416a5392`; Phase-18 transition not activated)
 **Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu:** Kenan AY
 **Dijital imza siniri:** Bu atif yalnizca insan-okunur dokumantasyon ve metadata icindir; runtime log, karar veya yetki kaynagi degildir.
+
+> Authority note: This report preserves the 2026-05-23 stabilization narrative.
+> Current phase authority is `docs/roadmap/CURRENT_PHASE`, the Phase-17
+> official closure package, and `PHASE18_TRANSITION_DECISION.md` as a
+> docs-only Platform Constitution transition package.
 
 ## Yetkili Durum
 
 | Konu | Repo gercegi | Sonuc |
 |---|---|---|
-| Son resmi kapanis | `phase16-official-closure` etiketi mevcut | Phase-16 OFFICIALLY CLOSED |
-| Aktif faz | `CURRENT_PHASE=17` | Phase-17 ACTIVE / CLOSURE PENDING |
+| Son resmi kapanis | `phase17-official-closure` etiketi `416a5392` uzerinde dogrulandi | Phase-17 OFFICIALLY CLOSED |
+| Aktif faz | `CURRENT_PHASE=17` | Phase-17 OFFICIALLY CLOSED / Phase-18 transition not activated |
 | Step 5 | PR #134, merge `71d10691` | Marker-validation dilimi mainline'a birlesti |
-| Phase-17 kapanisi | `phase17-official-closure` etiketi yok; `reports/phase17_official_closure_candidate/` bu changeset'te aday kayittir | Aday manifest resmi closure iddiasi kurmaz |
-| Phase-17.5 | PR #142 (`0682526d`) ve PR #144 (`156d721e`) `main`e kabul edildi; PR #148 workflow authority onarimi SHA `e0286c7b` ile kabul edildi | Kabul edilen subject SHA icin closure-candidate evidence baglanabilir; resmi tag ayri karardir |
-| Phase-18 | Yol haritasi dokumani | Aktif faz degildir |
-| Aktif execution roadmap | `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` | Accepted `main` SHA `e0286c7b`: full `ci-freeze` `26421295459` ve Phase-17 exact-SHA evidence kontrolleri PASS; closure candidate review/tag bekler |
-| Canonical performance baseline | `scripts/ci/perf-baseline.lock.json` | Accepted `main` SHA `e0286c7b` uzerinde standalone Performance Gate `26421295487` ve scoped Phase-17 acceptance `26421686338` PASS; bu sonuc resmi closure degildir |
+| Phase-17 kapanisi | `reports/phase17_official_closure_candidate/` official closure package ve verified tag mevcut | Closure authority exact-SHA subject ile sinirlidir; Phase-18'i aktive etmez |
+| Phase-17.5 | PR #142, PR #144, PR #148, PR #149/#151/#150, PR #152 ve closure decision package `main`e kabul edildi | Accepted subject SHA `416a5392` icin bounded evidence resmi closure'a baglandi |
+| Phase-18 | `PHASE18_TRANSITION_DECISION.md` | Platform Constitution transition package; aktif faz degildir |
+| Aktif execution roadmap | `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + `PHASE18_TRANSITION_DECISION.md` review | Explicit `CURRENT_PHASE` transition olmadan Phase-18 baslatilmaz |
+| Canonical performance baseline | `scripts/ci/perf-baseline.lock.json` | Accepted `main` SHA `416a5392`: standalone Performance Gate `26715068398` ve scoped Phase-17 acceptance `26712374737` PASS; closure tag dogrulandi |
 | Review enforcement | Issue #145 tek-maintainer ADR'i, `@kenanay` CODEOWNERS accountability metadata'si ve canli `main` `freeze` protection paritesi ile kapatildi | Bagimsiz self-review iddiasi yoktur; remote CI ve kayitli maintainer karari merge siniridir |
 
 ## Bu Degisiklikte Uygulanan Eksikler

--- a/PHASE18_ROADMAP.md
+++ b/PHASE18_ROADMAP.md
@@ -1,23 +1,36 @@
-# Phase-18: Full Kernel Runtime Validation — Roadmap
+# Phase-18: Historical Full Kernel Runtime Validation Roadmap
 
-**Status**: ROADMAP ONLY (not an active phase)
+**Status**: HISTORICAL / SUPERSEDED BY `PHASE18_TRANSITION_DECISION.md`
 **Created**: 2026-05-02  
-**Last Authority Sync**: 2026-05-23
+**Last Authority Sync**: 2026-05-31
 **Düzenleyen / Geliştiren / Oluşturan / Mimari Sorumlu**: Kenan AY *(informational metadata only)*
 
 ---
 
-## Authority Boundary (2026-05-23)
+## Authority Sync Notice (2026-05-31)
+
+This file is a pre-closure Phase-18 planning snapshot. It is retained for
+historical context and deferred validation backlog only.
+
+Current Phase-18 direction is defined by `PHASE18_TRANSITION_DECISION.md`:
+Phase-18 is the Platform Constitution phase, not a kernel expansion phase and
+not a new syscall phase.
+
+The runtime/QEMU/SMP/race items below may remain useful validation backlog, but
+they are not the active Phase-18 objective unless a separate reviewed phase
+decision reactivates them.
+
+## Historical Authority Boundary
 
 Parent execution plan: `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`.
-This file is a subordinate candidate-phase plan, not the active execution queue.
+This file is a subordinate historical planning snapshot, not the active
+execution queue.
 
-PR #134 merged the Phase-17 Step 5 marker-validation slice. It did not produce
-a formal Phase-17 closure tag or manifest. Phase-18 therefore remains planning
-material until Phase-17 runtime/QEMU acceptance and official closure evidence
-are established. Existing deterministic state trace, fail-closed proof, and
-invariant checks in `execution_slot` reduce prerequisite work but do not replace
-that acceptance.
+Phase-17 is now officially closed by `phase17-official-closure` at
+`416a5392afbe217e16d26a59e2e1716fdfa9c8f6`. That closure does not make this
+older runtime-validation roadmap the active Phase-18 authority. The active
+transition decision must preserve the frozen kernel ABI and define platform
+contracts above the execution substrate.
 
 ---
 
@@ -328,7 +341,7 @@ ASSERT_STATE_INVARIANT(slot, condition);
 
 **Signed**: Kenan AY — Architectural Steward  
 **Date**: 2026-05-02  
-**Status**: ROADMAP ONLY (Phase-17 formal closure is still required)
+**Status**: HISTORICAL / SUPERSEDED (Phase-17 formal closure is complete)
 
 ---
 
@@ -611,29 +624,32 @@ make qemu-test-phase18
 **Architectural Steward**: Kenan AY  
 **Implementation / Architecture Owner**: Kenan AY
 **Phase-17 Step 5 PR**: #134 (merged as `71d10691`)
-**Phase-18 Branch**: (not active; create only after Phase-17 closure)
+**Phase-18 Branch**: (not active; create only after explicit transition)
 
 ---
 
 ## 🎯 FINAL NOTES
 
 ### This is a Roadmap
-- **Status**: Planning only; Phase-18 is not active
-- **Authority**: Architectural planning; not closure or execution authority
-- **Purpose**: Prepare for Phase-18 without overlapping the active Phase-17 closure work
+- **Status**: Historical planning; superseded as active direction
+- **Authority**: Deferred validation context; not closure or execution authority
+- **Purpose**: Preserve older runtime-validation scope as backlog without
+  overriding the Platform Constitution transition decision
 
 ### When to Start Phase-18
-**Trigger**: Phase-17 official closure evidence and acceptance are established
+**Trigger**: Explicit `CURRENT_PHASE` transition after
+`PHASE18_TRANSITION_DECISION.md` review
 
 **NOT before**:
-- ❌ CI passes (not sufficient)
-- ❌ Review complete (not sufficient)
-- ❌ "Looks good" (not sufficient)
+- CI passes (not sufficient)
+- Review complete (not sufficient)
+- Historical roadmap exists (not sufficient)
 
 **ONLY after**:
-- ✅ Steward sign-off obtained
-- ✅ PR merged to main
-- ✅ Phase-17 officially closed
+- Phase-17 official closure remains verified.
+- The Platform Constitution transition is accepted.
+- `CURRENT_PHASE` is explicitly updated.
+- Kernel ABI expansion remains forbidden or is handled by a separate phase RFC.
 
 ### Why This Matters
 **Discipline**: Phases don't overlap  
@@ -644,7 +660,9 @@ make qemu-test-phase18
 
 **Prepared by**: Kenan AY — Architectural Steward  
 **Date**: 2026-05-02  
-**Status**: ROADMAP ONLY (awaiting Phase-17 formal closure)
-**Authority**: Architectural design + Phase-17 lessons learned
+**Status**: HISTORICAL / SUPERSEDED BY `PHASE18_TRANSITION_DECISION.md`
+**Authority**: Historical design + deferred validation backlog
 
-**Next Action**: Finish Phase-17 runtime/QEMU acceptance and formal closure review.
+**Next Action**: Use `PHASE18_TRANSITION_DECISION.md` as the Phase-18
+transition authority candidate; do not activate Phase-18 from this historical
+roadmap.

--- a/PHASE18_TRANSITION_DECISION.md
+++ b/PHASE18_TRANSITION_DECISION.md
@@ -1,0 +1,181 @@
+# Phase-18 Transition Decision - Platform Constitution
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH and
+`ARCHITECTURE_FREEZE.md`. In case of conflict, the foundational oath and the
+freeze contract prevail.
+
+**Status:** TRANSITION DECISION PACKAGE / PHASE-18 NOT ACTIVATED
+**Decision date:** 2026-05-31
+**Authority basis:** `phase17-official-closure` at
+`416a5392afbe217e16d26a59e2e1716fdfa9c8f6`
+**Attribution:** Kenan AY - informational documentation metadata only; not
+runtime, merge, or execution authority.
+
+## Decision
+
+Phase-18 does not expand the AykenOS kernel. Phase-18 defines the fail-closed
+platform constitution for modules, packages, capabilities, workspaces, trust
+classification, and plugin boundaries on top of the frozen execution substrate.
+
+Phase-18 is therefore the **Platform Constitution** phase, not a continuation
+of kernel runtime bring-up and not a new syscall phase.
+
+This package records the intended Phase-18 direction. It does not by itself
+change `docs/roadmap/CURRENT_PHASE` to `18`. Activation requires an explicit
+transition update that points `CURRENT_PHASE` and the active roadmap surfaces to
+this decision.
+
+## Closure Preconditions Already Satisfied
+
+Phase-17 is officially closed and no longer blocks a Phase-18 transition
+decision:
+
+| Evidence | Status |
+|---|---|
+| Official closure tag | `phase17-official-closure` |
+| Tag subject | `416a5392afbe217e16d26a59e2e1716fdfa9c8f6` |
+| Closure record | `reports/phase17_official_closure_candidate/closure_decision_record.json` |
+| Closure manifest | `reports/phase17_official_closure_candidate/closure_manifest.json` |
+| Bounded Phase-17 runtime/QEMU evidence | PASS on the exact closure subject |
+| Strict freeze and performance evidence | PASS on the exact closure subject |
+
+The Phase-17 closure proves the reviewed execution substrate evidence for the
+closure subject. It does not grant Phase-18 activation, kernel ABI expansion,
+or future runtime authority.
+
+## Mandatory Decisions
+
+| Decision | Verdict |
+|---|---|
+| `PHASE18_KERNEL_EXPANSION` | `FORBIDDEN` |
+| `PHASE18_NEW_SYSCALLS` | `FORBIDDEN` |
+| `PHASE18_RING0_POLICY` | `FORBIDDEN` |
+| `PHASE18_AI_AUTHORITY` | `FORBIDDEN` |
+| `PHASE18_PLATFORM_CONSTITUTION` | `REQUIRED` |
+
+Any kernel ABI or syscall expansion requires a separate phase decision, RFC,
+evidence plan, reviewed authority boundary, and closure process. Phase-18 must
+not be used as an implicit exception path for kernel growth.
+
+## Kernel ABI Versus Platform ABI
+
+Phase-18 is built on a strict separation:
+
+| Layer | Boundary |
+|---|---|
+| Kernel ABI | Frozen syscall v2 surface, syscall IDs `1000-1011`, 12 syscalls, Ring0 mechanism only |
+| Platform ABI | Module manifest, package metadata, workspace lifecycle, capability contract, trust classification, plugin boundary, semantic contract |
+
+Kernel ABI is the frozen execution substrate. Platform ABI is the governed
+userspace contract that defines how AykenOS can accept modules, packages,
+workspaces, plugins, and later semantic systems without widening Ring0.
+
+## Phase-18 Scope
+
+Phase-18 must answer one constitutional question:
+
+How can a developer add something to AykenOS in a safe, verifiable,
+fail-closed, and kernel-preserving way?
+
+Required Platform Constitution outputs:
+
+1. Module manifest schema.
+2. Package metadata schema.
+3. Workspace lifecycle contract.
+4. Capability contract for platform resources.
+5. Trust classification model.
+6. Plugin boundary contract.
+7. Platform ABI validation gate.
+8. Minimal reference examples that do not create new runtime authority.
+
+## Non-Goals
+
+Phase-18 must not include:
+
+1. New syscalls.
+2. Kernel ABI expansion.
+3. Ring0 policy engines.
+4. Kernel-resident plugin systems.
+5. AI Runtime authority.
+6. Semantic CLI as an execution verdict source.
+7. Scheduler, SMP, or BCIB expansion as the primary roadmap objective.
+
+## Trust Classification Model
+
+Trust classification is required, but it must not be confused with permission.
+
+**Trust level does not grant capability.**
+
+Trust may affect:
+
+1. Install eligibility.
+2. Enable/disable policy.
+3. Update policy.
+4. Distribution channel.
+5. Review requirement.
+6. Quarantine or revocation handling.
+
+Actual access is granted only through an explicit capability contract. No trust
+level may bypass the frozen kernel ABI, capability validation, workspace
+boundary, or package policy.
+
+Initial trust classifications may include:
+
+| Classification | Meaning |
+|---|---|
+| `local` | Locally developed or manually installed; no distribution trust implied |
+| `experimental` | Allowed only under explicit development policy |
+| `signed` | Cryptographically signed by an accepted identity |
+| `verified` | Passed required platform validation gates |
+| `trusted` | Accepted for a defined distribution or workspace policy |
+| `revoked` | Must not install, enable, update, or execute |
+
+These classifications are policy inputs. They are not authority tokens.
+
+## Validation Backlog
+
+The following items remain important and visible, but they do not define the
+main Phase-18 direction:
+
+1. BCIB completeness.
+2. SMP safety.
+3. Exhaustive race coverage.
+4. Advanced interrupt validation.
+5. Broader scheduler stress evidence.
+
+These belong to a deferred validation track unless a separate reviewed phase
+decision makes one of them the active scope.
+
+## Forward Phase Line
+
+| Phase | Direction |
+|---|---|
+| Phase-18 | Platform Constitution |
+| Phase-19 | Platform Runtime MVP |
+| Phase-20 | Capability Ecosystem / Module Registry |
+| Phase-21 | Semantic CLI Integration |
+| Phase-22 | AI Runtime Foundation |
+| Phase-23+ | Agent Systems |
+
+AI Runtime is intentionally outside Phase-18. Its non-determinism, authority
+ambiguity, hallucination risk, and verification difficulty require a later
+foundation after the platform contracts are explicit.
+
+## Fail-Closed Activation Rule
+
+Phase-18 must remain inactive if any of the following are true:
+
+1. `CURRENT_PHASE` has not been explicitly transitioned.
+2. Platform Constitution scope is ambiguous.
+3. Kernel ABI expansion is bundled into the transition.
+4. Trust classification is treated as capability grant.
+5. AI Runtime or Semantic CLI is made an execution authority.
+6. Required closure references cannot be verified.
+
+The safe default is no activation.
+
+## Supersession Notice
+
+`PHASE18_ROADMAP.md` is a historical pre-closure runtime-validation roadmap.
+Its QEMU/runtime validation items are retained as historical context and as
+deferred validation backlog, not as the active Phase-18 objective.

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **Remote CI (Phase-16):** Verification Layer MVP complete (2026-04-25)
 **CURRENT_PHASE:** `17` (`Phase-17 OFFICIALLY CLOSED`; Phase-18 ayrı transition olmadan aktif değildir)
 **Freeze Zinciri:** `make ci-freeze` = 40 kapılı strict suite (normative spec-purity dahil) | `make ci-freeze-local` = local performance authority
-**Authority Durumu:** Issue #145 tek-maintainer authority kararıyla giderildi; PR #142, PR #144, PR #148, PR #149, PR #151, PR #150 ve PR #152 birleşti. Closure exact-SHA kanıtı `main` SHA `416a5392` üzerinde yenilendi, gerekli uzak acceptance kontrolleri PASS verdi ve `phase17-official-closure` tag'i aynı SHA'ya doğrulandı
-**Yakın Hedef:** `reports/phase17_official_closure_candidate/` official closure kaydını merge etmek; Phase-18'i yalnız ayrı transition kararıyla değerlendirmek
+**Authority Durumu:** Issue #145 tek-maintainer authority kararıyla giderildi; PR #142, PR #144, PR #148, PR #149, PR #151, PR #150, PR #152 ve Phase-17 closure decision package birleşti. Closure exact-SHA kanıtı `main` SHA `416a5392` üzerinde yenilendi, gerekli uzak acceptance kontrolleri PASS verdi ve `phase17-official-closure` tag'i aynı SHA'ya doğrulandı
+**Yakın Hedef:** `PHASE18_TRANSITION_DECISION.md` karar paketini review etmek; Phase-18'i Platform Constitution olarak, explicit pointer transition olmadan aktive etmemek
 **Ring0 Export Ceiling:** `193 symbols` (current enforced ceiling)
 **Performance Baseline Candidate:** `gha-ubuntu24-20260518.149.1-X64` (authorized run `26370359958` artifact'i PR'a import edildi; SHA `f129d4aa` locked acceptance PASS verdi, ancak tek basina closure authority değildir)
-**Development Status:** Phase-16 OFFICIALLY CLOSED ✅ | Phase-17 OFFICIALLY CLOSED ✅ | SINGLE-MAINTAINER AUTHORITY ALIGNED (#145 RESOLVED) ✅ | PR #142/#144/#148/#149/#151/#150/#152 MERGED ✅ | EXACT-SHA REMOTE EVIDENCE PASS ✅ | Phase-18 ROADMAP ONLY
+**Development Status:** Phase-16 OFFICIALLY CLOSED ✅ | Phase-17 OFFICIALLY CLOSED ✅ | SINGLE-MAINTAINER AUTHORITY ALIGNED (#145 RESOLVED) ✅ | PR #142/#144/#148/#149/#151/#150/#152 + closure decision package MERGED ✅ | EXACT-SHA REMOTE EVIDENCE PASS ✅ | Phase-18 TRANSITION DECISION PACKAGE ONLY
 
 **Proje Durumu:** Core OS Phase 4.5 TAMAMLANDI ✅ | Phase 10-17 kapanış kayıtları mevcut ✅ | Phase 17 Execution Pipeline OFFICIALLY CLOSED ✅ (2026-05-31) | CURRENT_PHASE=17 🔄 | Phase-18 ayrı transition olmadan aktif değil 🔒 | Architecture Freeze ACTIVE ✅
 **Boot/Kernel Bring-up:** UEFI→kernel handoff doğrulandı ✅ | Ring3 process preparation operasyonel ✅ | ELF64 loader çalışıyor ✅ | User address space creation aktif ✅ | Syscall roundtrip doğrulandı ✅ | IRQ-tail preempt doğrulama hattı mevcut ✅
@@ -40,9 +40,9 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **Phase 15 Status:** OFFICIALLY CLOSED ✅ | tag `phase15-official-closure` at `48970cd0` | remote `ci-freeze` run `24213727039` (PR #104) | BCIB Execution Engine v3: three-layer architecture, 293 tests PASS, 12 property tests PASS | `ayken-cli` v0.1 (Faz A wrapper) shipped | `tools/ayken-cli/`
 **Phase 16 Status:** OFFICIALLY CLOSED ✅ | Verification Layer MVP COMPLETE | Evidence chain integrity verified | Trust anchor established | `make verify-system` → 3 gates → PASS | Constitutional rule enforcement active | Fail-closed behavior confirmed
 **Phase 17 Status:** OFFICIALLY CLOSED ✅ | tag `phase17-official-closure` at `416a5392` | full `ci-freeze` (`26712333892`), locked performance (`26715068398`, `26712374737`) ve Phase-17 QEMU evidence lanes (`26712374742`, `26712374736`, `26712374727`, `26712374744`, `26712374728`) PASS | `reports/phase17_official_closure_candidate/`
-**Phase 18 Status:** ROADMAP ONLY | Phase-17 resmi closure kurulmuştur; Phase-18 yine ayrı transition olmadan aktif faz sayılmaz
+**Phase 18 Status:** TRANSITION DECISION PACKAGE ONLY | Proposed direction: Platform Constitution; kernel expansion/new syscalls/AI authority forbidden unless a separate phase RFC and closure authority exists
 **Architecture Quick Map:** `docs/specs/phase12-trust-layer/AYKENOS_GATE_ARCHITECTURE.md`
-**Active Execution Roadmap:** `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` | stabilization-first; accepted `main` SHA `416a5392` uzerinde bounded uzak evidence PASS; official closure tag doğrulandı; Phase-18 ayrı transition gerektirir
+**Active Execution Roadmap:** `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + `PHASE18_TRANSITION_DECISION.md` review | accepted `main` SHA `416a5392` uzerinde bounded uzak evidence PASS; official closure tag doğrulandı; Phase-18 explicit transition gerektirir
 **Canonical Technical Definition:** AykenOS is a deterministic verification architecture that separates kernel execution, verification semantics, evidence artifacts, and distributed diagnostics into explicit layers. The kernel provides mechanism, userspace verification services produce artifact-bound verdicts and receipts, and parity/topology surfaces expose cross-node observability without elevating diagnostics into authority or consensus.
 
 ⚠️ **CI Mode:** `ci-freeze` workflow varsayılan olarak **CONSTITUTIONAL** modda çalışır (`PERF_BASELINE_MODE=constitutional`); provisional yol yalnız diagnosis/baseline artifact adayıdır ve acceptance/closure otoritesi değildir. Ayrıntı: [Constitutional CI Mode](docs/operations/CONSTITUTIONAL_CI_MODE.md), [Provisional CI Mode](docs/operations/PROVISIONAL_CI_MODE.md) ve [Performance Baseline Policy](docs/operations/PERF_BASELINE_POLICY.md).
@@ -54,7 +54,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 - **Current Phase:** `17`
 - **Status:** `OFFICIALLY CLOSED / PHASE-18 TRANSITION NOT ACTIVATED`
 - **Last Official Closure:** `17` (Execution Pipeline, 2026-05-31)
-- **Candidate Next Phase:** `18` (Full Kernel Runtime Validation; roadmap only)
+- **Candidate Next Phase:** `18` (Platform Constitution; transition decision package only)
 - **Verification Layer:** `COMPLETE` (MVP delivered 2026-04-25)
 - **Closure Index:** `reports/phase17_official_closure_candidate/closure_index.json`
 - **Phase-17 Authority Note:** `phase17-official-closure` resolves to the reviewed exact-SHA evidence subject; Phase-18 activation still requires a separate transition decision.
@@ -68,7 +68,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 - **Evidence:** A, B, C karakterleri başarıyla syscall üzerinden basıldı
 - **Result:** Ring3 infrastructure PROVEN, syscall path WORKING, instruction retirement VALIDATED
 
-**Next Focus:** `reports/phase17_official_closure_candidate/` official closure package'ını merge etmek; Phase-18 transition ayrı ve fail-closed değerlendirilecektir
+**Next Focus:** `PHASE18_TRANSITION_DECISION.md` karar paketini review etmek; `CURRENT_PHASE` explicit pointer transition olmadan `18` yapılmayacaktır.
 
 ## Authority Model
 
@@ -309,6 +309,7 @@ Phase 12 trust layer kapsamında tamamlananlar:
 - **Constitutional CI Mode:** `docs/operations/CONSTITUTIONAL_CI_MODE.md`
 - **Freeze Workflow:** `docs/roadmap/freeze-enforcement-workflow.md`
 - **Active Execution Roadmap:** `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`
+- **Phase-18 Transition Decision:** `PHASE18_TRANSITION_DECISION.md`
 - **Documentation Index:** `docs/development/DOCUMENTATION_INDEX.md`
 - **Ring3 User-Leaf Rule:** `docs/governance/RING3_USER_LEAF_ALLOCATION_RULE.md`
 - **Ring3 Runtime Closure Note:** `docs/governance/RING3_RUNTIME_CLOSURE_NOTE.md`
@@ -334,35 +335,31 @@ AykenOS iki lisans modeli ile dağıtılır:
 
 ## 🎯 Sonraki Hedefler
 
-**Kısa Vadeli (Phase-16):**
-- Ayken CLI Faz B: `ayken status`
-- Ayken CLI Faz B: `ayken risk`
-- Ayken CLI Faz B: `ayken gate all`
-- Ayken CLI Faz B: `ayken closure status --json` (advisory)
-- Ayken CLI Faz B: `ayken closure verify` (binding, fail-closed)
-- Ayken CLI Faz B: `ayken head verify` (binding, CI-backed)
-- Ayken CLI Faz B: `ayken head lineage` (advisory-only ancestry diagnostics)
-- Ayken CLI Faz B: `ayken risk` (advisory interpretation only)
-- Ayken CLI Faz B: `ayken gate all --json` (CI-ready gate + risk contract)
-- Ayken CLI Faz C: `ayken bcib verify`
-- Ayken CLI Faz C: `ayken bcib hash`
-- Ayken CLI Faz C: `ayken bcib inspect` (authority/lineage/risk observation only)
-- Authority modeli: `ci-freeze` authoritative, local tooling advisory
+**Kısa Vadeli (Phase-18 Transition):**
+- `PHASE18_TRANSITION_DECISION.md` review.
+- `CURRENT_PHASE` transition decision; explicit pointer update olmadan Phase-18 aktive edilmez.
+- Platform ABI schema draft.
+- Module manifest schema draft.
+- Package metadata schema draft.
+- Workspace lifecycle contract draft.
+- Capability contract draft.
+- Trust classification validation gate; trust level capability grant degildir.
+- Plugin boundary contract draft.
 
 **Orta Vadeli:**
-- ARM64 + RISC-V kernel portları
-- Gerçek donanım testleri (Raspberry Pi)
-- Network stack (temel TCP/IP)
+- Phase-19 Platform Runtime MVP.
+- Phase-20 Capability Ecosystem / Module Registry.
+- Deferred Validation Backlog: BCIB completeness, SMP safety, exhaustive race coverage ve advanced interrupt validation.
 
 **Uzun Vadeli:**
-- Tam AI entegrasyonu (TinyLLM)
-- Veri-odaklı dosya sistemi
-- AI-native shell
+- Phase-21 Semantic CLI Integration.
+- Phase-22 AI Runtime Foundation.
+- Phase-23+ Agent Systems.
 - Ekosistem geliştirme
 
 ---
 
-**Son Güncelleme:** 31 Mayıs 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=17; issue #145 çözüldü; PR #142/#144/#148/#149/#151/#150/#152 kabul edildi; bounded Phase-17 uzak evidence ve strict freeze PASS verdi; Phase-18 yalnızca yol haritasıdır ve ayrı transition olmadan aktif değildir.
+**Son Güncelleme:** 31 Mayıs 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=17; issue #145 çözüldü; PR #142/#144/#148/#149/#151/#150/#152 ve closure decision package kabul edildi; bounded Phase-17 uzak evidence ve strict freeze PASS verdi; Phase-18 Platform Constitution transition decision package olarak değerlendirilmektedir ve explicit transition olmadan aktif değildir.
 **Düzenleyen / Geliştiren / Oluşturan / Mimari Sorumlu:** Kenan AY *(metadata only; runtime/karar yetkisi değildir).*
 
 **© 2026 Kenan AY — AykenOS Project**

--- a/docs/development/DOCUMENTATION_INDEX.md
+++ b/docs/development/DOCUMENTATION_INDEX.md
@@ -1,10 +1,10 @@
 # AykenOS Documentation Index
 This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict, Phase 0 prevails.
 
-**Last Updated:** 2026-05-23
+**Last Updated:** 2026-05-31
 **Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu:** Kenan AY
 **Attribution Boundary:** Human-readable documentation metadata only; not runtime authority or execution evidence.
-**Current Authority Basis:** `phase16-official-closure` + `CURRENT_PHASE=17` + `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`
+**Current Authority Basis:** `phase17-official-closure` + `CURRENT_PHASE=17` + `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`
 
 ## Current Status
 - **Runtime:** `Phase-10` officially closed — `ci-freeze` run `22797401328`
@@ -14,10 +14,11 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict
 - **Observability Hardening:** `Phase-14` officially closed — all 5 workstreams merged
 - **BCIB Execution Engine v3:** `Phase-15` officially closed — `ci-freeze` run `24213727039` (PR #104)
 - **Verification Layer MVP:** `Phase-16` officially closed — `ci-freeze` run `25214669681`, tag `phase16-official-closure`
+- **Execution Pipeline:** `Phase-17` officially closed — tag `phase17-official-closure` at `416a5392`
 - **Formal Governance Pointer:** `CURRENT_PHASE=17`
-- **Active Phase:** Phase-17 ACTIVE / FORMAL CLOSURE PENDING
-- **Active Execution Priority:** Marker-enabled real kernel/QEMU lifecycle, deterministic result, fail-closed negative/race proof and performance overhead evidence
-- **Scope Boundary:** Phase-18 is a roadmap only; it is not activated while Phase-17 closure authority is absent
+- **Active Phase:** Phase-17 OFFICIALLY CLOSED / Phase-18 TRANSITION NOT ACTIVATED
+- **Active Execution Priority:** Review `PHASE18_TRANSITION_DECISION.md` as a docs-only Platform Constitution transition package
+- **Scope Boundary:** Phase-18 is not active until an explicit `CURRENT_PHASE` pointer transition; kernel expansion, new syscalls, Ring0 policy and AI Runtime authority remain forbidden for Phase-18
 
 ## Primary Truth Sources
 Current repo truth icin once su dosyalari referans alin:
@@ -29,14 +30,18 @@ Current repo truth icin once su dosyalari referans alin:
 5. `README.md`
 6. `docs/roadmap/freeze-enforcement-workflow.md`
 7. `shared/abi/ayken_abi.h` and `shared/abi/syscall_v2.h` — **canonical frozen ABI inputs**
-8. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
-9. `reports/phase15_official_closure/closure_index.json`
-10. `reports/phase13_official_closure_candidate/closure_index.json`
-11. `reports/phase12_official_closure_candidate/closure_manifest.json`
-12. `reports/phase10_phase11_official_closure_index.json`
-13. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
-14. `Makefile`
-15. `.github/workflows/ci-freeze.yml`
+8. `reports/phase17_official_closure_candidate/closure_decision_record.json`
+9. `reports/phase17_official_closure_candidate/closure_manifest.json`
+10. `reports/phase17_official_closure_candidate/closure_index.json`
+11. `PHASE18_TRANSITION_DECISION.md` — **Phase-18 Platform Constitution transition package; not active pointer**
+12. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
+13. `reports/phase15_official_closure/closure_index.json`
+14. `reports/phase13_official_closure_candidate/closure_index.json`
+15. `reports/phase12_official_closure_candidate/closure_manifest.json`
+16. `reports/phase10_phase11_official_closure_index.json`
+17. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
+18. `Makefile`
+19. `.github/workflows/ci-freeze.yml`
 
 Phase-14 workstream numbering ve aktif durum yorumu icin canonical truth source:
 
@@ -68,12 +73,14 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 3. `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`
 4. `docs/roadmap/freeze-enforcement-workflow.md`
 5. `AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md`
-6. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
-7. `docs/specs/phase16-ayken-orchestration/README.md`
-8. `docs/specs/authority-lineage-v1/README.md`
-9. `docs/specs/phase14-distributed-observability/README.md`
-10. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
-11. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
+6. `PHASE18_TRANSITION_DECISION.md` — transition package only
+7. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
+8. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
+9. `docs/specs/phase16-ayken-orchestration/README.md`
+10. `docs/specs/authority-lineage-v1/README.md`
+11. `docs/specs/phase14-distributed-observability/README.md`
+12. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
+13. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
 
 ## Phase-14 Reference Set
 ### Architecture and Observability Surfaces
@@ -182,10 +189,10 @@ Asagidaki dosyalar tarihsel snapshot niteligindedir; current truth yerine dogrud
 
 ## Note
 Eski raporlarda gecen blocker veya progress ifadeleri tarihsel baglam icindir.
-Current status yorumlari icin Phase-16 official closure otoritesi,
+Current status yorumlari icin Phase-17 official closure otoritesi,
 `docs/roadmap/CURRENT_PHASE` ve aktif stabilization roadmap birlikte
-kullanilmalidir. Yeni ozellik veya Phase-18 aktivasyonu, Phase-17 gercek
-kernel/QEMU acceptance evidence ve resmi closure yetkisi kurulmadan current
-execution plani olarak sunulamaz.
+kullanilmalidir. Yeni ozellik veya Phase-18 aktivasyonu,
+`PHASE18_TRANSITION_DECISION.md` review edilip explicit `CURRENT_PHASE`
+transition yapilmadan current execution plani olarak sunulamaz.
 
-**Son Guncelleme:** 2026-05-23
+**Son Guncelleme:** 2026-05-31

--- a/docs/governance/CI_GATE_INVENTORY_AND_DEBT_CONTROL_2026_05_25.md
+++ b/docs/governance/CI_GATE_INVENTORY_AND_DEBT_CONTROL_2026_05_25.md
@@ -6,7 +6,7 @@ promote a diagnostic lane, change runtime behavior, or grant closure.
 
 **Status:** S2 OPERATIONAL INVENTORY / REVIEW INPUT
 **Effective date:** 2026-05-25
-**Current phase:** Phase-17 active; formal closure pending
+**Current phase:** Phase-17 officially closed; Phase-18 transition not activated
 **Accepted-main evidence subject:** `e0286c7b64c15e27f810e634713a07652def169c`
 (`ci-gate-phase17-performance-acceptance` run `26421686338` PASS and full
 `ci-freeze` run `26421295459` PASS)

--- a/docs/operations/BASELINE_RENEWAL_PROCEDURE.md
+++ b/docs/operations/BASELINE_RENEWAL_PROCEDURE.md
@@ -2,7 +2,7 @@
 
 **Effective date:** 2026-05-25
 **Current authority:** `github-hosted-ubuntu-24.04-x64`
-**Current phase:** Phase-17 active; formal closure pending
+**Current phase:** Phase-17 officially closed; Phase-18 transition not activated
 **Authority boundary:** A generated lock artifact is not acceptance or merge
 authority. Import requires Kenan AY's recorded maintainer decision and
 subsequent constitutional remote PASS; it is not Phase-17 closure.

--- a/docs/operations/CONSTITUTIONAL_CI_MODE.md
+++ b/docs/operations/CONSTITUTIONAL_CI_MODE.md
@@ -3,7 +3,7 @@
 ## Status: DEFAULT FREEZE / LOCKED PERFORMANCE AUTHORITY
 
 **Effective date:** 2026-05-25
-**Current phase:** Phase-17 active; formal closure pending
+**Current phase:** Phase-17 officially closed; Phase-18 transition not activated
 **Previous remotely tested S2-D head before accepted-main restack:** `342deab6`
 (`ci-gate-phase17-performance-acceptance` run `26391379459` PASS and full
 `ci-freeze` run `26391379462` PASS)

--- a/docs/operations/PERF_BASELINE_POLICY.md
+++ b/docs/operations/PERF_BASELINE_POLICY.md
@@ -2,7 +2,7 @@
 
 **Effective date:** 2026-05-25
 **Current authority:** `github-hosted-ubuntu-24.04-x64`
-**Current phase:** Phase-17 active; formal closure pending
+**Current phase:** Phase-17 officially closed; Phase-18 transition not activated
 **Authority boundary:** A baseline renewal is an artifact-import procedure
 recorded by Kenan AY and followed by constitutional remote checks. It does
 not by itself grant merge authority or establish Phase-17 closure.

--- a/docs/operations/PROVISIONAL_CI_MODE.md
+++ b/docs/operations/PROVISIONAL_CI_MODE.md
@@ -3,7 +3,7 @@
 ## Status: DIAGNOSTIC / BASELINE-CANDIDATE ONLY
 
 **Effective date:** 2026-05-25
-**Current phase:** Phase-17 active; formal closure pending
+**Current phase:** Phase-17 officially closed; Phase-18 transition not activated
 **Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu:** Kenan AY
 **Attribution boundary:** Documentation metadata only; not runtime, evidence,
 baseline, merge or closure authority.

--- a/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
+++ b/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
@@ -65,8 +65,8 @@ Aktif urun cekirdegi su dort parcadir:
 
 ### 2.3 Urun Olmayan veya Ertelenen Alanlar
 
-Phase-17 closure kurulana kadar asagidakiler aktif implementation backlog'u
-degildir:
+Phase-18 explicit transition karari aktif pointer'a baglanana kadar
+asagidakiler aktif implementation backlog'u degildir:
 
 - Yeni syscall veya ABI surface genisletmesi.
 - ARM64/RISC-V/real-hardware feature genisletmesi.
@@ -75,9 +75,10 @@ degildir:
 - Yeni AI orchestration ozellikleri veya model sonucunun authoritative
   execution verdict'i olarak kullanilmasi.
 - Phase-18'in aktif faz olarak ilan edilmesi.
+- Trust classification'in capability grant gibi kullanilmasi.
 
 Bu alanlarda belge veya izole arastirma tutulabilir; production merge icin
-Phase-17 kapanis kapisini asamaz.
+Phase-18 Platform Constitution transition kapisini asamaz.
 
 ## 3. Bugunku Repo Gercegi
 
@@ -90,7 +91,7 @@ Phase-17 kapanis kapisini asamaz.
 | Governance | Spec-purity, fail-closed marker isolation, validation matrix ve S2 inventory kabul edildi | #145 tek-maintainer authority paritesiyle giderildi; closure yine ayrik reviewed karardir |
 | Review enforcement | `@kenanay` CODEOWNERS accountability metadata'si ve canli `main` required `freeze` protection'i tek-maintainer ADR'iyle hizalandi | Issue #145 RESOLVED; bagimsiz self-review iddiasi veya closure yetkisi kurulmaz |
 | Performance stability | PR-4 local readiness FAIL tarihsel kayit; PR-4A/PR-4B diagnostic; governed renewal ve workflow authority repair accepted | Accepted `main` SHA `416a5392`: Performance Gate `26715068398` ve scoped Phase-17 acceptance `26712374737` PASS; official tag dogrulandi |
-| Phase-18 | Roadmap only | Baslatilmaz |
+| Phase-18 | Transition decision package only | Platform Constitution review edilir; `CURRENT_PHASE` explicit transition olmadan baslatilmaz |
 
 ## 4. Stratejik Karar: Stabilization-First
 
@@ -99,12 +100,13 @@ AykenOS bundan sonraki gelistirmeyi "daha fazla yuzey" uzerinden degil,
 
 Oncelik sirasi:
 
-1. Phase-17 icin gercek kernel/QEMU runtime acceptance kaniti.
-2. Deterministic result, failure/race ve performance overhead kabulü.
-3. Closure manifest/tag ve clean-tree remote `ci-freeze` authority.
-4. BCIB tooling olgunlastirma; yalnız Ring3 ve mevcut ABI siniri icinde.
-5. Governance sadeleştirme ve gate maliyeti/tekrari denetimi.
-6. Ancak bunlardan sonra Phase-18 activation karari.
+1. Phase-17 official closure otoritesini exact-SHA tag ve manifest ile korumak.
+2. Phase-18'i kernel genisletme degil Platform Constitution olarak sinirlamak.
+3. Kernel ABI ile Platform ABI ayrimini dokuman otoritesine baglamak.
+4. Module/package/workspace/capability/trust/plugin kontratlarini fail-closed
+   tanimlamak.
+5. BCIB/SMP/race validation backlog'unu gorunur tutmak ama ana yon yapmamak.
+6. Ancak bunlardan sonra explicit Phase-18 activation pointer'i.
 
 ## 5. Technical Debt Control Rules
 
@@ -330,15 +332,23 @@ nondeterministic verification verdict'i uretmez.
 
 ### S5 - Phase-18 Activation Decision
 
-**Status:** NOT ACTIVE
+**Status:** TRANSITION DECISION PACKAGE PENDING / NOT ACTIVE
 
-`PHASE18_ROADMAP.md` ancak su kosullarla aktif uygulama planina donusebilir:
+Phase-17 closure precondition'lari artik saglanmistir, ancak Phase-18 yine de
+aktif degildir. Phase-18 icin authority adayi `PHASE18_TRANSITION_DECISION.md`
+olmalidir; eski `PHASE18_ROADMAP.md` tarihsel runtime-validation backlog'u
+olarak tutulur.
 
-1. Phase-17 official closure tag ve manifest mevcut.
-2. S1 runtime, race/fail-closed ve performance kaniti PASS.
-3. Remote strict CI temiz tree uzerinde PASS.
-4. Issue #145 tek-maintainer authority karari ve canli protection paritesiyle kapatilmis.
-5. Architecture review yeni kapsam ihtiyacini onaylamis.
+Phase-18 transition su kararlari korumadan aktif uygulama planina donusemez:
+
+1. Phase-18 = Platform Constitution.
+2. Kernel ABI expansion forbidden.
+3. New syscalls forbidden.
+4. Ring0 policy forbidden.
+5. AI Runtime authority forbidden.
+6. Kernel ABI ile Platform ABI ayrimi acik.
+7. Trust level capability grant degildir.
+8. `CURRENT_PHASE` ancak explicit transition ile `18` yapilir.
 
 ## 7. PR Sequence and Coordination Matrix
 
@@ -359,7 +369,8 @@ nondeterministic verification verdict'i uretmez.
 | PR #148 | MERGED (`e0286c7b`) / POST-MERGE PASS | Standalone Performance Gate workflow'unu locked authority modeliyle hizalamak | Workflow only; runtime/threshold degisikligi yok | Performance `26421295487`, freeze `26421295459` PASS |
 | PR #149/#151/#150 | MERGED (`7a42d312`) / EXACT-SHA REFRESHED | Closure-candidate record, governed baseline renewal ve ci-freeze prerequisite dedup | Candidate package, performance authority and CI prerequisite wiring | Historical refresh subject `7a42d312`; official tag ayridir |
 | PR #152 | MERGED (`416a5392`) / EXACT-SHA REFRESHED | Closure-candidate record'u accepted main subject'e yenilemek | Candidate manifest/index ve status docs | Refresh subject `416a5392`; official tag ayridir |
-| Closure decision package (bu changeset) | OFFICIAL CLOSURE CONFIRMED / PHASE-18 NOT ACTIVATED | Exact-SHA PASS kanitlarini verified official tag subject karar kaydina baglamak | Candidate manifest/index, decision record ve status docs | Candidate integrity + verified tag target; Phase-18 ayridir |
+| Phase-17 closure decision package | OFFICIAL CLOSURE CONFIRMED / PHASE-18 NOT ACTIVATED | Exact-SHA PASS kanitlarini verified official tag subject karar kaydina baglamak | Candidate manifest/index, decision record ve status docs | Candidate integrity + verified tag target; Phase-18 ayridir |
+| Phase-18 transition decision package | DOCS-ONLY / PHASE-18 NOT ACTIVATED | Phase-18'i Platform Constitution olarak sinirlamak | `PHASE18_TRANSITION_DECISION.md`, roadmap/index/current status sync | Kernel expansion/new syscall/AI authority forbidden; explicit pointer transition gerekir |
 
 PR koordinasyon kurallari:
 
@@ -411,7 +422,7 @@ PR koordinasyon kurallari:
 
 **Started work:**
 
-- Authority truth `CURRENT_PHASE=17` icin once Phase-17 pending durumu
+- Authority truth `CURRENT_PHASE=17` icin onceki Phase-17 pending status drift'i
   duzeltildi; 2026-05-31'de Phase-17 official closure confirmed oldu,
   Phase-18 transition ayrik tutuldu.
 - Canonical syscall/ABI parity `1000-1011` / 12 ve `0x00010001` olarak
@@ -1036,7 +1047,8 @@ Bu roadmap su olaylarda guncellenir:
 14. S2-D CI-mode authority dokuman senkronu sonrasi new-head PR CI sonucu.
 15. PR #142/#144/#148/#149/#151/#150 merge ve accepted-main exact-SHA evidence sonucu.
 16. Phase-17 closure candidate exact-SHA refresh review/merge sonucu ve official tag-subject karari.
-17. Yeni feature/ABI/authority surface onerisinin incelenmesi.
+17. Phase-18 Platform Constitution transition decision review/merge sonucu.
+18. Yeni feature/ABI/authority surface onerisinin incelenmesi.
 
 ## References
 
@@ -1053,6 +1065,7 @@ Bu roadmap su olaylarda guncellenir:
 - `docs/operations/POST_MERGE_SMOKE_TEST.md`
 - `reports/phase17_official_closure_candidate/closure_manifest.json`
 - `reports/phase17_official_closure_candidate/evidence_index.json`
+- `PHASE18_TRANSITION_DECISION.md`
 - `PHASE18_ROADMAP.md`
 - `shared/abi/syscall_v2.h`
 - `shared/abi/ayken_abi.h`

--- a/docs/roadmap/CURRENT_PHASE
+++ b/docs/roadmap/CURRENT_PHASE
@@ -3,8 +3,9 @@ CURRENT_PHASE=17
 # Phase-16 OFFICIALLY CLOSED - 2026-04-25 - tag: phase16-official-closure
 # Phase-17 OFFICIALLY CLOSED - 2026-05-31 - tag: phase17-official-closure at 416a5392.
 # Phase-17 closure evidence remains bounded to the reviewed exact-SHA runtime/QEMU, freeze, and performance runs.
-# Phase-18 is ROADMAP ONLY until a separate transition decision activates it.
+# Phase-18 is TRANSITION DECISION PACKAGE ONLY until a separate pointer transition activates it.
+# Proposed Phase-18 direction: Platform Constitution, not kernel expansion.
 # Active execution roadmap: docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
 # Remote evidence: ci-freeze 26712333892, Performance Gate 26715068398, Phase-17 lifecycle/determinism/public-e2e/worker/timeout/performance lanes all PASS on 416a5392.
-# Immediate work package: merge the official closure package without widening claims; evaluate Phase-18 only through a separate fail-closed transition.
+# Immediate work package: review PHASE18_TRANSITION_DECISION.md; do not activate Phase-18 without an explicit pointer transition.
 # Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu: Kenan AY (informational metadata only).

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -18,7 +18,10 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 4. `../../AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md`: mevcut changeset ve
    dogrulama raporu.
 5. `freeze-enforcement-workflow.md`: strict CI/gate order kontrati.
-6. `../../PHASE18_ROADMAP.md`: yalnizca sonraki faz planlamasi; aktif degil.
+6. `../../PHASE18_TRANSITION_DECISION.md`: Phase-18 Platform Constitution
+   transition package; aktif faz pointer'i degildir.
+7. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
+   planlamasi; aktif Phase-18 otoritesi degildir.
 
 ## Current Status
 
@@ -26,19 +29,21 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 |---|---|
 | Son resmi kapanis | Phase-17 OFFICIALLY CLOSED (`phase17-official-closure` at `416a5392`) |
 | Aktif faz | Phase-17 OFFICIALLY CLOSED / Phase-18 transition not activated |
-| Aktif odak | Stabilization-first Phase-17 acceptance evidence accepted on `main`; official closure tag verified on `416a5392`; Phase-18 remains roadmap only |
+| Aktif odak | Phase-18 Platform Constitution transition package review; no activation without explicit pointer transition |
 | ABI | Canonical `1000-1011` / 12 syscall, ABI version `0x00010001` |
-| Phase-18 | ROADMAP ONLY; Phase-17 closure olmadan aktivasyon yok |
+| Phase-18 | TRANSITION DECISION PACKAGE ONLY; kernel expansion and new syscalls forbidden unless a separate phase RFC/closure authority exists |
 
 ## Active Execution Rule
 
 Phase-17 resmi kapanis tag'i `416a5392` uzerinde uretilip dogrulanmistir.
-Phase-18 icin ayri transition karari uretilene kadar production roadmap'e
-yeni syscall, yeni platform feature'i, authority-genisleten observability veya
-AI orchestration isi alinmaz. Bounded runtime/QEMU lanes, strict `ci-freeze`,
-standalone locked Performance Gate ve scoped Phase-17 performance acceptance
-accepted `main` SHA `416a5392` uzerinde PASS vermistir. Bu closure, Phase-18
-activation veya genis BCIB semantic/race/SMP kapsami kurmaz.
+Phase-18 icin ayri transition karari aktif pointer'a baglanana kadar production
+roadmap'e yeni syscall, kernel ABI genislemesi, Ring0 policy, authority-genisleten
+observability veya AI orchestration isi alinmaz. Bounded runtime/QEMU lanes,
+strict `ci-freeze`, standalone locked Performance Gate ve scoped Phase-17
+performance acceptance accepted `main` SHA `416a5392` uzerinde PASS vermistir.
+Bu closure, Phase-18 activation veya genis BCIB semantic/race/SMP kapsami kurmaz.
+Phase-18'in proposed direction'i Platform Constitution'dir: module/package,
+workspace, capability, trust classification ve plugin boundary kontratlari.
 
 ## Historical References
 
@@ -53,6 +58,6 @@ current execution priority otoritesi degildir:
 
 ---
 
-**Next action:** `reports/phase17_official_closure_candidate/` official
-closure package'ini merge etmek; Phase-18 transition ayrica ve fail-closed
-degerlendirilir.
+**Next action:** `../../PHASE18_TRANSITION_DECISION.md` review edilip
+fail-closed Phase-18 transition karari ayrica verilir; `CURRENT_PHASE` explicit
+pointer transition olmadan `18` yapilmaz.

--- a/docs/roadmap/freeze-enforcement-workflow.md
+++ b/docs/roadmap/freeze-enforcement-workflow.md
@@ -19,9 +19,10 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict
 ### 0.1 Active Stabilization Execution Plan
 
 Aktif is sirasi `CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`
-tarafindan belirlenir. Bu siraya gore Phase-17 closure kurulana kadar
-feature expansion degil, PR-0 authority/governance/ABI parity repair ve
-ardindan marker-enabled gercek QEMU lifecycle acceptance kaniti onceliklidir.
+tarafindan belirlenir. Phase-17 resmi closure artik `phase17-official-closure`
+tag'iyle kurulmustur. Phase-18 explicit pointer transition yapilana kadar
+feature expansion degil, `PHASE18_TRANSITION_DECISION.md` icindeki Platform
+Constitution sinirinin review edilmesi onceliklidir.
 
 ---
 

--- a/docs/roadmap/overview.md
+++ b/docs/roadmap/overview.md
@@ -1,12 +1,12 @@
 # AykenOS Roadmap - Code and Evidence Status (2026-04-24)
 This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict, Phase 0 prevails.
 
-> **Authority notice (2026-05-23): HISTORICAL SNAPSHOT.** This document
+> **Authority notice (2026-05-31): HISTORICAL SNAPSHOT.** This document
 > preserves the 2026-04-24 evidence view and is not the current phase or
 > execution roadmap authority. Use `CURRENT_PHASE` and
-> `CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`; Phase-17 is now the
-> last official closure and Phase-18 is roadmap-only until a separate
-> transition decision.
+> `CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`; Phase-17 is the last
+> official closure and Phase-18 is not active until a separate Platform
+> Constitution transition decision is accepted.
 
 ## Scope
 Bu belge, roadmap durumunu dogrudan repo kodu, Make hedefleri, local evidence run'lari ve remote `ci-freeze` confirmation uzerinden ozetler.

--- a/docs/steering/product.md
+++ b/docs/steering/product.md
@@ -89,15 +89,16 @@ These rules are enforced by CI gates and MUST NOT be violated:
 - **Phase 14 Observability**: OFFICIALLY CLOSED (distributed observability, 5 workstreams complete)
 - **Phase 15 BCIB Engine**: OFFICIALLY CLOSED (BCIB Execution Engine v3, ci-freeze#24213727039, PR #104)
 - **Phase 16 Verification Layer**: OFFICIALLY CLOSED (MVP complete, evidence chain verified, trust anchor established)
-- **Constitutional System**: Phases 1-16 COMPLETE (governance framework active)
-- **Architecture Freeze**: ACTIVE (stabilization through Phase-17)
+- **Phase 17 Execution Pipeline**: OFFICIALLY CLOSED (`phase17-official-closure` at `416a5392`)
+- **Constitutional System**: Phases 1-17 COMPLETE (governance framework active)
+- **Architecture Freeze**: ACTIVE (Phase-18 transition requires explicit pointer decision)
 - **Worktree-Local Ring3 Rule**: executable user-leaf rule is live under `ci-gate-ring3-user-leaf-rule`; broader Phase10-A2 strict/global authority remains separate
 - **CI Enforcement**: strict freeze chain includes dedicated `Ring3 User Leaf Rule` before broader `Ring3 Execution Phase10a2`, followed by low-half scaffold, mailbox/runtime gates, alias proof, Phase-13 kill-switch enforcement, and Phase-16 verification layer gates
 - **Pre-CI Discipline**: Local advisory (5 core gates, ~60-90s, fail-closed) + verification layer integration
-- **CURRENT_PHASE**: `17` (Phase-17 active; formal closure pending)
-- **Current Execution Priority**: marker-enabled real kernel/QEMU execution-slot lifecycle, deterministic result, fail-closed/race and performance acceptance evidence
-- **Phase-18**: ROADMAP ONLY until Phase-17 official closure authority is established
-- **Scope Decision**: multi-architecture expansion, new AI orchestration and authority-surface growth remain deferred while stabilization evidence is incomplete
+- **CURRENT_PHASE**: `17` (Phase-17 officially closed; Phase-18 transition not activated)
+- **Current Execution Priority**: review `PHASE18_TRANSITION_DECISION.md` as a docs-only Platform Constitution transition package
+- **Phase-18**: TRANSITION DECISION PACKAGE ONLY until explicit `CURRENT_PHASE` pointer transition
+- **Scope Decision**: kernel expansion, new syscalls, Ring0 policy, AI Runtime authority and authority-surface growth remain deferred outside Phase-18 Platform Constitution scope
 
 ## License
 


### PR DESCRIPTION
## Summary

- Adds PHASE18_TRANSITION_DECISION.md as the docs-only Phase-18 Platform Constitution transition package.
- Marks the old PHASE18_ROADMAP.md as historical/superseded runtime-validation backlog.
- Syncs README, roadmap, operations, governance, steering, and documentation index surfaces to keep CURRENT_PHASE=17 while Phase-18 remains not activated.

## Authority Boundary

- No code/runtime changes.
- No CURRENT_PHASE transition to 18.
- Kernel ABI expansion, new syscalls, Ring0 policy, and AI Runtime authority remain forbidden for Phase-18 unless handled by a separate phase decision/RFC/evidence plan.

## Validation

- python3 tools/ci/validate_phase17_closure_candidate.py --expected-subject-sha 416a5392afbe217e16d26a59e2e1716fdfa9c8f6
- git diff --check
- stale Phase-17 pending / old Phase-18 runtime-roadmap wording search