### PR TITLE
[codex] docs: draft phase18 module manifest schema

### DIFF
--- a/PHASE18_TRANSITION_DECISION.md
+++ b/PHASE18_TRANSITION_DECISION.md
@@ -79,7 +79,7 @@ fail-closed, and kernel-preserving way?
 
 Required Platform Constitution outputs:
 
-1. Module manifest schema.
+1. Module manifest schema (`docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`).
 2. Package metadata schema.
 3. Workspace lifecycle contract.
 4. Capability contract for platform resources.
@@ -87,6 +87,10 @@ Required Platform Constitution outputs:
 6. Plugin boundary contract.
 7. Platform ABI validation gate.
 8. Minimal reference examples that do not create new runtime authority.
+
+Initial pre-activation spec work starts with the Module Manifest Schema. This
+does not activate Phase-18 and does not grant package, capability, workspace,
+trust, plugin, semantic, or AI Runtime authority.
 
 ## Non-Goals
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **CURRENT_PHASE:** `17` (`Phase-17 OFFICIALLY CLOSED`; Phase-18 ayrı transition olmadan aktif değildir)
 **Freeze Zinciri:** `make ci-freeze` = 40 kapılı strict suite (normative spec-purity dahil) | `make ci-freeze-local` = local performance authority
 **Authority Durumu:** Issue #145 tek-maintainer authority kararıyla giderildi; PR #142, PR #144, PR #148, PR #149, PR #151, PR #150, PR #152 ve Phase-17 closure decision package birleşti. Closure exact-SHA kanıtı `main` SHA `416a5392` üzerinde yenilendi, gerekli uzak acceptance kontrolleri PASS verdi ve `phase17-official-closure` tag'i aynı SHA'ya doğrulandı
-**Yakın Hedef:** `PHASE18_TRANSITION_DECISION.md` karar paketini review etmek; Phase-18'i Platform Constitution olarak, explicit pointer transition olmadan aktive etmemek
+**Yakın Hedef:** Phase-18 Platform Constitution RFC setini yazmak; ilk somut çıktı `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, explicit pointer transition olmadan Phase-18 aktive edilmez
 **Ring0 Export Ceiling:** `193 symbols` (current enforced ceiling)
 **Performance Baseline Candidate:** `gha-ubuntu24-20260518.149.1-X64` (authorized run `26370359958` artifact'i PR'a import edildi; SHA `f129d4aa` locked acceptance PASS verdi, ancak tek basina closure authority değildir)
 **Development Status:** Phase-16 OFFICIALLY CLOSED ✅ | Phase-17 OFFICIALLY CLOSED ✅ | SINGLE-MAINTAINER AUTHORITY ALIGNED (#145 RESOLVED) ✅ | PR #142/#144/#148/#149/#151/#150/#152 + closure decision package MERGED ✅ | EXACT-SHA REMOTE EVIDENCE PASS ✅ | Phase-18 TRANSITION DECISION PACKAGE ONLY
@@ -42,7 +42,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **Phase 17 Status:** OFFICIALLY CLOSED ✅ | tag `phase17-official-closure` at `416a5392` | full `ci-freeze` (`26712333892`), locked performance (`26715068398`, `26712374737`) ve Phase-17 QEMU evidence lanes (`26712374742`, `26712374736`, `26712374727`, `26712374744`, `26712374728`) PASS | `reports/phase17_official_closure_candidate/`
 **Phase 18 Status:** TRANSITION DECISION PACKAGE ONLY | Proposed direction: Platform Constitution; kernel expansion/new syscalls/AI authority forbidden unless a separate phase RFC and closure authority exists
 **Architecture Quick Map:** `docs/specs/phase12-trust-layer/AYKENOS_GATE_ARCHITECTURE.md`
-**Active Execution Roadmap:** `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + `PHASE18_TRANSITION_DECISION.md` review | accepted `main` SHA `416a5392` uzerinde bounded uzak evidence PASS; official closure tag doğrulandı; Phase-18 explicit transition gerektirir
+**Active Execution Roadmap:** `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution RFC set | accepted `main` SHA `416a5392` uzerinde bounded uzak evidence PASS; official closure tag doğrulandı; Phase-18 explicit transition gerektirir
 **Canonical Technical Definition:** AykenOS is a deterministic verification architecture that separates kernel execution, verification semantics, evidence artifacts, and distributed diagnostics into explicit layers. The kernel provides mechanism, userspace verification services produce artifact-bound verdicts and receipts, and parity/topology surfaces expose cross-node observability without elevating diagnostics into authority or consensus.
 
 ⚠️ **CI Mode:** `ci-freeze` workflow varsayılan olarak **CONSTITUTIONAL** modda çalışır (`PERF_BASELINE_MODE=constitutional`); provisional yol yalnız diagnosis/baseline artifact adayıdır ve acceptance/closure otoritesi değildir. Ayrıntı: [Constitutional CI Mode](docs/operations/CONSTITUTIONAL_CI_MODE.md), [Provisional CI Mode](docs/operations/PROVISIONAL_CI_MODE.md) ve [Performance Baseline Policy](docs/operations/PERF_BASELINE_POLICY.md).
@@ -68,7 +68,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 - **Evidence:** A, B, C karakterleri başarıyla syscall üzerinden basıldı
 - **Result:** Ring3 infrastructure PROVEN, syscall path WORKING, instruction retirement VALIDATED
 
-**Next Focus:** `PHASE18_TRANSITION_DECISION.md` karar paketini review etmek; `CURRENT_PHASE` explicit pointer transition olmadan `18` yapılmayacaktır.
+**Next Focus:** Phase-18 Platform Constitution RFC setini yazmak; ilk çıktı `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `CURRENT_PHASE` explicit pointer transition olmadan `18` yapılmayacaktır.
 
 ## Authority Model
 
@@ -310,6 +310,7 @@ Phase 12 trust layer kapsamında tamamlananlar:
 - **Freeze Workflow:** `docs/roadmap/freeze-enforcement-workflow.md`
 - **Active Execution Roadmap:** `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`
 - **Phase-18 Transition Decision:** `PHASE18_TRANSITION_DECISION.md`
+- **Phase-18 Module Manifest Schema:** `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`
 - **Documentation Index:** `docs/development/DOCUMENTATION_INDEX.md`
 - **Ring3 User-Leaf Rule:** `docs/governance/RING3_USER_LEAF_ALLOCATION_RULE.md`
 - **Ring3 Runtime Closure Note:** `docs/governance/RING3_RUNTIME_CLOSURE_NOTE.md`
@@ -336,10 +337,10 @@ AykenOS iki lisans modeli ile dağıtılır:
 ## 🎯 Sonraki Hedefler
 
 **Kısa Vadeli (Phase-18 Transition):**
-- `PHASE18_TRANSITION_DECISION.md` review.
+- `PHASE18_TRANSITION_DECISION.md` merged; this is not Phase-18 activation.
 - `CURRENT_PHASE` transition decision; explicit pointer update olmadan Phase-18 aktive edilmez.
 - Platform ABI schema draft.
-- Module manifest schema draft.
+- Module manifest schema RFC draft: `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`.
 - Package metadata schema draft.
 - Workspace lifecycle contract draft.
 - Capability contract draft.

--- a/docs/development/DOCUMENTATION_INDEX.md
+++ b/docs/development/DOCUMENTATION_INDEX.md
@@ -17,7 +17,7 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict
 - **Execution Pipeline:** `Phase-17` officially closed — tag `phase17-official-closure` at `416a5392`
 - **Formal Governance Pointer:** `CURRENT_PHASE=17`
 - **Active Phase:** Phase-17 OFFICIALLY CLOSED / Phase-18 TRANSITION NOT ACTIVATED
-- **Active Execution Priority:** Review `PHASE18_TRANSITION_DECISION.md` as a docs-only Platform Constitution transition package
+- **Active Execution Priority:** Draft the Phase-18 Platform Constitution RFC set, starting with `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`
 - **Scope Boundary:** Phase-18 is not active until an explicit `CURRENT_PHASE` pointer transition; kernel expansion, new syscalls, Ring0 policy and AI Runtime authority remain forbidden for Phase-18
 
 ## Primary Truth Sources
@@ -34,14 +34,15 @@ Current repo truth icin once su dosyalari referans alin:
 9. `reports/phase17_official_closure_candidate/closure_manifest.json`
 10. `reports/phase17_official_closure_candidate/closure_index.json`
 11. `PHASE18_TRANSITION_DECISION.md` — **Phase-18 Platform Constitution transition package; not active pointer**
-12. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
-13. `reports/phase15_official_closure/closure_index.json`
-14. `reports/phase13_official_closure_candidate/closure_index.json`
-15. `reports/phase12_official_closure_candidate/closure_manifest.json`
-16. `reports/phase10_phase11_official_closure_index.json`
-17. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
-18. `Makefile`
-19. `.github/workflows/ci-freeze.yml`
+12. `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md` — **first pre-activation Platform Constitution RFC draft**
+13. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
+14. `reports/phase15_official_closure/closure_index.json`
+15. `reports/phase13_official_closure_candidate/closure_index.json`
+16. `reports/phase12_official_closure_candidate/closure_manifest.json`
+17. `reports/phase10_phase11_official_closure_index.json`
+18. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
+19. `Makefile`
+20. `.github/workflows/ci-freeze.yml`
 
 Phase-14 workstream numbering ve aktif durum yorumu icin canonical truth source:
 
@@ -74,13 +75,20 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 4. `docs/roadmap/freeze-enforcement-workflow.md`
 5. `AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md`
 6. `PHASE18_TRANSITION_DECISION.md` — transition package only
-7. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
-8. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
-9. `docs/specs/phase16-ayken-orchestration/README.md`
-10. `docs/specs/authority-lineage-v1/README.md`
-11. `docs/specs/phase14-distributed-observability/README.md`
-12. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
-13. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
+7. `docs/specs/phase18-platform-constitution/README.md` — Phase-18 spec set index
+8. `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`
+9. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
+10. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
+11. `docs/specs/phase16-ayken-orchestration/README.md`
+12. `docs/specs/authority-lineage-v1/README.md`
+13. `docs/specs/phase14-distributed-observability/README.md`
+14. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
+15. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
+
+## Phase-18 Reference Set
+1. `PHASE18_TRANSITION_DECISION.md`
+2. `docs/specs/phase18-platform-constitution/README.md`
+3. `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`
 
 ## Phase-14 Reference Set
 ### Architecture and Observability Surfaces

--- a/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
+++ b/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
@@ -349,6 +349,8 @@ Phase-18 transition su kararlari korumadan aktif uygulama planina donusemez:
 6. Kernel ABI ile Platform ABI ayrimi acik.
 7. Trust level capability grant degildir.
 8. `CURRENT_PHASE` ancak explicit transition ile `18` yapilir.
+9. Module Manifest, Capability Contract ve Workspace Lifecycle spec'leri
+   fail-closed olarak review edilmeden implementation phase baslamaz.
 
 ## 7. PR Sequence and Coordination Matrix
 
@@ -371,6 +373,7 @@ Phase-18 transition su kararlari korumadan aktif uygulama planina donusemez:
 | PR #152 | MERGED (`416a5392`) / EXACT-SHA REFRESHED | Closure-candidate record'u accepted main subject'e yenilemek | Candidate manifest/index ve status docs | Refresh subject `416a5392`; official tag ayridir |
 | Phase-17 closure decision package | OFFICIAL CLOSURE CONFIRMED / PHASE-18 NOT ACTIVATED | Exact-SHA PASS kanitlarini verified official tag subject karar kaydina baglamak | Candidate manifest/index, decision record ve status docs | Candidate integrity + verified tag target; Phase-18 ayridir |
 | Phase-18 transition decision package | DOCS-ONLY / PHASE-18 NOT ACTIVATED | Phase-18'i Platform Constitution olarak sinirlamak | `PHASE18_TRANSITION_DECISION.md`, roadmap/index/current status sync | Kernel expansion/new syscall/AI authority forbidden; explicit pointer transition gerekir |
+| Phase-18 Module Manifest Schema | DOCS-ONLY / PRE-ACTIVATION RFC | Modülün kimlik, entrypoint, artifact ve capability request beyanini fail-closed tanimlamak | `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md` | Capability/trust/workspace authority grant yok; unknown fields fail-closed |
 
 PR koordinasyon kurallari:
 
@@ -1048,7 +1051,8 @@ Bu roadmap su olaylarda guncellenir:
 15. PR #142/#144/#148/#149/#151/#150 merge ve accepted-main exact-SHA evidence sonucu.
 16. Phase-17 closure candidate exact-SHA refresh review/merge sonucu ve official tag-subject karari.
 17. Phase-18 Platform Constitution transition decision review/merge sonucu.
-18. Yeni feature/ABI/authority surface onerisinin incelenmesi.
+18. Phase-18 Module Manifest Schema review/merge sonucu.
+19. Yeni feature/ABI/authority surface onerisinin incelenmesi.
 
 ## References
 
@@ -1057,6 +1061,7 @@ Bu roadmap su olaylarda guncellenir:
 - `docs/roadmap/CURRENT_PHASE`
 - `docs/roadmap/freeze-enforcement-workflow.md`
 - `docs/specs/phase17-execution-pipeline/VALIDATION_FLAG_MATRIX.md`
+- `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`
 - `docs/governance/CI_GATE_INVENTORY_AND_DEBT_CONTROL_2026_05_25.md`
 - `docs/operations/CONSTITUTIONAL_CI_MODE.md`
 - `docs/operations/PROVISIONAL_CI_MODE.md`

--- a/docs/roadmap/CURRENT_PHASE
+++ b/docs/roadmap/CURRENT_PHASE
@@ -7,5 +7,5 @@ CURRENT_PHASE=17
 # Proposed Phase-18 direction: Platform Constitution, not kernel expansion.
 # Active execution roadmap: docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
 # Remote evidence: ci-freeze 26712333892, Performance Gate 26715068398, Phase-17 lifecycle/determinism/public-e2e/worker/timeout/performance lanes all PASS on 416a5392.
-# Immediate work package: review PHASE18_TRANSITION_DECISION.md; do not activate Phase-18 without an explicit pointer transition.
+# Immediate work package: draft Phase-18 Platform Constitution specs starting with docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md; do not activate Phase-18 without an explicit pointer transition.
 # Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu: Kenan AY (informational metadata only).

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -20,7 +20,9 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 5. `freeze-enforcement-workflow.md`: strict CI/gate order kontrati.
 6. `../../PHASE18_TRANSITION_DECISION.md`: Phase-18 Platform Constitution
    transition package; aktif faz pointer'i degildir.
-7. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
+7. `../specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`:
+   ilk Phase-18 Platform Constitution RFC draft'i; authority grant degildir.
+8. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
    planlamasi; aktif Phase-18 otoritesi degildir.
 
 ## Current Status
@@ -29,7 +31,7 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 |---|---|
 | Son resmi kapanis | Phase-17 OFFICIALLY CLOSED (`phase17-official-closure` at `416a5392`) |
 | Aktif faz | Phase-17 OFFICIALLY CLOSED / Phase-18 transition not activated |
-| Aktif odak | Phase-18 Platform Constitution transition package review; no activation without explicit pointer transition |
+| Aktif odak | Phase-18 Platform Constitution RFC set; first draft is Module Manifest Schema; no activation without explicit pointer transition |
 | ABI | Canonical `1000-1011` / 12 syscall, ABI version `0x00010001` |
 | Phase-18 | TRANSITION DECISION PACKAGE ONLY; kernel expansion and new syscalls forbidden unless a separate phase RFC/closure authority exists |
 
@@ -58,6 +60,6 @@ current execution priority otoritesi degildir:
 
 ---
 
-**Next action:** `../../PHASE18_TRANSITION_DECISION.md` review edilip
-fail-closed Phase-18 transition karari ayrica verilir; `CURRENT_PHASE` explicit
-pointer transition olmadan `18` yapilmaz.
+**Next action:** `../specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`
+RFC draft'i review edilir; Capability Contract ve Workspace Lifecycle spec'leri
+gelmeden `CURRENT_PHASE` explicit pointer transition ile `18` yapilmaz.

--- a/docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md
+++ b/docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md
@@ -1,0 +1,422 @@
+# Phase-18 Module Manifest Schema
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, and `PHASE18_TRANSITION_DECISION.md`. In case of
+conflict, those documents prevail.
+
+**Status:** RFC-DRAFT / PRE-ACTIVATION SPEC
+**Schema id:** `ayken.platform.module.manifest.v1`
+**Canonical file name:** `ayken.module.json`
+**Authority boundary:** Documentation/specification only; not an installer,
+runtime loader, capability grant, trust grant, or Phase-18 activation.
+
+## Purpose
+
+The module manifest answers the first Phase-18 Platform Constitution question:
+
+How does a module declare what it is, what it exposes, and what platform
+resources it requests without expanding the kernel or receiving implicit
+authority?
+
+This schema defines the minimum declarative module contract. It is intentionally
+smaller than a package format, registry entry, signing envelope, or workspace
+lifecycle contract.
+
+## Non-Goals
+
+This schema does not define:
+
+1. Package distribution format.
+2. Publisher identity or signature trust.
+3. Capability token issuance.
+4. Workspace mount lifecycle.
+5. Plugin host execution protocol.
+6. Semantic CLI authority.
+7. AI Runtime authority.
+8. Kernel ABI or syscall changes.
+
+## Core Rule
+
+A manifest may request platform resources. It must never grant them.
+
+The following invariants are mandatory:
+
+1. `capability_requests` are requests only.
+2. Trust classification is external to the manifest.
+3. Capability tokens must not appear in the manifest.
+4. Kernel ABI expansion must not be expressible in the manifest.
+5. Unknown top-level fields fail validation.
+6. Manifest validation must fail closed.
+
+## Manifest Encoding
+
+`ayken.module.json` must be:
+
+1. UTF-8 JSON.
+2. A single JSON object.
+3. Free of comments and trailing commas.
+4. Free of duplicate keys.
+5. Parsed with unknown top-level fields rejected.
+6. Canonicalized by the future validator before digest computation.
+
+The manifest must not contain a self-declared manifest digest. A validator or
+package layer may compute and store the digest externally.
+
+## Required Top-Level Fields
+
+| Field | Type | Requirement |
+|---|---|---|
+| `manifest_version` | integer | Must be `1` for this RFC |
+| `schema_id` | string | Must be `ayken.platform.module.manifest.v1` |
+| `module_id` | string | Stable globally unique module id |
+| `name` | string | Human-readable short name |
+| `version` | string | Semver-compatible module version |
+| `module_kind` | string | One of the allowed module kinds |
+| `summary` | string | Short human-readable summary |
+| `entrypoints` | array | Declared module entrypoints |
+| `platform` | object | Platform ABI compatibility declaration |
+| `capability_requests` | array | Requested capabilities; may be empty |
+| `workspace` | object | Workspace requirement declaration |
+| `integrity` | object | Artifact hash declarations |
+
+Optional top-level fields are limited to:
+
+| Field | Type | Requirement |
+|---|---|---|
+| `description` | string | Longer description |
+| `authors` | array | Human-readable author metadata |
+| `license` | string | License identifier or proprietary marker |
+| `links` | object | Non-authoritative links |
+| `dependencies` | object | Declarative dependency requirements |
+| `plugin_boundary` | object | Plugin host/export declaration |
+| `semantic_surface` | object | Advisory-only semantic metadata |
+| `extensions` | object | Non-authoritative extension metadata |
+
+All other top-level fields must fail validation.
+
+## Field Rules
+
+### `module_id`
+
+`module_id` must be a lower-case, reverse-DNS-like identifier:
+
+```text
+^[a-z][a-z0-9]*(\.[a-z][a-z0-9-]*)+$
+```
+
+Examples:
+
+```text
+org.ayken.examples.echo
+com.example.workspace-indexer
+```
+
+The identifier must not include `kernel`, `ring0`, `syscall`, `driver`, or
+`ai-runtime` as a segment in Phase-18.
+
+### `version`
+
+`version` must use a semver-compatible string:
+
+```text
+MAJOR.MINOR.PATCH
+```
+
+Pre-release and build metadata may be allowed by a future validator, but this
+RFC only requires the base form.
+
+### `module_kind`
+
+Allowed values:
+
+| Value | Meaning |
+|---|---|
+| `tool` | User-invoked platform tool |
+| `service` | Userspace platform service |
+| `plugin` | Module loaded through a plugin boundary |
+| `library` | Shared userspace library surface |
+| `workflow` | Declarative workflow surface |
+
+Forbidden values include `kernel`, `driver`, `syscall`, `ring0`,
+`scheduler`, `interrupt`, `semantic-verdict`, and `ai-runtime`.
+
+### `entrypoints`
+
+Each entrypoint must be an object:
+
+| Field | Type | Requirement |
+|---|---|---|
+| `id` | string | Stable entrypoint id unique within the module |
+| `kind` | string | `cli`, `service`, `plugin`, `worker`, or `library` |
+| `path` | string | Relative artifact path |
+| `abi` | string | Entrypoint ABI id |
+| `default` | boolean | Optional default marker |
+
+`path` must be relative, must not contain `..`, and must not start with `/`.
+The manifest may declare an entrypoint, but it does not authorize execution.
+
+The initial entrypoint ABI id is:
+
+```text
+ayken.platform.entrypoint.v1
+```
+
+### `platform`
+
+The `platform` object must declare compatibility with the Platform ABI above the
+frozen kernel:
+
+```json
+{
+  "platform_abi": "ayken.platform.module.v1",
+  "kernel_abi_floor": "syscall-v2-1000-1011"
+}
+```
+
+`kernel_abi_floor` is a compatibility floor only. It must not be interpreted as
+direct syscall access or kernel ABI expansion.
+
+### `capability_requests`
+
+Each capability request must be an object:
+
+| Field | Type | Requirement |
+|---|---|---|
+| `id` | string | Capability id from a future capability registry |
+| `access` | array | Requested access verbs |
+| `scope` | object | Requested resource scope |
+| `required` | boolean | Whether missing capability blocks enablement |
+| `reason` | string | Human-readable justification |
+
+`capability_requests` do not grant capabilities. They are admission inputs for
+future platform validation and user/admin review.
+
+The following fields are forbidden anywhere under `capability_requests`:
+
+1. `grant`
+2. `token`
+3. `capability_token`
+4. `trusted`
+5. `verified`
+6. `ring0`
+7. `syscall`
+
+### `workspace`
+
+The `workspace` object declares workspace dependency only:
+
+| Field | Type | Requirement |
+|---|---|---|
+| `mode` | string | `none`, `optional`, or `required` |
+| `declared_mounts` | array | Requested logical mounts; may be empty |
+
+Workspace declarations do not create mounts. The future Workspace Lifecycle
+Specification defines install, enable, mount, disable, and removal behavior.
+
+### `integrity`
+
+The `integrity` object declares module artifact hashes:
+
+| Field | Type | Requirement |
+|---|---|---|
+| `artifacts` | array | Hashes for shipped module artifacts |
+
+Each artifact entry must include:
+
+| Field | Type | Requirement |
+|---|---|---|
+| `path` | string | Relative artifact path |
+| `kind` | string | `executable`, `library`, `asset`, or `metadata` |
+| `sha256` | string | 64-character lower-case hex SHA-256 |
+
+Artifact hashes are package evidence inputs. They are not trust classification.
+
+### `plugin_boundary`
+
+`plugin_boundary` is optional. If present, it must be declarative:
+
+| Field | Type | Requirement |
+|---|---|---|
+| `host_interfaces` | array | Host interfaces requested by the plugin |
+| `exports` | array | Interfaces exported by the module |
+
+This field does not load a plugin. The future Plugin Boundary Contract defines
+host admission and runtime behavior.
+
+### `semantic_surface`
+
+`semantic_surface` is optional. If present, it must explicitly remain
+advisory-only:
+
+```json
+{
+  "authority": "advisory_only",
+  "declares_execution_verdict": false
+}
+```
+
+Any semantic field that claims execution verdict authority must fail
+validation.
+
+### `extensions`
+
+`extensions` may carry non-authoritative metadata for experiments. It must not
+contain fields that affect install, enable, capability grant, trust
+classification, workspace access, plugin loading, semantic verdicts, or AI
+authority.
+
+## Trust Boundary
+
+Trust is intentionally not a manifest field.
+
+The following top-level fields are forbidden:
+
+1. `trust`
+2. `trust_level`
+3. `trusted`
+4. `verified`
+5. `review_status`
+6. `distribution_trust`
+
+Trust classification belongs to the future Trust Classification Model and to
+external registry/install receipts. A module must not self-certify trust.
+
+## Forbidden Authority Fields
+
+The manifest must fail validation if any top-level or nested field attempts to
+declare:
+
+1. New syscall IDs.
+2. Kernel ABI changes.
+3. Ring0 policy.
+4. Scheduler policy.
+5. IRQ/interrupt control.
+6. Capability grants or tokens.
+7. Trust classification.
+8. AI Runtime authority.
+9. Semantic execution verdict authority.
+
+## Minimal Valid Example
+
+```json
+{
+  "manifest_version": 1,
+  "schema_id": "ayken.platform.module.manifest.v1",
+  "module_id": "org.ayken.examples.echo",
+  "name": "echo",
+  "version": "0.1.0",
+  "module_kind": "tool",
+  "summary": "Echo text through a userspace module boundary.",
+  "entrypoints": [
+    {
+      "id": "echo-cli",
+      "kind": "cli",
+      "path": "bin/echo",
+      "abi": "ayken.platform.entrypoint.v1",
+      "default": true
+    }
+  ],
+  "platform": {
+    "platform_abi": "ayken.platform.module.v1",
+    "kernel_abi_floor": "syscall-v2-1000-1011"
+  },
+  "capability_requests": [
+    {
+      "id": "workspace.read",
+      "access": ["read"],
+      "scope": {
+        "workspace": "current"
+      },
+      "required": false,
+      "reason": "Read user-selected workspace input files."
+    }
+  ],
+  "workspace": {
+    "mode": "optional",
+    "declared_mounts": []
+  },
+  "integrity": {
+    "artifacts": [
+      {
+        "path": "bin/echo",
+        "kind": "executable",
+        "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      }
+    ]
+  },
+  "plugin_boundary": {
+    "host_interfaces": [],
+    "exports": []
+  }
+}
+```
+
+## Invalid Examples
+
+### Self-Granted Capability
+
+```json
+{
+  "capability_requests": [
+    {
+      "id": "workspace.write",
+      "grant": true
+    }
+  ]
+}
+```
+
+Reason: `grant` attempts to convert a request into authority.
+
+### Self-Declared Trust
+
+```json
+{
+  "trust_level": "trusted"
+}
+```
+
+Reason: trust classification is external to the manifest.
+
+### Kernel Expansion
+
+```json
+{
+  "syscalls": [1012]
+}
+```
+
+Reason: Phase-18 does not add syscalls.
+
+## Fail-Closed Validation Matrix
+
+| Condition | Validator result |
+|---|---|
+| Missing required field | FAIL |
+| Unknown top-level field | FAIL |
+| Duplicate JSON key | FAIL |
+| Unsupported `manifest_version` | FAIL |
+| Absolute or parent-relative path | FAIL |
+| Capability grant/token field present | FAIL |
+| Trust classification field present | FAIL |
+| Kernel/Ring0/syscall expansion field present | FAIL |
+| Semantic verdict authority present | FAIL |
+| AI Runtime authority present | FAIL |
+
+## Relationship To Future Specs
+
+| Future spec | Relationship |
+|---|---|
+| Package Metadata Schema | Owns publisher, signature, package digest, distribution channel |
+| Capability Contract Specification | Defines capability ids, grants, tokens, receipts, revocation |
+| Workspace Lifecycle Specification | Defines workspace states, mounts, enable/disable/remove behavior |
+| Trust Classification Model | Defines trusted/verified/signed/local/revoked classification |
+| Plugin Boundary Contract | Defines host admission, plugin loading, interface binding |
+| Platform ABI Validation Gate | Implements fail-closed schema and authority checks |
+
+## Activation Boundary
+
+This RFC draft is not sufficient to activate Phase-18. Phase-18 activation still
+requires an explicit `CURRENT_PHASE` pointer transition and acceptance of the
+remaining Platform Constitution contracts required by
+`PHASE18_TRANSITION_DECISION.md`.

--- a/docs/specs/phase18-platform-constitution/README.md
+++ b/docs/specs/phase18-platform-constitution/README.md
@@ -1,0 +1,44 @@
+# Phase-18 Platform Constitution Specs
+
+This directory is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, and `PHASE18_TRANSITION_DECISION.md`. In case of
+conflict, those documents prevail.
+
+**Status:** PRE-ACTIVATION SPEC SET / PHASE-18 NOT ACTIVATED
+**Authority basis:** `phase17-official-closure` at `416a5392`
+**Attribution:** Documentation metadata only; not runtime, merge, or execution
+authority.
+
+## Purpose
+
+This directory defines the Platform Constitution contracts that must exist
+before the ayken platform can safely accept modules, packages, workspaces,
+plugins, and later semantic systems above the frozen kernel execution
+substrate.
+
+These specs do not activate Phase-18 and do not change `CURRENT_PHASE=17`.
+
+## Current Specs
+
+1. `MODULE_MANIFEST_SCHEMA.md` - first RFC for the declarative module manifest.
+
+## Planned Specs
+
+1. Package Metadata Schema.
+2. Capability Contract Specification.
+3. Workspace Lifecycle Specification.
+4. Trust Classification Model.
+5. Plugin Boundary Contract.
+6. Platform ABI Validation Gate.
+
+## Non-Authority Rule
+
+No file in this directory may grant:
+
+1. New syscalls.
+2. Kernel ABI expansion.
+3. Ring0 policy authority.
+4. Capability tokens.
+5. Trust classification.
+6. AI Runtime authority.
+7. Semantic CLI execution verdict authority.


### PR DESCRIPTION
## Summary

- Adds the Phase-18 Platform Constitution spec directory.
- Drafts `MODULE_MANIFEST_SCHEMA.md` as the first pre-activation RFC for declarative module manifests.
- Updates roadmap, README, documentation index, and transition-decision references to point to the Module Manifest RFC while keeping `CURRENT_PHASE=17`.

## Authority Boundary

- Docs/spec only; no code or runtime changes.
- Does not activate Phase-18.
- Does not grant trust, capabilities, workspace access, plugin loading, semantic verdict authority, AI Runtime authority, or kernel/syscall expansion.

## Validation

- `git diff --check`
- `make ci-gate-spec-purity`
- `make ci-gate-naming-compliance`
- `python3 tools/ci/validate_phase17_closure_candidate.py --expected-subject-sha 416a5392afbe217e16d26a59e2e1716fdfa9c8f6`