### PR TITLE
docs: draft phase18 capability contract spec

### DIFF
--- a/PHASE18_TRANSITION_DECISION.md
+++ b/PHASE18_TRANSITION_DECISION.md
@@ -82,15 +82,16 @@ Required Platform Constitution outputs:
 1. Module manifest schema (`docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`).
 2. Package metadata schema.
 3. Workspace lifecycle contract.
-4. Capability contract for platform resources.
+4. Capability contract for platform resources (`docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`).
 5. Trust classification model.
 6. Plugin boundary contract.
 7. Platform ABI validation gate.
 8. Minimal reference examples that do not create new runtime authority.
 
-Initial pre-activation spec work starts with the Module Manifest Schema. This
-does not activate Phase-18 and does not grant package, capability, workspace,
-trust, plugin, semantic, or AI Runtime authority.
+Initial pre-activation spec work starts with the Module Manifest Schema and
+Capability Contract Specification. This does not activate Phase-18 and does not
+grant capability, package, workspace, trust, plugin, semantic, or AI Runtime
+authority.
 
 ## Non-Goals
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **Oluşturan:** Kenan AY
 **Düzenleyen / Geliştiren / Mimari Sorumlu:** Kenan AY *(bilgilendirme metadata'sı; runtime yetkisi değildir)*
 **Oluşturma Tarihi:** 01.01.2026
-**Son Güncelleme:** 31.05.2026
+**Son Güncelleme:** 01.06.2026
 **Closure Evidence:** `local-freeze-p10p11` + `local-phase11-closure` + `run-local-phase12c-closure-2026-03-11` + `run-local-p13-kill-switch-20260315T000051Z` + `phase15-official-closure` + `phase16-verification-layer-mvp-complete`
 **Evidence Git SHA (Phase-10/11):** `9cb2171b` | **Evidence Git SHA (Phase-12C):** `01d1cb5c` | **Evidence Git SHA (Phase-13):** `40158350` | **Evidence Git SHA (Phase-15):** `48970cd0` | **Evidence Git SHA (Phase-16):** `489868f8`
 **Closure Sync / Remote CI (Phase-10/11):** `fe9031d7` (`ci-freeze#22797401328 = success`)
@@ -25,7 +25,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **CURRENT_PHASE:** `17` (`Phase-17 OFFICIALLY CLOSED`; Phase-18 ayrı transition olmadan aktif değildir)
 **Freeze Zinciri:** `make ci-freeze` = 40 kapılı strict suite (normative spec-purity dahil) | `make ci-freeze-local` = local performance authority
 **Authority Durumu:** Issue #145 tek-maintainer authority kararıyla giderildi; PR #142, PR #144, PR #148, PR #149, PR #151, PR #150, PR #152 ve Phase-17 closure decision package birleşti. Closure exact-SHA kanıtı `main` SHA `416a5392` üzerinde yenilendi, gerekli uzak acceptance kontrolleri PASS verdi ve `phase17-official-closure` tag'i aynı SHA'ya doğrulandı
-**Yakın Hedef:** Phase-18 Platform Constitution RFC setini yazmak; ilk somut çıktı `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, explicit pointer transition olmadan Phase-18 aktive edilmez
+**Yakın Hedef:** Phase-18 Platform Constitution RFC setini yazmak; mevcut somut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md` ve `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, explicit pointer transition olmadan Phase-18 aktive edilmez
 **Ring0 Export Ceiling:** `193 symbols` (current enforced ceiling)
 **Performance Baseline Candidate:** `gha-ubuntu24-20260518.149.1-X64` (authorized run `26370359958` artifact'i PR'a import edildi; SHA `f129d4aa` locked acceptance PASS verdi, ancak tek basina closure authority değildir)
 **Development Status:** Phase-16 OFFICIALLY CLOSED ✅ | Phase-17 OFFICIALLY CLOSED ✅ | SINGLE-MAINTAINER AUTHORITY ALIGNED (#145 RESOLVED) ✅ | PR #142/#144/#148/#149/#151/#150/#152 + closure decision package MERGED ✅ | EXACT-SHA REMOTE EVIDENCE PASS ✅ | Phase-18 TRANSITION DECISION PACKAGE ONLY
@@ -68,7 +68,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 - **Evidence:** A, B, C karakterleri başarıyla syscall üzerinden basıldı
 - **Result:** Ring3 infrastructure PROVEN, syscall path WORKING, instruction retirement VALIDATED
 
-**Next Focus:** Phase-18 Platform Constitution RFC setini yazmak; ilk çıktı `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `CURRENT_PHASE` explicit pointer transition olmadan `18` yapılmayacaktır.
+**Next Focus:** Phase-18 Platform Constitution RFC setini yazmak; mevcut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md` ve `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `CURRENT_PHASE` explicit pointer transition olmadan `18` yapılmayacaktır.
 
 ## Authority Model
 
@@ -311,6 +311,7 @@ Phase 12 trust layer kapsamında tamamlananlar:
 - **Active Execution Roadmap:** `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`
 - **Phase-18 Transition Decision:** `PHASE18_TRANSITION_DECISION.md`
 - **Phase-18 Module Manifest Schema:** `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`
+- **Phase-18 Capability Contract Specification:** `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`
 - **Documentation Index:** `docs/development/DOCUMENTATION_INDEX.md`
 - **Ring3 User-Leaf Rule:** `docs/governance/RING3_USER_LEAF_ALLOCATION_RULE.md`
 - **Ring3 Runtime Closure Note:** `docs/governance/RING3_RUNTIME_CLOSURE_NOTE.md`
@@ -341,9 +342,9 @@ AykenOS iki lisans modeli ile dağıtılır:
 - `CURRENT_PHASE` transition decision; explicit pointer update olmadan Phase-18 aktive edilmez.
 - Platform ABI schema draft.
 - Module manifest schema RFC draft: `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`.
+- Capability contract RFC draft: `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`.
 - Package metadata schema draft.
 - Workspace lifecycle contract draft.
-- Capability contract draft.
 - Trust classification validation gate; trust level capability grant degildir.
 - Plugin boundary contract draft.
 
@@ -360,7 +361,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 
 ---
 
-**Son Güncelleme:** 31 Mayıs 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=17; issue #145 çözüldü; PR #142/#144/#148/#149/#151/#150/#152 ve closure decision package kabul edildi; bounded Phase-17 uzak evidence ve strict freeze PASS verdi; Phase-18 Platform Constitution transition decision package olarak değerlendirilmektedir ve explicit transition olmadan aktif değildir.
+**Son Güncelleme:** 01 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=17; Module Manifest ve Capability Contract RFC draft'lari Phase-18 Platform Constitution pre-activation setine eklendi; explicit transition olmadan Phase-18 aktif değildir.
 **Düzenleyen / Geliştiren / Oluşturan / Mimari Sorumlu:** Kenan AY *(metadata only; runtime/karar yetkisi değildir).*
 
 **© 2026 Kenan AY — AykenOS Project**

--- a/docs/development/DOCUMENTATION_INDEX.md
+++ b/docs/development/DOCUMENTATION_INDEX.md
@@ -1,7 +1,7 @@
 # AykenOS Documentation Index
 This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict, Phase 0 prevails.
 
-**Last Updated:** 2026-05-31
+**Last Updated:** 2026-06-01
 **Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu:** Kenan AY
 **Attribution Boundary:** Human-readable documentation metadata only; not runtime authority or execution evidence.
 **Current Authority Basis:** `phase17-official-closure` + `CURRENT_PHASE=17` + `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`
@@ -17,7 +17,7 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict
 - **Execution Pipeline:** `Phase-17` officially closed — tag `phase17-official-closure` at `416a5392`
 - **Formal Governance Pointer:** `CURRENT_PHASE=17`
 - **Active Phase:** Phase-17 OFFICIALLY CLOSED / Phase-18 TRANSITION NOT ACTIVATED
-- **Active Execution Priority:** Draft the Phase-18 Platform Constitution RFC set, starting with `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`
+- **Active Execution Priority:** Draft the Phase-18 Platform Constitution RFC set, currently `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md` and `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`
 - **Scope Boundary:** Phase-18 is not active until an explicit `CURRENT_PHASE` pointer transition; kernel expansion, new syscalls, Ring0 policy and AI Runtime authority remain forbidden for Phase-18
 
 ## Primary Truth Sources
@@ -35,14 +35,15 @@ Current repo truth icin once su dosyalari referans alin:
 10. `reports/phase17_official_closure_candidate/closure_index.json`
 11. `PHASE18_TRANSITION_DECISION.md` — **Phase-18 Platform Constitution transition package; not active pointer**
 12. `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md` — **first pre-activation Platform Constitution RFC draft**
-13. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
-14. `reports/phase15_official_closure/closure_index.json`
-15. `reports/phase13_official_closure_candidate/closure_index.json`
-16. `reports/phase12_official_closure_candidate/closure_manifest.json`
-17. `reports/phase10_phase11_official_closure_index.json`
-18. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
-19. `Makefile`
-20. `.github/workflows/ci-freeze.yml`
+13. `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md` — **capability request/decision/receipt/revocation RFC draft**
+14. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
+15. `reports/phase15_official_closure/closure_index.json`
+16. `reports/phase13_official_closure_candidate/closure_index.json`
+17. `reports/phase12_official_closure_candidate/closure_manifest.json`
+18. `reports/phase10_phase11_official_closure_index.json`
+19. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
+20. `Makefile`
+21. `.github/workflows/ci-freeze.yml`
 
 Phase-14 workstream numbering ve aktif durum yorumu icin canonical truth source:
 
@@ -77,18 +78,20 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 6. `PHASE18_TRANSITION_DECISION.md` — transition package only
 7. `docs/specs/phase18-platform-constitution/README.md` — Phase-18 spec set index
 8. `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`
-9. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
-10. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
-11. `docs/specs/phase16-ayken-orchestration/README.md`
-12. `docs/specs/authority-lineage-v1/README.md`
-13. `docs/specs/phase14-distributed-observability/README.md`
-14. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
-15. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
+9. `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`
+10. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
+11. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
+12. `docs/specs/phase16-ayken-orchestration/README.md`
+13. `docs/specs/authority-lineage-v1/README.md`
+14. `docs/specs/phase14-distributed-observability/README.md`
+15. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
+16. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
 
 ## Phase-18 Reference Set
 1. `PHASE18_TRANSITION_DECISION.md`
 2. `docs/specs/phase18-platform-constitution/README.md`
 3. `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`
+4. `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`
 
 ## Phase-14 Reference Set
 ### Architecture and Observability Surfaces

--- a/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
+++ b/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
@@ -374,6 +374,7 @@ Phase-18 transition su kararlari korumadan aktif uygulama planina donusemez:
 | Phase-17 closure decision package | OFFICIAL CLOSURE CONFIRMED / PHASE-18 NOT ACTIVATED | Exact-SHA PASS kanitlarini verified official tag subject karar kaydina baglamak | Candidate manifest/index, decision record ve status docs | Candidate integrity + verified tag target; Phase-18 ayridir |
 | Phase-18 transition decision package | DOCS-ONLY / PHASE-18 NOT ACTIVATED | Phase-18'i Platform Constitution olarak sinirlamak | `PHASE18_TRANSITION_DECISION.md`, roadmap/index/current status sync | Kernel expansion/new syscall/AI authority forbidden; explicit pointer transition gerekir |
 | Phase-18 Module Manifest Schema | DOCS-ONLY / PRE-ACTIVATION RFC | Modülün kimlik, entrypoint, artifact ve capability request beyanini fail-closed tanimlamak | `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md` | Capability/trust/workspace authority grant yok; unknown fields fail-closed |
+| Phase-18 Capability Contract Specification | DOCS-ONLY / PRE-ACTIVATION RFC | Capability request, authorization decision, receipt ve revocation sinirlarini fail-closed tanimlamak | `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md` | Manifest self-grant yok; trust capability grant degil; token/receipt ayrimi korunur |
 
 PR koordinasyon kurallari:
 
@@ -1052,7 +1053,8 @@ Bu roadmap su olaylarda guncellenir:
 16. Phase-17 closure candidate exact-SHA refresh review/merge sonucu ve official tag-subject karari.
 17. Phase-18 Platform Constitution transition decision review/merge sonucu.
 18. Phase-18 Module Manifest Schema review/merge sonucu.
-19. Yeni feature/ABI/authority surface onerisinin incelenmesi.
+19. Phase-18 Capability Contract Specification review/merge sonucu.
+20. Yeni feature/ABI/authority surface onerisinin incelenmesi.
 
 ## References
 
@@ -1071,6 +1073,9 @@ Bu roadmap su olaylarda guncellenir:
 - `reports/phase17_official_closure_candidate/closure_manifest.json`
 - `reports/phase17_official_closure_candidate/evidence_index.json`
 - `PHASE18_TRANSITION_DECISION.md`
+- `docs/specs/phase18-platform-constitution/README.md`
+- `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`
+- `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`
 - `PHASE18_ROADMAP.md`
 - `shared/abi/syscall_v2.h`
 - `shared/abi/ayken_abi.h`

--- a/docs/roadmap/CURRENT_PHASE
+++ b/docs/roadmap/CURRENT_PHASE
@@ -7,5 +7,5 @@ CURRENT_PHASE=17
 # Proposed Phase-18 direction: Platform Constitution, not kernel expansion.
 # Active execution roadmap: docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
 # Remote evidence: ci-freeze 26712333892, Performance Gate 26715068398, Phase-17 lifecycle/determinism/public-e2e/worker/timeout/performance lanes all PASS on 416a5392.
-# Immediate work package: draft Phase-18 Platform Constitution specs starting with docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md; do not activate Phase-18 without an explicit pointer transition.
+# Immediate work package: draft Phase-18 Platform Constitution specs starting with docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md and docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md; do not activate Phase-18 without an explicit pointer transition.
 # Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu: Kenan AY (informational metadata only).

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -22,7 +22,10 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
    transition package; aktif faz pointer'i degildir.
 7. `../specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`:
    ilk Phase-18 Platform Constitution RFC draft'i; authority grant degildir.
-8. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
+8. `../specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`:
+   capability request, decision, receipt ve revocation RFC draft'i; token veya
+   trust grant degildir.
+9. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
    planlamasi; aktif Phase-18 otoritesi degildir.
 
 ## Current Status
@@ -31,7 +34,7 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 |---|---|
 | Son resmi kapanis | Phase-17 OFFICIALLY CLOSED (`phase17-official-closure` at `416a5392`) |
 | Aktif faz | Phase-17 OFFICIALLY CLOSED / Phase-18 transition not activated |
-| Aktif odak | Phase-18 Platform Constitution RFC set; first draft is Module Manifest Schema; no activation without explicit pointer transition |
+| Aktif odak | Phase-18 Platform Constitution RFC set; Module Manifest Schema and Capability Contract drafts; no activation without explicit pointer transition |
 | ABI | Canonical `1000-1011` / 12 syscall, ABI version `0x00010001` |
 | Phase-18 | TRANSITION DECISION PACKAGE ONLY; kernel expansion and new syscalls forbidden unless a separate phase RFC/closure authority exists |
 
@@ -60,6 +63,6 @@ current execution priority otoritesi degildir:
 
 ---
 
-**Next action:** `../specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`
-RFC draft'i review edilir; Capability Contract ve Workspace Lifecycle spec'leri
-gelmeden `CURRENT_PHASE` explicit pointer transition ile `18` yapilmaz.
+**Next action:** `../specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`
+RFC draft'i review edilir; Workspace Lifecycle spec'i gelmeden `CURRENT_PHASE`
+explicit pointer transition ile `18` yapilmaz.

--- a/docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md
+++ b/docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md
@@ -1,0 +1,515 @@
+# Phase-18 Capability Contract Specification
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, `PHASE18_TRANSITION_DECISION.md`, and
+`MODULE_MANIFEST_SCHEMA.md`. In case of conflict, those documents prevail.
+
+**Status:** RFC-DRAFT / PRE-ACTIVATION SPEC
+**Contract id:** `ayken.platform.capability.contract.v1`
+**Authority boundary:** Documentation/specification only; not a runtime
+capability issuer, not a kernel token format, not a trust grant, and not
+Phase-18 activation.
+
+## Purpose
+
+The capability contract answers the second Phase-18 Platform Constitution
+question:
+
+How does a module request platform access, receive an explicit authorization
+decision, and remain revocable without self-granting authority or expanding
+the frozen kernel ABI?
+
+The module manifest declares `capability_requests`. This specification defines
+what those requests mean, how they must be evaluated, what a decision may
+record, and which authority surfaces remain out of scope.
+
+## Non-Goals
+
+This contract does not define:
+
+1. A new syscall.
+2. A new kernel capability token layout.
+3. A runtime token issuer implementation.
+4. A package registry.
+5. A workspace mount implementation.
+6. Trust classification policy.
+7. Semantic CLI execution verdict authority.
+8. AI Runtime authority.
+
+## Core Rule
+
+A capability request is not authority. A trust level is not authority. A
+receipt is not authority. Runtime access requires an explicit capability
+authorization decision and a future runtime binding that remains subordinate to
+the frozen kernel ABI.
+
+The following invariants are mandatory:
+
+1. Modules may request capabilities only through the manifest contract.
+2. A manifest must never contain granted capabilities, bearer tokens, or
+   trust status.
+3. Unknown capability ids fail closed.
+4. Unknown access verbs fail closed.
+5. Missing or ambiguous scope fails closed.
+6. Trust classification may affect review path only; it must not grant
+   capability.
+7. Platform capability decisions must not require kernel ABI expansion.
+8. Revocation must be representable for every positive authorization decision.
+
+## Relationship To Existing Kernel Capability Mechanism
+
+The existing syscall v2 kernel capability path is the frozen mechanism layer.
+The Platform Constitution capability contract is the userspace policy and
+admission layer above it.
+
+| Layer | Role | Phase-18 rule |
+|---|---|---|
+| Kernel ABI | Frozen syscall v2 mechanism, including capability bind/revoke | Must not expand |
+| Platform capability request | Manifest-declared access request | Must not grant access |
+| Platform authorization decision | Reviewed policy outcome | Must remain external to manifest |
+| Runtime token or binding | Future runtime implementation detail | Must use existing ABI or a later separate phase decision |
+| Receipt | Evidence that a decision was made | Must not be a bearer token |
+
+This contract may reference the existing mechanism. It must not redefine the
+kernel ABI, add syscalls, or turn a platform decision record into a direct
+kernel handle.
+
+## Capability Request Object
+
+The `capability_requests` entries in `ayken.module.json` use this shape:
+
+| Field | Type | Requirement |
+|---|---|---|
+| `id` | string | Capability id from an accepted registry |
+| `access` | array | Requested access verbs |
+| `scope` | object | Requested resource scope |
+| `required` | boolean | Whether denial blocks enablement |
+| `reason` | string | Human-readable justification |
+
+Unknown fields in a capability request fail validation.
+
+### `id`
+
+The capability id must be lower-case and namespace-qualified:
+
+```text
+^[a-z][a-z0-9]*(\.[a-z][a-z0-9-]*){2,}$
+```
+
+Examples:
+
+```text
+ayken.platform.workspace.read
+ayken.platform.workspace.write
+ayken.platform.plugin.invoke
+ayken.platform.observation.read
+```
+
+Phase-18 reserves the following segments. They must not appear in capability
+ids unless a later reviewed phase explicitly reopens one of them:
+
+1. `kernel`
+2. `ring0`
+3. `syscall`
+4. `driver`
+5. `root`
+6. `admin`
+7. `authority`
+8. `verdict`
+9. `trust`
+10. `trusted`
+11. `verified`
+12. `token`
+13. `grant`
+14. `ai-runtime`
+15. `semantic-verdict`
+
+### `access`
+
+`access` is an array of lower-case verbs. The initial common verb set is:
+
+| Verb | Meaning |
+|---|---|
+| `read` | Inspect an allowed resource |
+| `write` | Modify an allowed resource |
+| `create` | Create a resource inside an allowed scope |
+| `delete` | Remove a resource inside an allowed scope |
+| `execute` | Run an allowed userspace entrypoint |
+| `invoke` | Call an allowed plugin or service interface |
+| `observe` | Read non-authoritative diagnostic state |
+
+The accepted capability registry may restrict verbs per capability id. A verb
+not accepted for the requested id fails closed.
+
+The following verbs are forbidden in Phase-18:
+
+1. `kernel`
+2. `ring0`
+3. `syscall`
+4. `admin`
+5. `root`
+6. `authority`
+7. `verdict`
+8. `grant`
+9. `trust`
+10. `token`
+
+### `scope`
+
+`scope` limits the requested resource. It must be a JSON object:
+
+| Field | Type | Requirement |
+|---|---|---|
+| `kind` | string | Scope kind |
+| `selector` | string | Stable selector within that scope |
+| `constraints` | object | Additional least-privilege constraints |
+
+Unknown fields in `scope` fail validation.
+
+Initial scope kinds:
+
+| Kind | Meaning |
+|---|---|
+| `workspace` | Workspace-local resource selected by the future workspace contract |
+| `package` | Package metadata or package-local artifact surface |
+| `module` | Same-module declared artifact or entrypoint surface |
+| `plugin_host` | Future plugin host interface boundary |
+| `platform_observation` | Non-authoritative diagnostic or status surface |
+
+The scope must be specific enough for review. The selector `*` is forbidden in
+Phase-18. Empty selectors fail validation.
+
+`constraints` must be a JSON object. Empty constraints are allowed only when
+the capability registry explicitly marks the capability as scope-complete
+without extra constraints.
+
+### `required`
+
+If `required` is `true`, denial of the capability must block module enablement.
+If `required` is `false`, denial must disable only the dependent feature path.
+
+A module must not use `required=false` to hide an authority dependency. If an
+entrypoint cannot run correctly without the capability, the request must be
+required.
+
+### `reason`
+
+`reason` must describe why the module needs the capability. Empty, generic, or
+misleading reasons fail review. The reason is review metadata only and does not
+grant authority.
+
+## Authorization Decision Record
+
+A capability authorization decision is external to the manifest. It may be
+stored by a future package/workspace/runtime layer, but the manifest must not
+embed it.
+
+A decision record must include at least:
+
+| Field | Type | Requirement |
+|---|---|---|
+| `contract_id` | string | Must be `ayken.platform.capability.contract.v1` |
+| `module_id` | string | Module subject |
+| `module_version` | string | Module version subject |
+| `request_index` | integer | Index of the manifest request |
+| `request_digest` | string | Digest of the canonical request object |
+| `decision` | string | `approved`, `denied`, `quarantined`, or `revoked` |
+| `effective_scope` | object | Scope accepted by policy |
+| `policy_digest` | string | Digest of the policy input set |
+| `review_mode` | string | `automatic`, `manual`, or `blocked` |
+| `expires_at` | string | Timestamp or `never` |
+| `revocation_epoch` | integer | Monotonic revocation epoch |
+
+The effective scope must be equal to or narrower than the requested scope. A
+decision must fail closed if the policy layer cannot prove that narrowing.
+
+Decision records must not include:
+
+1. Runtime bearer tokens.
+2. Kernel handles.
+3. Raw syscall arguments.
+4. Private signing keys.
+5. Trust self-declarations.
+6. AI or semantic execution verdicts.
+
+## Decision Lifecycle
+
+The decision lifecycle is:
+
+```text
+requested -> evaluated -> approved
+                       -> denied
+                       -> quarantined
+approved -> active
+approved -> expired
+approved -> revoked
+active -> suspended
+active -> revoked
+suspended -> active
+suspended -> revoked
+```
+
+Rules:
+
+1. `requested` comes only from a validated manifest request.
+2. `evaluated` requires accepted registry, policy, trust, package, and
+   workspace inputs.
+3. `approved` records authorization only; it does not mint a runtime token.
+4. `active` is a future runtime state and must not be claimed by the manifest.
+5. `expired`, `suspended`, and `revoked` must deny future access by default.
+6. Unknown lifecycle states fail closed.
+
+## Receipt Boundary
+
+A capability receipt is evidence that a decision occurred. It is not a bearer
+token and must not authorize access by itself.
+
+A receipt may include:
+
+| Field | Type | Requirement |
+|---|---|---|
+| `receipt_id` | string | Stable receipt id |
+| `decision_digest` | string | Digest of the authorization decision |
+| `module_id` | string | Module subject |
+| `capability_id` | string | Capability subject |
+| `decision` | string | Decision result |
+| `issued_at` | string | Receipt creation time |
+| `evidence_refs` | array | Non-authoritative evidence references |
+
+A receipt must not include:
+
+1. Token material.
+2. Secret material.
+3. Direct kernel capability ids.
+4. A claim that trust grants capability.
+5. A semantic or AI-generated verdict as authority.
+
+## Revocation Contract
+
+Every approved capability must be revocable.
+
+Revocation may be triggered by:
+
+1. Explicit user or maintainer action.
+2. Package update.
+3. Manifest digest change.
+4. Workspace removal or policy change.
+5. Trust downgrade or quarantine.
+6. Capability registry withdrawal.
+7. Expiration.
+8. Evidence invalidation.
+
+Revocation effects:
+
+1. Future evaluation must deny access.
+2. Future runtime token issuance must stop.
+3. Existing future runtime bindings must be revoked by the runtime layer.
+4. Receipts remain historical evidence, but no longer imply active access.
+5. Failure to apply revocation must fail closed.
+
+Trust downgrade may trigger revocation review. Trust downgrade does not prove a
+capability violation by itself, and trust upgrade does not restore capability
+by itself.
+
+## Trust Boundary
+
+Trust level does not grant capability.
+
+Trust classification may affect:
+
+1. Whether review is automatic or manual.
+2. Whether installation is allowed.
+3. Whether enablement is allowed.
+4. Whether updates are accepted.
+5. Whether quarantine is required.
+6. Whether revocation review is triggered.
+
+Trust classification must not:
+
+1. Add access verbs.
+2. Widen scope.
+3. Create tokens.
+4. Bypass registry policy.
+5. Bypass workspace policy.
+6. Bypass kernel capability checks.
+
+## Registry Boundary
+
+This specification defines the contract shape, not the final capability
+registry. A future Platform ABI Validation Gate must reject requests whose ids
+are absent from the accepted registry.
+
+Initial registry entries should define:
+
+1. Capability id.
+2. Allowed access verbs.
+3. Allowed scope kinds.
+4. Required scope constraints.
+5. Whether manual review is required.
+6. Whether the capability is workspace-bound.
+7. Whether revocation requires runtime cleanup.
+
+Registry entries must not authorize kernel ABI expansion.
+
+## Valid Request Example
+
+```json
+{
+  "id": "ayken.platform.workspace.read",
+  "access": ["read"],
+  "scope": {
+    "kind": "workspace",
+    "selector": "current.project.documents",
+    "constraints": {
+      "recursive": false,
+      "write": false
+    }
+  },
+  "required": true,
+  "reason": "Read declared project documents for the module entrypoint."
+}
+```
+
+This example is a request only. It does not grant workspace access.
+
+## Valid Decision Example
+
+```json
+{
+  "contract_id": "ayken.platform.capability.contract.v1",
+  "module_id": "org.ayken.examples.echo",
+  "module_version": "1.0.0",
+  "request_index": 0,
+  "request_digest": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "decision": "approved",
+  "effective_scope": {
+    "kind": "workspace",
+    "selector": "current.project.documents",
+    "constraints": {
+      "recursive": false,
+      "write": false
+    }
+  },
+  "policy_digest": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+  "review_mode": "manual",
+  "expires_at": "never",
+  "revocation_epoch": 0
+}
+```
+
+This example records a decision only. It is not a runtime token.
+
+## Invalid Examples
+
+### Self-Granted Capability
+
+```json
+{
+  "id": "ayken.platform.workspace.read",
+  "access": ["read"],
+  "scope": {
+    "kind": "workspace",
+    "selector": "current.project.documents",
+    "constraints": {}
+  },
+  "required": true,
+  "reason": "Needed by entrypoint.",
+  "grant": true
+}
+```
+
+Invalid because a manifest request contains `grant`.
+
+### Trust As Capability
+
+```json
+{
+  "id": "ayken.platform.workspace.write",
+  "access": ["write"],
+  "scope": {
+    "kind": "workspace",
+    "selector": "current.project",
+    "constraints": {}
+  },
+  "required": true,
+  "reason": "Trusted modules can write.",
+  "trusted": true
+}
+```
+
+Invalid because trust metadata appears in a capability request and is treated as
+authority.
+
+### Kernel Expansion Request
+
+```json
+{
+  "id": "ayken.platform.kernel.syscall",
+  "access": ["syscall"],
+  "scope": {
+    "kind": "kernel",
+    "selector": "1000-1011",
+    "constraints": {}
+  },
+  "required": true,
+  "reason": "Need direct syscall authority."
+}
+```
+
+Invalid because Phase-18 cannot request kernel, syscall, or Ring0 authority.
+
+### Wildcard Scope
+
+```json
+{
+  "id": "ayken.platform.workspace.read",
+  "access": ["read"],
+  "scope": {
+    "kind": "workspace",
+    "selector": "*",
+    "constraints": {}
+  },
+  "required": true,
+  "reason": "Read everything."
+}
+```
+
+Invalid because wildcard scope is forbidden.
+
+## Fail-Closed Matrix
+
+| Condition | Required result |
+|---|---|
+| Unknown capability id | Deny |
+| Unknown access verb | Deny |
+| Forbidden reserved segment | Deny |
+| Missing scope | Deny |
+| Wildcard scope | Deny |
+| Effective scope wider than request | Deny |
+| Manifest contains token/grant/trust | Reject manifest |
+| Decision references kernel ABI expansion | Reject decision |
+| Receipt used as bearer token | Reject access |
+| Revocation state unknown | Deny |
+| Trust level treated as capability | Deny |
+| AI or semantic verdict used as authority | Deny |
+
+## Relationship To Other Phase-18 Specs
+
+1. `MODULE_MANIFEST_SCHEMA.md` defines where requests are declared.
+2. Package Metadata Schema will bind request and artifact digests to a package.
+3. Workspace Lifecycle Specification will define workspace selectors and mount
+   lifecycle.
+4. Trust Classification Model will define review inputs, not authority.
+5. Plugin Boundary Contract will define plugin host interface capability ids.
+6. Platform ABI Validation Gate will enforce registry, request, decision, and
+   receipt invariants.
+
+## Activation Boundary
+
+This RFC is not sufficient to activate Phase-18. Phase-18 activation still
+requires an explicit `CURRENT_PHASE` pointer transition and reviewed acceptance
+of the required Platform Constitution set.
+
+This RFC does not authorize implementation work that widens the kernel ABI,
+adds syscalls, places policy in Ring0, or makes semantic/AI systems execution
+authority.

--- a/docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md
+++ b/docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md
@@ -322,10 +322,15 @@ declare:
   },
   "capability_requests": [
     {
-      "id": "workspace.read",
+      "id": "ayken.platform.workspace.read",
       "access": ["read"],
       "scope": {
-        "workspace": "current"
+        "kind": "workspace",
+        "selector": "current.project.input",
+        "constraints": {
+          "recursive": false,
+          "write": false
+        }
       },
       "required": false,
       "reason": "Read user-selected workspace input files."
@@ -359,7 +364,7 @@ declare:
 {
   "capability_requests": [
     {
-      "id": "workspace.write",
+      "id": "ayken.platform.workspace.write",
       "grant": true
     }
   ]
@@ -408,7 +413,7 @@ Reason: Phase-18 does not add syscalls.
 | Future spec | Relationship |
 |---|---|
 | Package Metadata Schema | Owns publisher, signature, package digest, distribution channel |
-| Capability Contract Specification | Defines capability ids, grants, tokens, receipts, revocation |
+| `CAPABILITY_CONTRACT_SPECIFICATION.md` | Defines request, decision, receipt, and revocation boundaries |
 | Workspace Lifecycle Specification | Defines workspace states, mounts, enable/disable/remove behavior |
 | Trust Classification Model | Defines trusted/verified/signed/local/revoked classification |
 | Plugin Boundary Contract | Defines host admission, plugin loading, interface binding |

--- a/docs/specs/phase18-platform-constitution/README.md
+++ b/docs/specs/phase18-platform-constitution/README.md
@@ -21,15 +21,16 @@ These specs do not activate Phase-18 and do not change `CURRENT_PHASE=17`.
 ## Current Specs
 
 1. `MODULE_MANIFEST_SCHEMA.md` - first RFC for the declarative module manifest.
+2. `CAPABILITY_CONTRACT_SPECIFICATION.md` - RFC for request, decision,
+   receipt, and revocation boundaries.
 
 ## Planned Specs
 
 1. Package Metadata Schema.
-2. Capability Contract Specification.
-3. Workspace Lifecycle Specification.
-4. Trust Classification Model.
-5. Plugin Boundary Contract.
-6. Platform ABI Validation Gate.
+2. Workspace Lifecycle Specification.
+3. Trust Classification Model.
+4. Plugin Boundary Contract.
+5. Platform ABI Validation Gate.
 
 ## Non-Authority Rule
 


### PR DESCRIPTION
Docs-only Phase-18 Platform Constitution RFC. Adds Capability Contract Specification for request, authorization decision, receipt, and revocation boundaries. Keeps CURRENT_PHASE=17 and does not grant capability/runtime/kernel authority. Local checks: git diff --check; make ci-gate-spec-purity; make ci-gate-naming-compliance; phase17 closure validator PASS.