### PR TITLE
docs: draft phase18 workspace lifecycle spec

### DIFF
--- a/PHASE18_TRANSITION_DECISION.md
+++ b/PHASE18_TRANSITION_DECISION.md
@@ -81,17 +81,17 @@ Required Platform Constitution outputs:
 
 1. Module manifest schema (`docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`).
 2. Package metadata schema.
-3. Workspace lifecycle contract.
+3. Workspace lifecycle contract (`docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`).
 4. Capability contract for platform resources (`docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`).
 5. Trust classification model.
 6. Plugin boundary contract.
 7. Platform ABI validation gate.
 8. Minimal reference examples that do not create new runtime authority.
 
-Initial pre-activation spec work starts with the Module Manifest Schema and
-Capability Contract Specification. This does not activate Phase-18 and does not
-grant capability, package, workspace, trust, plugin, semantic, or AI Runtime
-authority.
+Initial pre-activation spec work starts with the Module Manifest Schema,
+Capability Contract Specification, and Workspace Lifecycle Specification. This
+does not activate Phase-18 and does not grant capability, package, workspace,
+trust, plugin, semantic, or AI Runtime authority.
 
 ## Non-Goals
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **CURRENT_PHASE:** `17` (`Phase-17 OFFICIALLY CLOSED`; Phase-18 ayrı transition olmadan aktif değildir)
 **Freeze Zinciri:** `make ci-freeze` = 40 kapılı strict suite (normative spec-purity dahil) | `make ci-freeze-local` = local performance authority
 **Authority Durumu:** Issue #145 tek-maintainer authority kararıyla giderildi; PR #142, PR #144, PR #148, PR #149, PR #151, PR #150, PR #152 ve Phase-17 closure decision package birleşti. Closure exact-SHA kanıtı `main` SHA `416a5392` üzerinde yenilendi, gerekli uzak acceptance kontrolleri PASS verdi ve `phase17-official-closure` tag'i aynı SHA'ya doğrulandı
-**Yakın Hedef:** Phase-18 Platform Constitution RFC setini yazmak; mevcut somut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md` ve `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, explicit pointer transition olmadan Phase-18 aktive edilmez
+**Yakın Hedef:** Phase-18 Platform Constitution RFC setini yazmak; mevcut somut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md` ve `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, explicit pointer transition olmadan Phase-18 aktive edilmez
 **Ring0 Export Ceiling:** `193 symbols` (current enforced ceiling)
 **Performance Baseline Candidate:** `gha-ubuntu24-20260518.149.1-X64` (authorized run `26370359958` artifact'i PR'a import edildi; SHA `f129d4aa` locked acceptance PASS verdi, ancak tek basina closure authority değildir)
 **Development Status:** Phase-16 OFFICIALLY CLOSED ✅ | Phase-17 OFFICIALLY CLOSED ✅ | SINGLE-MAINTAINER AUTHORITY ALIGNED (#145 RESOLVED) ✅ | PR #142/#144/#148/#149/#151/#150/#152 + closure decision package MERGED ✅ | EXACT-SHA REMOTE EVIDENCE PASS ✅ | Phase-18 TRANSITION DECISION PACKAGE ONLY
@@ -68,7 +68,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 - **Evidence:** A, B, C karakterleri başarıyla syscall üzerinden basıldı
 - **Result:** Ring3 infrastructure PROVEN, syscall path WORKING, instruction retirement VALIDATED
 
-**Next Focus:** Phase-18 Platform Constitution RFC setini yazmak; mevcut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md` ve `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `CURRENT_PHASE` explicit pointer transition olmadan `18` yapılmayacaktır.
+**Next Focus:** Phase-18 Platform Constitution RFC setini yazmak; mevcut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md` ve `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, `CURRENT_PHASE` explicit pointer transition olmadan `18` yapılmayacaktır.
 
 ## Authority Model
 
@@ -312,6 +312,7 @@ Phase 12 trust layer kapsamında tamamlananlar:
 - **Phase-18 Transition Decision:** `PHASE18_TRANSITION_DECISION.md`
 - **Phase-18 Module Manifest Schema:** `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`
 - **Phase-18 Capability Contract Specification:** `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`
+- **Phase-18 Workspace Lifecycle Specification:** `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`
 - **Documentation Index:** `docs/development/DOCUMENTATION_INDEX.md`
 - **Ring3 User-Leaf Rule:** `docs/governance/RING3_USER_LEAF_ALLOCATION_RULE.md`
 - **Ring3 Runtime Closure Note:** `docs/governance/RING3_RUNTIME_CLOSURE_NOTE.md`
@@ -343,8 +344,8 @@ AykenOS iki lisans modeli ile dağıtılır:
 - Platform ABI schema draft.
 - Module manifest schema RFC draft: `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`.
 - Capability contract RFC draft: `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`.
+- Workspace lifecycle contract RFC draft: `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`.
 - Package metadata schema draft.
-- Workspace lifecycle contract draft.
 - Trust classification validation gate; trust level capability grant degildir.
 - Plugin boundary contract draft.
 
@@ -361,7 +362,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 
 ---
 
-**Son Güncelleme:** 01 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=17; Module Manifest ve Capability Contract RFC draft'lari Phase-18 Platform Constitution pre-activation setine eklendi; explicit transition olmadan Phase-18 aktif değildir.
+**Son Güncelleme:** 01 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=17; Module Manifest, Capability Contract ve Workspace Lifecycle RFC draft'lari Phase-18 Platform Constitution pre-activation setine eklendi; explicit transition olmadan Phase-18 aktif değildir.
 **Düzenleyen / Geliştiren / Oluşturan / Mimari Sorumlu:** Kenan AY *(metadata only; runtime/karar yetkisi değildir).*
 
 **© 2026 Kenan AY — AykenOS Project**

--- a/docs/development/DOCUMENTATION_INDEX.md
+++ b/docs/development/DOCUMENTATION_INDEX.md
@@ -17,7 +17,7 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict
 - **Execution Pipeline:** `Phase-17` officially closed — tag `phase17-official-closure` at `416a5392`
 - **Formal Governance Pointer:** `CURRENT_PHASE=17`
 - **Active Phase:** Phase-17 OFFICIALLY CLOSED / Phase-18 TRANSITION NOT ACTIVATED
-- **Active Execution Priority:** Draft the Phase-18 Platform Constitution RFC set, currently `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md` and `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`
+- **Active Execution Priority:** Draft the Phase-18 Platform Constitution RFC set, currently `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, and `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`
 - **Scope Boundary:** Phase-18 is not active until an explicit `CURRENT_PHASE` pointer transition; kernel expansion, new syscalls, Ring0 policy and AI Runtime authority remain forbidden for Phase-18
 
 ## Primary Truth Sources
@@ -36,14 +36,15 @@ Current repo truth icin once su dosyalari referans alin:
 11. `PHASE18_TRANSITION_DECISION.md` — **Phase-18 Platform Constitution transition package; not active pointer**
 12. `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md` — **first pre-activation Platform Constitution RFC draft**
 13. `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md` — **capability request/decision/receipt/revocation RFC draft**
-14. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
-15. `reports/phase15_official_closure/closure_index.json`
-16. `reports/phase13_official_closure_candidate/closure_index.json`
-17. `reports/phase12_official_closure_candidate/closure_manifest.json`
-18. `reports/phase10_phase11_official_closure_index.json`
-19. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
-20. `Makefile`
-21. `.github/workflows/ci-freeze.yml`
+14. `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md` — **workspace admission/logical-mount lifecycle RFC draft**
+15. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
+16. `reports/phase15_official_closure/closure_index.json`
+17. `reports/phase13_official_closure_candidate/closure_index.json`
+18. `reports/phase12_official_closure_candidate/closure_manifest.json`
+19. `reports/phase10_phase11_official_closure_index.json`
+20. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
+21. `Makefile`
+22. `.github/workflows/ci-freeze.yml`
 
 Phase-14 workstream numbering ve aktif durum yorumu icin canonical truth source:
 
@@ -79,19 +80,21 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 7. `docs/specs/phase18-platform-constitution/README.md` — Phase-18 spec set index
 8. `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`
 9. `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`
-10. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
-11. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
-12. `docs/specs/phase16-ayken-orchestration/README.md`
-13. `docs/specs/authority-lineage-v1/README.md`
-14. `docs/specs/phase14-distributed-observability/README.md`
-15. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
-16. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
+10. `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`
+11. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
+12. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
+13. `docs/specs/phase16-ayken-orchestration/README.md`
+14. `docs/specs/authority-lineage-v1/README.md`
+15. `docs/specs/phase14-distributed-observability/README.md`
+16. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
+17. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
 
 ## Phase-18 Reference Set
 1. `PHASE18_TRANSITION_DECISION.md`
 2. `docs/specs/phase18-platform-constitution/README.md`
 3. `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`
 4. `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`
+5. `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`
 
 ## Phase-14 Reference Set
 ### Architecture and Observability Surfaces

--- a/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
+++ b/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
@@ -375,6 +375,7 @@ Phase-18 transition su kararlari korumadan aktif uygulama planina donusemez:
 | Phase-18 transition decision package | DOCS-ONLY / PHASE-18 NOT ACTIVATED | Phase-18'i Platform Constitution olarak sinirlamak | `PHASE18_TRANSITION_DECISION.md`, roadmap/index/current status sync | Kernel expansion/new syscall/AI authority forbidden; explicit pointer transition gerekir |
 | Phase-18 Module Manifest Schema | DOCS-ONLY / PRE-ACTIVATION RFC | Modülün kimlik, entrypoint, artifact ve capability request beyanini fail-closed tanimlamak | `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md` | Capability/trust/workspace authority grant yok; unknown fields fail-closed |
 | Phase-18 Capability Contract Specification | DOCS-ONLY / PRE-ACTIVATION RFC | Capability request, authorization decision, receipt ve revocation sinirlarini fail-closed tanimlamak | `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md` | Manifest self-grant yok; trust capability grant degil; token/receipt ayrimi korunur |
+| Phase-18 Workspace Lifecycle Specification | DOCS-ONLY / PRE-ACTIVATION RFC | Workspace admission, logical mount, disable, quarantine, revocation ve removal sinirlarini fail-closed tanimlamak | `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md` | Workspace declaration mount grant degil; mount capability grant degil; runtime loader yok |
 
 PR koordinasyon kurallari:
 
@@ -1054,7 +1055,8 @@ Bu roadmap su olaylarda guncellenir:
 17. Phase-18 Platform Constitution transition decision review/merge sonucu.
 18. Phase-18 Module Manifest Schema review/merge sonucu.
 19. Phase-18 Capability Contract Specification review/merge sonucu.
-20. Yeni feature/ABI/authority surface onerisinin incelenmesi.
+20. Phase-18 Workspace Lifecycle Specification review/merge sonucu.
+21. Yeni feature/ABI/authority surface onerisinin incelenmesi.
 
 ## References
 
@@ -1076,6 +1078,7 @@ Bu roadmap su olaylarda guncellenir:
 - `docs/specs/phase18-platform-constitution/README.md`
 - `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`
 - `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`
+- `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`
 - `PHASE18_ROADMAP.md`
 - `shared/abi/syscall_v2.h`
 - `shared/abi/ayken_abi.h`

--- a/docs/roadmap/CURRENT_PHASE
+++ b/docs/roadmap/CURRENT_PHASE
@@ -7,5 +7,5 @@ CURRENT_PHASE=17
 # Proposed Phase-18 direction: Platform Constitution, not kernel expansion.
 # Active execution roadmap: docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
 # Remote evidence: ci-freeze 26712333892, Performance Gate 26715068398, Phase-17 lifecycle/determinism/public-e2e/worker/timeout/performance lanes all PASS on 416a5392.
-# Immediate work package: draft Phase-18 Platform Constitution specs starting with docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md and docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md; do not activate Phase-18 without an explicit pointer transition.
+# Immediate work package: draft Phase-18 Platform Constitution specs starting with docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md, docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md, and docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md; do not activate Phase-18 without an explicit pointer transition.
 # Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu: Kenan AY (informational metadata only).

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -25,7 +25,10 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 8. `../specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`:
    capability request, decision, receipt ve revocation RFC draft'i; token veya
    trust grant degildir.
-9. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
+9. `../specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`:
+   workspace admission, logical mount, disable, quarantine, revocation ve
+   removal RFC draft'i; mount veya capability grant degildir.
+10. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
    planlamasi; aktif Phase-18 otoritesi degildir.
 
 ## Current Status
@@ -34,7 +37,7 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 |---|---|
 | Son resmi kapanis | Phase-17 OFFICIALLY CLOSED (`phase17-official-closure` at `416a5392`) |
 | Aktif faz | Phase-17 OFFICIALLY CLOSED / Phase-18 transition not activated |
-| Aktif odak | Phase-18 Platform Constitution RFC set; Module Manifest Schema and Capability Contract drafts; no activation without explicit pointer transition |
+| Aktif odak | Phase-18 Platform Constitution RFC set; Module Manifest, Capability Contract and Workspace Lifecycle drafts; no activation without explicit pointer transition |
 | ABI | Canonical `1000-1011` / 12 syscall, ABI version `0x00010001` |
 | Phase-18 | TRANSITION DECISION PACKAGE ONLY; kernel expansion and new syscalls forbidden unless a separate phase RFC/closure authority exists |
 
@@ -63,6 +66,6 @@ current execution priority otoritesi degildir:
 
 ---
 
-**Next action:** `../specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`
-RFC draft'i review edilir; Workspace Lifecycle spec'i gelmeden `CURRENT_PHASE`
-explicit pointer transition ile `18` yapilmaz.
+**Next action:** `../specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`
+RFC draft'i review edilir; Package Metadata ve Trust Classification spec'leri
+gelmeden `CURRENT_PHASE` explicit pointer transition ile `18` yapilmaz.

--- a/docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md
+++ b/docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md
@@ -497,8 +497,8 @@ Invalid because wildcard scope is forbidden.
 
 1. `MODULE_MANIFEST_SCHEMA.md` defines where requests are declared.
 2. Package Metadata Schema will bind request and artifact digests to a package.
-3. Workspace Lifecycle Specification will define workspace selectors and mount
-   lifecycle.
+3. `WORKSPACE_LIFECYCLE_SPECIFICATION.md` defines workspace selectors,
+   admission, logical mounts, and lifecycle.
 4. Trust Classification Model will define review inputs, not authority.
 5. Plugin Boundary Contract will define plugin host interface capability ids.
 6. Platform ABI Validation Gate will enforce registry, request, decision, and

--- a/docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md
+++ b/docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md
@@ -414,7 +414,7 @@ Reason: Phase-18 does not add syscalls.
 |---|---|
 | Package Metadata Schema | Owns publisher, signature, package digest, distribution channel |
 | `CAPABILITY_CONTRACT_SPECIFICATION.md` | Defines request, decision, receipt, and revocation boundaries |
-| Workspace Lifecycle Specification | Defines workspace states, mounts, enable/disable/remove behavior |
+| `WORKSPACE_LIFECYCLE_SPECIFICATION.md` | Defines workspace states, logical mounts, enable/disable/remove behavior |
 | Trust Classification Model | Defines trusted/verified/signed/local/revoked classification |
 | Plugin Boundary Contract | Defines host admission, plugin loading, interface binding |
 | Platform ABI Validation Gate | Implements fail-closed schema and authority checks |

--- a/docs/specs/phase18-platform-constitution/README.md
+++ b/docs/specs/phase18-platform-constitution/README.md
@@ -23,14 +23,15 @@ These specs do not activate Phase-18 and do not change `CURRENT_PHASE=17`.
 1. `MODULE_MANIFEST_SCHEMA.md` - first RFC for the declarative module manifest.
 2. `CAPABILITY_CONTRACT_SPECIFICATION.md` - RFC for request, decision,
    receipt, and revocation boundaries.
+3. `WORKSPACE_LIFECYCLE_SPECIFICATION.md` - RFC for workspace admission,
+   logical mount, disable, quarantine, revocation, and removal boundaries.
 
 ## Planned Specs
 
 1. Package Metadata Schema.
-2. Workspace Lifecycle Specification.
-3. Trust Classification Model.
-4. Plugin Boundary Contract.
-5. Platform ABI Validation Gate.
+2. Trust Classification Model.
+3. Plugin Boundary Contract.
+4. Platform ABI Validation Gate.
 
 ## Non-Authority Rule
 

--- a/docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md
+++ b/docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md
@@ -1,0 +1,467 @@
+# Phase-18 Workspace Lifecycle Specification
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, `PHASE18_TRANSITION_DECISION.md`,
+`MODULE_MANIFEST_SCHEMA.md`, and `CAPABILITY_CONTRACT_SPECIFICATION.md`. In
+case of conflict, those documents prevail.
+
+**Status:** RFC-DRAFT / PRE-ACTIVATION SPEC
+**Contract id:** `ayken.platform.workspace.lifecycle.v1`
+**Authority boundary:** Documentation/specification only; not an installer,
+runtime mount implementation, capability grant, trust grant, kernel mapping
+contract, or Phase-18 activation.
+
+## Purpose
+
+The workspace lifecycle contract answers the third Phase-18 Platform
+Constitution question:
+
+How does a module declare workspace dependency, become installable and
+enableable inside a workspace, receive bounded logical workspace surfaces, and
+remain disableable/removable without granting authority by declaration?
+
+The module manifest declares `workspace`. The capability contract defines
+whether requested workspace access may be authorized. This specification
+defines the workspace states and transitions that must happen around those
+contracts.
+
+## Non-Goals
+
+This contract does not define:
+
+1. A new syscall.
+2. Kernel filesystem or VFS policy.
+3. Runtime mount implementation.
+4. Package distribution format.
+5. Capability token issuance.
+6. Trust classification policy.
+7. Plugin host execution.
+8. Semantic CLI execution verdict authority.
+9. AI Runtime authority.
+
+## Core Rule
+
+A workspace declaration is not a mount. A mount declaration is not capability.
+A capability decision is not a mount. A trust level is not workspace authority.
+
+The following invariants are mandatory:
+
+1. Workspace lifecycle state is external to the manifest.
+2. A manifest may declare workspace dependency only.
+3. A module must not create workspace mounts by declaration.
+4. A module must not receive workspace access without an approved capability
+   decision.
+5. Workspace selectors must be bounded and reviewable.
+6. Unknown lifecycle states fail closed.
+7. Disable, quarantine, revocation, and removal must deny future access by
+   default.
+8. Workspace lifecycle must not require kernel ABI expansion.
+
+## Relationship To Existing Contracts
+
+| Contract | Relationship |
+|---|---|
+| `MODULE_MANIFEST_SCHEMA.md` | Declares `workspace.mode` and `workspace.declared_mounts` |
+| `CAPABILITY_CONTRACT_SPECIFICATION.md` | Authorizes or denies requested workspace capability access |
+| Package Metadata Schema | Will bind package, manifest, artifact, and workspace policy digests |
+| Trust Classification Model | May influence review path, not workspace authority |
+| Platform ABI Validation Gate | Must reject stale, ambiguous, or authority-expanding workspace states |
+
+Workspace lifecycle is the admission state machine around a module in a
+workspace. It is not a direct execution, loader, filesystem, or kernel mapping
+surface.
+
+## Workspace Declaration In Manifest
+
+The module manifest `workspace` object remains declarative:
+
+| Field | Type | Requirement |
+|---|---|---|
+| `mode` | string | `none`, `optional`, or `required` |
+| `declared_mounts` | array | Requested logical mount declarations; may be empty |
+
+Unknown fields in `workspace` fail validation.
+
+### `mode`
+
+| Value | Meaning |
+|---|---|
+| `none` | Module does not require workspace lifecycle admission |
+| `optional` | Module may enable without workspace surfaces, but dependent paths remain disabled |
+| `required` | Module cannot enable unless workspace admission succeeds |
+
+If `mode` is `none`, `declared_mounts` must be empty.
+
+If `mode` is `required`, at least one workspace capability request must exist
+unless a future registry marks the module kind as workspace-admitted without
+resource access. The safe default is rejection.
+
+### `declared_mounts`
+
+Each declared mount is a request for a logical workspace surface. It does not
+create a mount.
+
+| Field | Type | Requirement |
+|---|---|---|
+| `id` | string | Mount declaration id unique within the module |
+| `kind` | string | Mount kind |
+| `selector` | string | Workspace selector |
+| `access` | array | Requested access verbs |
+| `required` | boolean | Whether missing mount blocks enablement |
+| `reason` | string | Human-readable justification |
+
+Unknown fields in a declared mount fail validation.
+
+Initial mount kinds:
+
+| Kind | Meaning |
+|---|---|
+| `workspace_view` | Logical view into a workspace-defined resource set |
+| `workspace_cache` | Module-local cache namespace inside workspace policy |
+| `workspace_output` | Module output namespace inside workspace policy |
+| `workspace_config` | Workspace-scoped configuration surface |
+
+Forbidden mount kinds include `kernel`, `ring0`, `syscall`, `driver`,
+`device`, `root`, `authority`, `trust`, `token`, `semantic-verdict`, and
+`ai-runtime`.
+
+The selector `*` is forbidden. Absolute paths, parent-relative paths, raw host
+paths, device paths, and kernel paths are forbidden.
+
+## Workspace Lifecycle States
+
+The lifecycle state machine is:
+
+```text
+absent -> discovered -> installed -> admitted -> enabled
+enabled -> disabled -> enabled
+enabled -> quarantined
+enabled -> revoked
+disabled -> removed
+quarantined -> disabled
+quarantined -> removed
+revoked -> removed
+installed -> removed
+admitted -> removed
+```
+
+State meanings:
+
+| State | Meaning |
+|---|---|
+| `absent` | Module is not known to the workspace |
+| `discovered` | Manifest/package candidate is visible, not installed |
+| `installed` | Package artifacts are present, not workspace-admitted |
+| `admitted` | Manifest, package, trust, and capability decisions allow workspace admission |
+| `enabled` | Module is allowed to expose declared entrypoints in this workspace |
+| `disabled` | Module remains installed but entrypoints and mounts are inactive |
+| `quarantined` | Module is isolated pending review; enablement denied |
+| `revoked` | Workspace authority has been withdrawn; future access denied |
+| `removed` | Module artifacts and workspace lifecycle records are removed or tombstoned |
+
+Unknown states fail closed.
+
+## Transition Requirements
+
+### Discover
+
+`absent -> discovered` requires:
+
+1. Candidate manifest is parseable.
+2. Unknown manifest fields are rejected.
+3. No capability, trust, semantic, AI, or kernel authority is claimed.
+
+Discovery does not install or enable the module.
+
+### Install
+
+`discovered -> installed` requires:
+
+1. Manifest validation PASS.
+2. Package metadata validation PASS when package metadata exists.
+3. Artifact integrity input available.
+4. No capability decision embedded in the manifest.
+5. No trust self-declaration embedded in the manifest.
+
+Install does not enable entrypoints and does not create mounts.
+
+### Admit
+
+`installed -> admitted` requires:
+
+1. Workspace declaration validation PASS.
+2. Capability request validation PASS.
+3. Required workspace capability decisions are approved.
+4. Effective scopes are equal to or narrower than requested scopes.
+5. Trust classification permits the review path.
+6. Workspace policy accepts the package and module subject.
+
+Admission does not mint runtime tokens and does not execute the module.
+
+### Enable
+
+`admitted -> enabled` requires:
+
+1. Current manifest digest matches the admitted subject.
+2. Current package digest matches the admitted subject when package metadata
+   exists.
+3. Required capability decisions are not expired, suspended, quarantined, or
+   revoked.
+4. Workspace policy is still current.
+5. Declared mount ids resolve to bounded logical surfaces.
+
+Enablement allows future platform runtime to expose entrypoints and logical
+workspace surfaces. It does not bypass capability checks.
+
+### Disable
+
+`enabled -> disabled` requires:
+
+1. Future access is denied by default.
+2. Logical mounts are inactive.
+3. Runtime bindings, if any exist in a later phase, are stopped or marked
+   inactive.
+4. Receipts remain historical evidence only.
+
+Disablement must be reversible only through a fresh enable check.
+
+### Quarantine
+
+`enabled -> quarantined` or `admitted -> quarantined` may be triggered by:
+
+1. Trust downgrade.
+2. Policy conflict.
+3. Evidence invalidation.
+4. Package digest mismatch.
+5. Manifest digest mismatch.
+6. Capability registry withdrawal.
+7. Manual review action.
+
+Quarantine denies enablement and future access. Quarantine does not prove a
+capability violation by itself.
+
+### Revoke
+
+`enabled -> revoked` or `admitted -> revoked` requires:
+
+1. Capability decisions are no longer usable.
+2. Future workspace access is denied.
+3. Runtime bindings, if any exist in a later phase, must be revoked by that
+   runtime layer.
+4. Receipts remain historical evidence only.
+
+Revocation must fail closed if cleanup status is unknown.
+
+### Remove
+
+`disabled -> removed`, `quarantined -> removed`, `revoked -> removed`,
+`installed -> removed`, or `admitted -> removed` requires:
+
+1. Entry points are inactive.
+2. Logical mounts are inactive.
+3. Future capability evaluation for the removed subject denies by default.
+4. Workspace-local module state is deleted or tombstoned according to package
+   policy.
+5. Removal receipt records what was removed without creating new authority.
+
+Removal must not remove unrelated modules, packages, workspace data, or
+evidence records.
+
+## Workspace Admission Record
+
+A workspace admission record is external to the manifest. It may be stored by a
+future workspace or package layer.
+
+Required fields:
+
+| Field | Type | Requirement |
+|---|---|---|
+| `contract_id` | string | Must be `ayken.platform.workspace.lifecycle.v1` |
+| `workspace_id` | string | Workspace subject |
+| `module_id` | string | Module subject |
+| `module_version` | string | Module version subject |
+| `manifest_digest` | string | Canonical manifest digest |
+| `package_digest` | string | Package digest or `none` |
+| `state` | string | Lifecycle state |
+| `capability_decision_refs` | array | References to external capability decisions |
+| `policy_digest` | string | Workspace policy input digest |
+| `trust_ref` | string | External trust classification reference or `none` |
+| `revocation_epoch` | integer | Monotonic revocation epoch |
+
+The admission record must not include:
+
+1. Runtime bearer tokens.
+2. Kernel handles.
+3. Raw syscall arguments.
+4. Trust self-declarations.
+5. Semantic or AI execution verdicts.
+
+## Logical Mount Record
+
+A logical mount record is external to the manifest and subordinate to workspace
+admission.
+
+Required fields:
+
+| Field | Type | Requirement |
+|---|---|---|
+| `mount_id` | string | Stable workspace-local mount id |
+| `module_id` | string | Module subject |
+| `declaration_id` | string | Matching manifest declared mount id |
+| `kind` | string | Accepted mount kind |
+| `selector` | string | Accepted bounded selector |
+| `effective_access` | array | Access verbs authorized for this mount |
+| `capability_decision_ref` | string | Matching approved capability decision |
+| `state` | string | `inactive`, `active`, `suspended`, or `revoked` |
+
+`effective_access` must be equal to or narrower than both the declared mount
+access and the approved capability decision. If this cannot be proven, the
+mount remains inactive.
+
+Logical mount records must not include raw host paths, kernel paths, device
+paths, or bearer tokens.
+
+## Valid Manifest Workspace Example
+
+```json
+{
+  "mode": "required",
+  "declared_mounts": [
+    {
+      "id": "input-documents",
+      "kind": "workspace_view",
+      "selector": "current.project.documents",
+      "access": ["read"],
+      "required": true,
+      "reason": "Read selected project documents for the module entrypoint."
+    }
+  ]
+}
+```
+
+This example declares dependency only. It does not create a mount and does not
+grant workspace access.
+
+## Valid Admission Example
+
+```json
+{
+  "contract_id": "ayken.platform.workspace.lifecycle.v1",
+  "workspace_id": "local.workspace.current",
+  "module_id": "org.ayken.examples.echo",
+  "module_version": "1.0.0",
+  "manifest_digest": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "package_digest": "none",
+  "state": "admitted",
+  "capability_decision_refs": [
+    "capability-decision:workspace-read:0"
+  ],
+  "policy_digest": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+  "trust_ref": "none",
+  "revocation_epoch": 0
+}
+```
+
+This example records admission only. It is not runtime authority.
+
+## Invalid Examples
+
+### Direct Mount Grant
+
+```json
+{
+  "mode": "required",
+  "declared_mounts": [
+    {
+      "id": "all-files",
+      "kind": "workspace_view",
+      "selector": "*",
+      "access": ["read", "write"],
+      "grant": true,
+      "required": true,
+      "reason": "Need everything."
+    }
+  ]
+}
+```
+
+Invalid because wildcard selector and `grant` attempt to create authority.
+
+### Raw Host Path
+
+```json
+{
+  "mode": "required",
+  "declared_mounts": [
+    {
+      "id": "host-root",
+      "kind": "workspace_view",
+      "selector": "/",
+      "access": ["read"],
+      "required": true,
+      "reason": "Read host root."
+    }
+  ]
+}
+```
+
+Invalid because raw host paths are forbidden.
+
+### Kernel Workspace
+
+```json
+{
+  "mode": "required",
+  "declared_mounts": [
+    {
+      "id": "kernel",
+      "kind": "kernel",
+      "selector": "ring0",
+      "access": ["syscall"],
+      "required": true,
+      "reason": "Need kernel access."
+    }
+  ]
+}
+```
+
+Invalid because workspace lifecycle cannot request kernel, Ring0, or syscall
+authority.
+
+## Fail-Closed Matrix
+
+| Condition | Required result |
+|---|---|
+| Unknown workspace field | Reject manifest |
+| `mode=none` with declared mounts | Reject manifest |
+| Unknown mount kind | Reject manifest |
+| Wildcard selector | Reject manifest |
+| Raw host or kernel path | Reject manifest |
+| Missing required capability decision | Deny admission |
+| Effective mount wider than request | Keep mount inactive |
+| Capability revoked | Disable or revoke workspace access |
+| Trust treated as workspace authority | Deny |
+| Receipt used as runtime authority | Deny |
+| Unknown lifecycle state | Deny |
+| Cleanup status unknown during removal | Deny future access |
+| AI or semantic verdict used as authority | Deny |
+
+## Relationship To Other Phase-18 Specs
+
+1. `MODULE_MANIFEST_SCHEMA.md` defines workspace declaration placement.
+2. `CAPABILITY_CONTRACT_SPECIFICATION.md` defines required authorization
+   decisions for workspace access.
+3. Package Metadata Schema will bind package and manifest digests to admission.
+4. Trust Classification Model will define review inputs, not authority.
+5. Plugin Boundary Contract will define plugin workspace surfaces.
+6. Platform ABI Validation Gate will enforce workspace lifecycle invariants.
+
+## Activation Boundary
+
+This RFC is not sufficient to activate Phase-18. Phase-18 activation still
+requires an explicit `CURRENT_PHASE` pointer transition and reviewed acceptance
+of the required Platform Constitution set.
+
+This RFC does not authorize implementation work that widens the kernel ABI,
+adds syscalls, places policy in Ring0, creates runtime mounts, or makes
+semantic/AI systems execution authority.


### PR DESCRIPTION
Docs-only Phase-18 Platform Constitution RFC. Adds Workspace Lifecycle Specification for workspace admission, logical mounts, disable, quarantine, revocation, and removal boundaries. Keeps CURRENT_PHASE=17 and does not grant mount, capability, runtime, kernel, trust, semantic, or AI authority. Local checks: git diff --check; make ci-gate-spec-purity; make ci-gate-naming-compliance; phase17 closure validator PASS.