### PR TITLE
docs: draft phase18 package metadata schema

### DIFF
--- a/PHASE18_TRANSITION_DECISION.md
+++ b/PHASE18_TRANSITION_DECISION.md
@@ -80,7 +80,7 @@ fail-closed, and kernel-preserving way?
 Required Platform Constitution outputs:
 
 1. Module manifest schema (`docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`).
-2. Package metadata schema.
+2. Package metadata schema (`docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`).
 3. Workspace lifecycle contract (`docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`).
 4. Capability contract for platform resources (`docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`).
 5. Trust classification model.
@@ -89,9 +89,10 @@ Required Platform Constitution outputs:
 8. Minimal reference examples that do not create new runtime authority.
 
 Initial pre-activation spec work starts with the Module Manifest Schema,
-Capability Contract Specification, and Workspace Lifecycle Specification. This
-does not activate Phase-18 and does not grant capability, package, workspace,
-trust, plugin, semantic, or AI Runtime authority.
+Capability Contract Specification, Workspace Lifecycle Specification, and
+Package Metadata Schema. This does not activate Phase-18 and does not grant
+capability, package install, package execution, workspace, trust, plugin,
+semantic, or AI Runtime authority.
 
 ## Non-Goals
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **Oluşturan:** Kenan AY
 **Düzenleyen / Geliştiren / Mimari Sorumlu:** Kenan AY *(bilgilendirme metadata'sı; runtime yetkisi değildir)*
 **Oluşturma Tarihi:** 01.01.2026
-**Son Güncelleme:** 01.06.2026
+**Son Güncelleme:** 02.06.2026
 **Closure Evidence:** `local-freeze-p10p11` + `local-phase11-closure` + `run-local-phase12c-closure-2026-03-11` + `run-local-p13-kill-switch-20260315T000051Z` + `phase15-official-closure` + `phase16-verification-layer-mvp-complete`
 **Evidence Git SHA (Phase-10/11):** `9cb2171b` | **Evidence Git SHA (Phase-12C):** `01d1cb5c` | **Evidence Git SHA (Phase-13):** `40158350` | **Evidence Git SHA (Phase-15):** `48970cd0` | **Evidence Git SHA (Phase-16):** `489868f8`
 **Closure Sync / Remote CI (Phase-10/11):** `fe9031d7` (`ci-freeze#22797401328 = success`)
@@ -25,7 +25,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **CURRENT_PHASE:** `17` (`Phase-17 OFFICIALLY CLOSED`; Phase-18 ayrı transition olmadan aktif değildir)
 **Freeze Zinciri:** `make ci-freeze` = 40 kapılı strict suite (normative spec-purity dahil) | `make ci-freeze-local` = local performance authority
 **Authority Durumu:** Issue #145 tek-maintainer authority kararıyla giderildi; PR #142, PR #144, PR #148, PR #149, PR #151, PR #150, PR #152 ve Phase-17 closure decision package birleşti. Closure exact-SHA kanıtı `main` SHA `416a5392` üzerinde yenilendi, gerekli uzak acceptance kontrolleri PASS verdi ve `phase17-official-closure` tag'i aynı SHA'ya doğrulandı
-**Yakın Hedef:** Phase-18 Platform Constitution RFC setini yazmak; mevcut somut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md` ve `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, explicit pointer transition olmadan Phase-18 aktive edilmez
+**Yakın Hedef:** Phase-18 Platform Constitution RFC setini yazmak; mevcut somut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md` ve `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`, explicit pointer transition olmadan Phase-18 aktive edilmez
 **Ring0 Export Ceiling:** `193 symbols` (current enforced ceiling)
 **Performance Baseline Candidate:** `gha-ubuntu24-20260518.149.1-X64` (authorized run `26370359958` artifact'i PR'a import edildi; SHA `f129d4aa` locked acceptance PASS verdi, ancak tek basina closure authority değildir)
 **Development Status:** Phase-16 OFFICIALLY CLOSED ✅ | Phase-17 OFFICIALLY CLOSED ✅ | SINGLE-MAINTAINER AUTHORITY ALIGNED (#145 RESOLVED) ✅ | PR #142/#144/#148/#149/#151/#150/#152 + closure decision package MERGED ✅ | EXACT-SHA REMOTE EVIDENCE PASS ✅ | Phase-18 TRANSITION DECISION PACKAGE ONLY
@@ -68,7 +68,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 - **Evidence:** A, B, C karakterleri başarıyla syscall üzerinden basıldı
 - **Result:** Ring3 infrastructure PROVEN, syscall path WORKING, instruction retirement VALIDATED
 
-**Next Focus:** Phase-18 Platform Constitution RFC setini yazmak; mevcut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md` ve `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, `CURRENT_PHASE` explicit pointer transition olmadan `18` yapılmayacaktır.
+**Next Focus:** Phase-18 Platform Constitution RFC setini yazmak; mevcut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md` ve `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`, `CURRENT_PHASE` explicit pointer transition olmadan `18` yapılmayacaktır.
 
 ## Authority Model
 
@@ -313,6 +313,7 @@ Phase 12 trust layer kapsamında tamamlananlar:
 - **Phase-18 Module Manifest Schema:** `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`
 - **Phase-18 Capability Contract Specification:** `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`
 - **Phase-18 Workspace Lifecycle Specification:** `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`
+- **Phase-18 Package Metadata Schema:** `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`
 - **Documentation Index:** `docs/development/DOCUMENTATION_INDEX.md`
 - **Ring3 User-Leaf Rule:** `docs/governance/RING3_USER_LEAF_ALLOCATION_RULE.md`
 - **Ring3 Runtime Closure Note:** `docs/governance/RING3_RUNTIME_CLOSURE_NOTE.md`
@@ -345,7 +346,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 - Module manifest schema RFC draft: `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`.
 - Capability contract RFC draft: `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`.
 - Workspace lifecycle contract RFC draft: `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`.
-- Package metadata schema draft.
+- Package metadata schema RFC draft: `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`; identity/version/publisher/hash/signature/dependency/compatibility only.
 - Trust classification validation gate; trust level capability grant degildir.
 - Plugin boundary contract draft.
 
@@ -362,7 +363,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 
 ---
 
-**Son Güncelleme:** 01 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=17; Module Manifest, Capability Contract ve Workspace Lifecycle RFC draft'lari Phase-18 Platform Constitution pre-activation setine eklendi; explicit transition olmadan Phase-18 aktif değildir.
+**Son Güncelleme:** 02 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=17; Module Manifest, Capability Contract, Workspace Lifecycle ve Package Metadata RFC draft'lari Phase-18 Platform Constitution pre-activation setine eklendi; explicit transition olmadan Phase-18 aktif değildir.
 **Düzenleyen / Geliştiren / Oluşturan / Mimari Sorumlu:** Kenan AY *(metadata only; runtime/karar yetkisi değildir).*
 
 **© 2026 Kenan AY — AykenOS Project**

--- a/docs/development/DOCUMENTATION_INDEX.md
+++ b/docs/development/DOCUMENTATION_INDEX.md
@@ -17,7 +17,7 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict
 - **Execution Pipeline:** `Phase-17` officially closed — tag `phase17-official-closure` at `416a5392`
 - **Formal Governance Pointer:** `CURRENT_PHASE=17`
 - **Active Phase:** Phase-17 OFFICIALLY CLOSED / Phase-18 TRANSITION NOT ACTIVATED
-- **Active Execution Priority:** Draft the Phase-18 Platform Constitution RFC set, currently `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, and `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`
+- **Active Execution Priority:** Draft the Phase-18 Platform Constitution RFC set, currently `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, and `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`
 - **Scope Boundary:** Phase-18 is not active until an explicit `CURRENT_PHASE` pointer transition; kernel expansion, new syscalls, Ring0 policy and AI Runtime authority remain forbidden for Phase-18
 
 ## Primary Truth Sources
@@ -37,14 +37,15 @@ Current repo truth icin once su dosyalari referans alin:
 12. `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md` — **first pre-activation Platform Constitution RFC draft**
 13. `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md` — **capability request/decision/receipt/revocation RFC draft**
 14. `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md` — **workspace admission/logical-mount lifecycle RFC draft**
-15. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
-16. `reports/phase15_official_closure/closure_index.json`
-17. `reports/phase13_official_closure_candidate/closure_index.json`
-18. `reports/phase12_official_closure_candidate/closure_manifest.json`
-19. `reports/phase10_phase11_official_closure_index.json`
-20. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
-21. `Makefile`
-22. `.github/workflows/ci-freeze.yml`
+15. `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md` — **package metadata evidence-only RFC draft**
+16. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
+17. `reports/phase15_official_closure/closure_index.json`
+18. `reports/phase13_official_closure_candidate/closure_index.json`
+19. `reports/phase12_official_closure_candidate/closure_manifest.json`
+20. `reports/phase10_phase11_official_closure_index.json`
+21. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
+22. `Makefile`
+23. `.github/workflows/ci-freeze.yml`
 
 Phase-14 workstream numbering ve aktif durum yorumu icin canonical truth source:
 
@@ -81,13 +82,14 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 8. `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`
 9. `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`
 10. `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`
-11. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
-12. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
-13. `docs/specs/phase16-ayken-orchestration/README.md`
-14. `docs/specs/authority-lineage-v1/README.md`
-15. `docs/specs/phase14-distributed-observability/README.md`
-16. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
-17. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
+11. `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`
+12. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
+13. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
+14. `docs/specs/phase16-ayken-orchestration/README.md`
+15. `docs/specs/authority-lineage-v1/README.md`
+16. `docs/specs/phase14-distributed-observability/README.md`
+17. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
+18. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
 
 ## Phase-18 Reference Set
 1. `PHASE18_TRANSITION_DECISION.md`
@@ -95,6 +97,7 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 3. `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`
 4. `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`
 5. `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`
+6. `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`
 
 ## Phase-14 Reference Set
 ### Architecture and Observability Surfaces

--- a/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
+++ b/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
@@ -349,8 +349,9 @@ Phase-18 transition su kararlari korumadan aktif uygulama planina donusemez:
 6. Kernel ABI ile Platform ABI ayrimi acik.
 7. Trust level capability grant degildir.
 8. `CURRENT_PHASE` ancak explicit transition ile `18` yapilir.
-9. Module Manifest, Capability Contract ve Workspace Lifecycle spec'leri
-   fail-closed olarak review edilmeden implementation phase baslamaz.
+9. Module Manifest, Capability Contract, Workspace Lifecycle ve Package
+   Metadata spec'leri fail-closed olarak review edilmeden implementation phase
+   baslamaz.
 
 ## 7. PR Sequence and Coordination Matrix
 
@@ -376,6 +377,7 @@ Phase-18 transition su kararlari korumadan aktif uygulama planina donusemez:
 | Phase-18 Module Manifest Schema | DOCS-ONLY / PRE-ACTIVATION RFC | Modülün kimlik, entrypoint, artifact ve capability request beyanini fail-closed tanimlamak | `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md` | Capability/trust/workspace authority grant yok; unknown fields fail-closed |
 | Phase-18 Capability Contract Specification | DOCS-ONLY / PRE-ACTIVATION RFC | Capability request, authorization decision, receipt ve revocation sinirlarini fail-closed tanimlamak | `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md` | Manifest self-grant yok; trust capability grant degil; token/receipt ayrimi korunur |
 | Phase-18 Workspace Lifecycle Specification | DOCS-ONLY / PRE-ACTIVATION RFC | Workspace admission, logical mount, disable, quarantine, revocation ve removal sinirlarini fail-closed tanimlamak | `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md` | Workspace declaration mount grant degil; mount capability grant degil; runtime loader yok |
+| Phase-18 Package Metadata Schema | DOCS-ONLY / PRE-ACTIVATION RFC | Package identity, version, publisher, hash, signature, dependency ve Platform ABI compatibility metadata'sini fail-closed tanimlamak | `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md` | Trust/capability/workspace/execution/mount/loader grant yok; package digest metadata icinde self-declare edilmez |
 
 PR koordinasyon kurallari:
 
@@ -1056,7 +1058,8 @@ Bu roadmap su olaylarda guncellenir:
 18. Phase-18 Module Manifest Schema review/merge sonucu.
 19. Phase-18 Capability Contract Specification review/merge sonucu.
 20. Phase-18 Workspace Lifecycle Specification review/merge sonucu.
-21. Yeni feature/ABI/authority surface onerisinin incelenmesi.
+21. Phase-18 Package Metadata Schema review/merge sonucu.
+22. Yeni feature/ABI/authority surface onerisinin incelenmesi.
 
 ## References
 

--- a/docs/roadmap/CURRENT_PHASE
+++ b/docs/roadmap/CURRENT_PHASE
@@ -7,5 +7,5 @@ CURRENT_PHASE=17
 # Proposed Phase-18 direction: Platform Constitution, not kernel expansion.
 # Active execution roadmap: docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
 # Remote evidence: ci-freeze 26712333892, Performance Gate 26715068398, Phase-17 lifecycle/determinism/public-e2e/worker/timeout/performance lanes all PASS on 416a5392.
-# Immediate work package: draft Phase-18 Platform Constitution specs starting with docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md, docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md, and docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md; do not activate Phase-18 without an explicit pointer transition.
+# Immediate work package: draft Phase-18 Platform Constitution specs starting with docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md, docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md, docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md, and docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md; do not activate Phase-18 without an explicit pointer transition.
 # Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu: Kenan AY (informational metadata only).

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -28,7 +28,11 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 9. `../specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`:
    workspace admission, logical mount, disable, quarantine, revocation ve
    removal RFC draft'i; mount veya capability grant degildir.
-10. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
+10. `../specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`:
+   package identity, version, publisher, hash, signature, dependency ve
+   Platform ABI compatibility RFC draft'i; trust/capability/workspace/execution
+   grant degildir.
+11. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
    planlamasi; aktif Phase-18 otoritesi degildir.
 
 ## Current Status
@@ -37,7 +41,7 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 |---|---|
 | Son resmi kapanis | Phase-17 OFFICIALLY CLOSED (`phase17-official-closure` at `416a5392`) |
 | Aktif faz | Phase-17 OFFICIALLY CLOSED / Phase-18 transition not activated |
-| Aktif odak | Phase-18 Platform Constitution RFC set; Module Manifest, Capability Contract and Workspace Lifecycle drafts; no activation without explicit pointer transition |
+| Aktif odak | Phase-18 Platform Constitution RFC set; Module Manifest, Capability Contract, Workspace Lifecycle and Package Metadata drafts; no activation without explicit pointer transition |
 | ABI | Canonical `1000-1011` / 12 syscall, ABI version `0x00010001` |
 | Phase-18 | TRANSITION DECISION PACKAGE ONLY; kernel expansion and new syscalls forbidden unless a separate phase RFC/closure authority exists |
 
@@ -66,6 +70,6 @@ current execution priority otoritesi degildir:
 
 ---
 
-**Next action:** `../specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`
-RFC draft'i review edilir; Package Metadata ve Trust Classification spec'leri
-gelmeden `CURRENT_PHASE` explicit pointer transition ile `18` yapilmaz.
+**Next action:** Trust Classification Model RFC draft'i acilir; Plugin Boundary
+ve Platform ABI Validation Gate spec'leri gelmeden `CURRENT_PHASE` explicit
+pointer transition ile `18` yapilmaz.

--- a/docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md
+++ b/docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md
@@ -496,7 +496,9 @@ Invalid because wildcard scope is forbidden.
 ## Relationship To Other Phase-18 Specs
 
 1. `MODULE_MANIFEST_SCHEMA.md` defines where requests are declared.
-2. Package Metadata Schema will bind request and artifact digests to a package.
+2. `PACKAGE_METADATA_SCHEMA.md` remains external to capability decisions and
+   must not contain capability requests, decisions, receipts, tokens, or
+   grants.
 3. `WORKSPACE_LIFECYCLE_SPECIFICATION.md` defines workspace selectors,
    admission, logical mounts, and lifecycle.
 4. Trust Classification Model will define review inputs, not authority.

--- a/docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md
+++ b/docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md
@@ -412,7 +412,7 @@ Reason: Phase-18 does not add syscalls.
 
 | Future spec | Relationship |
 |---|---|
-| Package Metadata Schema | Owns publisher, signature, package digest, distribution channel |
+| `PACKAGE_METADATA_SCHEMA.md` | Owns package identity, publisher declaration, content hashes, signature evidence, dependencies, and compatibility metadata |
 | `CAPABILITY_CONTRACT_SPECIFICATION.md` | Defines request, decision, receipt, and revocation boundaries |
 | `WORKSPACE_LIFECYCLE_SPECIFICATION.md` | Defines workspace states, logical mounts, enable/disable/remove behavior |
 | Trust Classification Model | Defines trusted/verified/signed/local/revoked classification |

--- a/docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md
+++ b/docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md
@@ -1,0 +1,550 @@
+# Phase-18 Package Metadata Schema
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, `PHASE18_TRANSITION_DECISION.md`,
+`MODULE_MANIFEST_SCHEMA.md`, `CAPABILITY_CONTRACT_SPECIFICATION.md`, and
+`WORKSPACE_LIFECYCLE_SPECIFICATION.md`. In case of conflict, those documents
+prevail.
+
+**Status:** RFC-DRAFT / PRE-ACTIVATION SPEC
+**Schema id:** `ayken.platform.package.metadata.v1`
+**Canonical file name:** `ayken.package.json`
+**Authority boundary:** Documentation/specification only; not an installer,
+registry, runtime loader, capability grant, trust grant, workspace admission,
+mount authority, plugin host, execution right, or Phase-18 activation.
+
+## Purpose
+
+The package metadata schema answers the fourth Phase-18 Platform Constitution
+question:
+
+How does a package declare identity, version, publisher, content hashes,
+signature evidence, dependency metadata, and Platform ABI compatibility without
+becoming an authority source?
+
+This first package metadata RFC is intentionally narrow. It records package
+evidence inputs only. It does not define package installation, enablement,
+execution, workspace admission, capability decisions, trust classification, or
+runtime loading.
+
+## Positive Scope
+
+Version 1 package metadata is limited to:
+
+1. Identity.
+2. Version.
+3. Publisher declaration.
+4. Hash and integrity evidence.
+5. Signature evidence references.
+6. Dependency declarations.
+7. Platform ABI compatibility.
+
+No other constitutional domain is expressible in this RFC.
+
+## Non-Goals
+
+This schema does not define:
+
+1. A new syscall.
+2. Kernel ABI expansion.
+3. A package installer implementation.
+4. A package registry implementation.
+5. A runtime package loader.
+6. Capability requests, decisions, receipts, tokens, or grants.
+7. Trust classification policy.
+8. Workspace admission, workspace state, or mount creation.
+9. Entrypoint execution rights.
+10. Plugin host execution.
+11. Semantic CLI execution verdict authority.
+12. AI Runtime authority.
+
+## Core Rule
+
+Package metadata may declare package evidence. It must never grant authority.
+
+The following invariants are mandatory:
+
+1. Package metadata may identify a package and its content.
+2. Package metadata may declare publisher identity claims and signature
+   evidence references.
+3. Package metadata may declare dependencies and compatibility floors.
+4. Package metadata must not contain capability fields.
+5. Package metadata must not contain trust classification fields.
+6. Package metadata must not contain workspace or mount fields.
+7. Package metadata must not contain loader, execution, or runtime handle
+   fields.
+8. Package metadata must not express kernel ABI expansion.
+9. Unknown top-level fields fail validation.
+10. Package metadata validation must fail closed.
+
+## Metadata Encoding
+
+`ayken.package.json` must be:
+
+1. UTF-8 JSON.
+2. A single JSON object.
+3. Free of comments and trailing commas.
+4. Free of duplicate keys.
+5. Parsed with unknown top-level fields rejected.
+6. Canonicalized by the future validator before digest computation.
+
+The metadata file must not contain a self-declared package digest. A future
+package envelope, registry, or validation gate may compute and store package
+digests externally.
+
+## Required Top-Level Fields
+
+| Field | Type | Requirement |
+|---|---|---|
+| `package_metadata_version` | integer | Must be `1` for this RFC |
+| `schema_id` | string | Must be `ayken.platform.package.metadata.v1` |
+| `package_id` | string | Stable globally unique package id |
+| `name` | string | Human-readable short name |
+| `package_version` | string | Semver-compatible package version |
+| `package_kind` | string | One of the allowed package kinds |
+| `publisher` | object | Non-authoritative publisher declaration |
+| `hashes` | object | Content hash declarations |
+| `signatures` | object | External signature evidence references |
+| `dependencies` | array | Declarative dependency requirements |
+| `compatibility` | object | Platform ABI compatibility declaration |
+
+Optional top-level fields are limited to:
+
+| Field | Type | Requirement |
+|---|---|---|
+| `summary` | string | Short human-readable summary |
+| `description` | string | Longer description |
+| `links` | object | Non-authoritative links |
+
+All other top-level fields must fail validation.
+
+## Field Rules
+
+### `package_id`
+
+`package_id` must be a lower-case, reverse-DNS-like identifier:
+
+```text
+^[a-z][a-z0-9]*(\.[a-z][a-z0-9-]*)+$
+```
+
+Examples:
+
+```text
+org.ayken.examples.echo-package
+com.example.workspace-indexer-package
+```
+
+The identifier must not include reserved authority segments:
+
+1. `kernel`
+2. `ring0`
+3. `syscall`
+4. `driver`
+5. `root`
+6. `admin`
+7. `authority`
+8. `verdict`
+9. `trust`
+10. `trusted`
+11. `verified`
+12. `token`
+13. `grant`
+14. `capability`
+15. `workspace`
+16. `mount`
+17. `loader`
+18. `execution`
+19. `ai-runtime`
+20. `semantic-verdict`
+
+### `package_version`
+
+`package_version` must use a semver-compatible string:
+
+```text
+MAJOR.MINOR.PATCH
+```
+
+Pre-release and build metadata may be allowed by a future validator, but this
+RFC only requires the base form.
+
+### `package_kind`
+
+Allowed values:
+
+| Value | Meaning |
+|---|---|
+| `module_package` | Package containing userspace module metadata and artifacts |
+| `library_package` | Package containing userspace library artifacts |
+| `asset_package` | Package containing static assets |
+| `bundle_package` | Package containing multiple package-local resources |
+
+Forbidden values include `kernel`, `driver`, `syscall`, `ring0`,
+`scheduler`, `interrupt`, `plugin`, `semantic-verdict`, and `ai-runtime`.
+
+Plugin package semantics are deferred until the Plugin Boundary Contract exists.
+
+### `publisher`
+
+The `publisher` object is a declaration, not trust classification.
+
+| Field | Type | Requirement |
+|---|---|---|
+| `declared_id` | string | Publisher identity claim |
+| `display_name` | string | Optional human-readable name |
+| `contact_refs` | array | Optional contact or profile references |
+
+Unknown fields in `publisher` fail validation.
+
+Publisher declarations may be inputs to a future Trust Classification Model.
+They do not create trust by themselves.
+
+### `hashes`
+
+The `hashes` object declares package content hashes:
+
+| Field | Type | Requirement |
+|---|---|---|
+| `algorithm` | string | Must be `sha256` for this RFC |
+| `content_set_digest` | string | Digest over the canonical content descriptor set |
+| `content` | array | Hashed package content descriptors |
+
+Each `content` entry must include:
+
+| Field | Type | Requirement |
+|---|---|---|
+| `id` | string | Stable content id unique within the package |
+| `path` | string | Relative package-local path |
+| `kind` | string | Content kind |
+| `sha256` | string | 64-character lower-case hex SHA-256 |
+| `size_bytes` | integer | Non-negative byte size |
+
+Allowed content kinds:
+
+| Kind | Meaning |
+|---|---|
+| `manifest` | Declarative manifest or metadata file |
+| `executable` | Userspace executable artifact |
+| `library` | Userspace library artifact |
+| `asset` | Static package asset |
+| `config` | Declarative configuration artifact |
+| `metadata` | Non-authoritative metadata artifact |
+
+Paths must be relative, must not contain `..`, and must not start with `/`.
+Raw host paths, device paths, kernel paths, and URLs are forbidden.
+
+Content hashes are evidence inputs. They are not trust classification, install
+authority, or execution authority.
+
+The following fields are forbidden under `hashes`:
+
+1. `package_digest`
+2. `envelope_digest`
+3. `trust_digest`
+4. `capability_digest`
+5. `workspace_digest`
+6. `runtime_handle`
+
+Package or envelope digests must be computed externally by a future package
+validation gate or registry layer.
+
+### `signatures`
+
+The `signatures` object declares external signature evidence references:
+
+| Field | Type | Requirement |
+|---|---|---|
+| `signature_policy` | string | Must be `evidence_only` |
+| `signature_refs` | array | External signature references; may be empty |
+
+Each signature reference must include:
+
+| Field | Type | Requirement |
+|---|---|---|
+| `id` | string | Stable reference id |
+| `kind` | string | `external`, `minisign`, `cosign`, `pgp`, or `x509` |
+| `ref` | string | External evidence reference |
+| `signed_digest` | string | Digest claimed by the signature reference |
+
+Signature references are evidence inputs only. They do not imply `signed`,
+`verified`, `trusted`, installation eligibility, or capability approval.
+
+The `signatures` object must not contain private keys, bearer tokens, trust
+levels, review verdicts, or registry approval status.
+
+### `dependencies`
+
+Each dependency entry must include:
+
+| Field | Type | Requirement |
+|---|---|---|
+| `package_id` | string | Required package id |
+| `version_constraint` | string | Version constraint expression |
+| `required` | boolean | Whether absence blocks dependency resolution |
+| `reason` | string | Human-readable reason |
+
+Dependencies are review and resolution inputs only. They do not install,
+enable, trust, execute, or authorize another package.
+
+Unknown fields in a dependency entry fail validation.
+
+### `compatibility`
+
+The `compatibility` object must declare compatibility above the frozen kernel:
+
+```json
+{
+  "platform_package_abi": "ayken.platform.package.v1",
+  "kernel_abi_floor": "syscall-v2-1000-1011"
+}
+```
+
+`kernel_abi_floor` is a compatibility floor only. It must not be interpreted as
+direct syscall access or kernel ABI expansion.
+
+Unknown fields in `compatibility` fail validation.
+
+## Forbidden Domain Fields
+
+The following top-level or nested domains are forbidden in Version 1 package
+metadata:
+
+1. `trust`
+2. `trust_level`
+3. `trusted`
+4. `verified`
+5. `review_status`
+6. `distribution_trust`
+7. `capability`
+8. `capabilities`
+9. `capability_requests`
+10. `capabilities_granted`
+11. `capability_decisions`
+12. `capability_token`
+13. `token`
+14. `workspace`
+15. `workspace_binding`
+16. `mount`
+17. `mounts`
+18. `execution`
+19. `entrypoints`
+20. `loader`
+21. `autoload`
+22. `runtime_handle`
+23. `plugin_boundary`
+24. `semantic_verdict`
+25. `ai_runtime`
+
+## Forbidden Authority Claims
+
+The package metadata must fail validation if any top-level or nested field
+attempts to declare:
+
+1. New syscall IDs.
+2. Kernel ABI changes.
+3. Ring0 policy.
+4. Scheduler policy.
+5. IRQ/interrupt control.
+6. Capability requests, grants, decisions, receipts, or tokens.
+7. Runtime handles.
+8. Trust classification.
+9. Workspace admission or mounts.
+10. Plugin loading authority.
+11. Entrypoint execution rights.
+12. Semantic execution verdict authority.
+13. AI Runtime authority.
+
+## Minimal Valid Example
+
+```json
+{
+  "package_metadata_version": 1,
+  "schema_id": "ayken.platform.package.metadata.v1",
+  "package_id": "org.ayken.examples.echo-package",
+  "name": "echo-package",
+  "package_version": "1.0.0",
+  "package_kind": "module_package",
+  "publisher": {
+    "declared_id": "org.ayken.examples",
+    "display_name": "Example Publisher",
+    "contact_refs": []
+  },
+  "hashes": {
+    "algorithm": "sha256",
+    "content_set_digest": "2222222222222222222222222222222222222222222222222222222222222222",
+    "content": [
+      {
+        "id": "module-manifest",
+        "path": "ayken.module.json",
+        "kind": "manifest",
+        "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        "size_bytes": 2048
+      },
+      {
+        "id": "echo-cli",
+        "path": "bin/echo",
+        "kind": "executable",
+        "sha256": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+        "size_bytes": 4096
+      }
+    ]
+  },
+  "signatures": {
+    "signature_policy": "evidence_only",
+    "signature_refs": []
+  },
+  "dependencies": [],
+  "compatibility": {
+    "platform_package_abi": "ayken.platform.package.v1",
+    "kernel_abi_floor": "syscall-v2-1000-1011"
+  },
+  "summary": "Package metadata for the echo example module."
+}
+```
+
+This example declares package evidence only. It does not install, enable,
+execute, trust, admit, mount, or authorize the package.
+
+## Invalid Examples
+
+### Self-Declared Trust
+
+```json
+{
+  "trust_level": "trusted"
+}
+```
+
+Invalid because trust classification is external to package metadata.
+
+### Capability Field
+
+```json
+{
+  "capability_requests": [
+    "ayken.platform.workspace.read"
+  ]
+}
+```
+
+Invalid because package metadata cannot request, grant, decide, or bind
+capabilities.
+
+### Workspace Field
+
+```json
+{
+  "workspace": {
+    "mode": "required"
+  }
+}
+```
+
+Invalid because package metadata cannot declare workspace admission or mounts.
+
+### Embedded Package Digest
+
+```json
+{
+  "hashes": {
+    "package_digest": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  }
+}
+```
+
+Invalid because package or envelope digest must be computed externally.
+
+### Runtime Loader Authority
+
+```json
+{
+  "loader": {
+    "autoload": true,
+    "runtime_handle": "active"
+  }
+}
+```
+
+Invalid because package metadata cannot load or enable runtime surfaces.
+
+### Kernel Package
+
+```json
+{
+  "package_kind": "kernel",
+  "syscalls": [1012]
+}
+```
+
+Invalid because Phase-18 cannot add syscalls or package kernel authority.
+
+### Absolute Content Path
+
+```json
+{
+  "hashes": {
+    "algorithm": "sha256",
+    "content_set_digest": "2222222222222222222222222222222222222222222222222222222222222222",
+    "content": [
+      {
+        "id": "host-root",
+        "path": "/bin/sh",
+        "kind": "executable",
+        "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        "size_bytes": 1
+      }
+    ]
+  }
+}
+```
+
+Invalid because absolute host paths are forbidden.
+
+## Fail-Closed Validation Matrix
+
+| Condition | Required result |
+|---|---|
+| Missing required field | Reject package metadata |
+| Unknown top-level field | Reject package metadata |
+| Duplicate JSON key | Reject package metadata |
+| Unsupported `package_metadata_version` | Reject package metadata |
+| Package id uses reserved authority segment | Reject package metadata |
+| Absolute or parent-relative content path | Reject package metadata |
+| URL, device, host, or kernel path in content path | Reject package metadata |
+| Content set digest mismatch | Reject package metadata |
+| Capability field present | Reject package metadata |
+| Trust classification field present | Reject package metadata |
+| Workspace or mount field present | Reject package metadata |
+| Runtime loader/handle field present | Reject package metadata |
+| Package digest self-declared inside metadata | Reject package metadata |
+| Kernel/Ring0/syscall expansion field present | Reject package metadata |
+| Semantic verdict authority present | Reject package metadata |
+| AI Runtime authority present | Reject package metadata |
+
+## Relationship To Existing Phase-18 Specs
+
+1. `MODULE_MANIFEST_SCHEMA.md` may be shipped as a hashed package content file;
+   package metadata does not interpret manifest capability or workspace fields.
+2. `CAPABILITY_CONTRACT_SPECIFICATION.md` remains external; package metadata
+   must not contain capability requests, decisions, receipts, tokens, or
+   grants.
+3. `WORKSPACE_LIFECYCLE_SPECIFICATION.md` remains external; package metadata
+   must not contain workspace admission, lifecycle state, or mount fields.
+4. Trust Classification Model will define how publisher and signature evidence
+   influence review without granting capability.
+5. Plugin Boundary Contract will define plugin package semantics later;
+   `plugin` package kinds are deferred in this RFC.
+6. Platform ABI Validation Gate will enforce package metadata, manifest,
+   capability, workspace, trust, and plugin invariants.
+
+## Activation Boundary
+
+This RFC is not sufficient to activate Phase-18. Phase-18 activation still
+requires an explicit `CURRENT_PHASE` pointer transition and reviewed acceptance
+of the required Platform Constitution set.
+
+This RFC does not authorize implementation work that widens the kernel ABI,
+adds syscalls, places policy in Ring0, creates runtime loaders, admits
+workspaces, grants trust, grants capabilities, or makes semantic/AI systems
+execution authority.

--- a/docs/specs/phase18-platform-constitution/README.md
+++ b/docs/specs/phase18-platform-constitution/README.md
@@ -25,13 +25,15 @@ These specs do not activate Phase-18 and do not change `CURRENT_PHASE=17`.
    receipt, and revocation boundaries.
 3. `WORKSPACE_LIFECYCLE_SPECIFICATION.md` - RFC for workspace admission,
    logical mount, disable, quarantine, revocation, and removal boundaries.
+4. `PACKAGE_METADATA_SCHEMA.md` - RFC for package identity, version,
+   publisher, hash, signature, dependency, and Platform ABI compatibility
+   metadata.
 
 ## Planned Specs
 
-1. Package Metadata Schema.
-2. Trust Classification Model.
-3. Plugin Boundary Contract.
-4. Platform ABI Validation Gate.
+1. Trust Classification Model.
+2. Plugin Boundary Contract.
+3. Platform ABI Validation Gate.
 
 ## Non-Authority Rule
 
@@ -44,3 +46,4 @@ No file in this directory may grant:
 5. Trust classification.
 6. AI Runtime authority.
 7. Semantic CLI execution verdict authority.
+8. Package install, execution, workspace admission, or loader authority.

--- a/docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md
+++ b/docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md
@@ -63,7 +63,7 @@ The following invariants are mandatory:
 |---|---|
 | `MODULE_MANIFEST_SCHEMA.md` | Declares `workspace.mode` and `workspace.declared_mounts` |
 | `CAPABILITY_CONTRACT_SPECIFICATION.md` | Authorizes or denies requested workspace capability access |
-| Package Metadata Schema | Will bind package, manifest, artifact, and workspace policy digests |
+| `PACKAGE_METADATA_SCHEMA.md` | Declares package identity, content hashes, signatures, dependencies, and compatibility only; no workspace admission or mount fields |
 | Trust Classification Model | May influence review path, not workspace authority |
 | Platform ABI Validation Gate | Must reject stale, ambiguous, or authority-expanding workspace states |
 
@@ -451,7 +451,8 @@ authority.
 1. `MODULE_MANIFEST_SCHEMA.md` defines workspace declaration placement.
 2. `CAPABILITY_CONTRACT_SPECIFICATION.md` defines required authorization
    decisions for workspace access.
-3. Package Metadata Schema will bind package and manifest digests to admission.
+3. `PACKAGE_METADATA_SCHEMA.md` may provide package evidence inputs, but it
+   must not contain workspace admission, lifecycle state, or mount fields.
 4. Trust Classification Model will define review inputs, not authority.
 5. Plugin Boundary Contract will define plugin workspace surfaces.
 6. Platform ABI Validation Gate will enforce workspace lifecycle invariants.


### PR DESCRIPTION
Docs-only Phase-18 Platform Constitution RFC. Adds Package Metadata Schema as an evidence-only package metadata draft limited to identity, version, publisher, hashes, signatures, dependencies, and Platform ABI compatibility. Explicitly forbids trust, capability, workspace, execution, mount, loader, kernel ABI expansion, new syscalls, Semantic CLI authority, and AI Runtime authority. Keeps CURRENT_PHASE=17 and does not activate Phase-18. Local checks: git diff --check PASS; make ci-gate-spec-purity PASS; make ci-gate-naming-compliance PASS; phase17 closure candidate validation PASS; make ci-gate-governance PASS; make ci-gate-drift-activation PASS.