### PR TITLE
docs: add phase18 activation decision package

### DIFF
--- a/PHASE18_ACTIVATION_DECISION.md
+++ b/PHASE18_ACTIVATION_DECISION.md
@@ -1,0 +1,178 @@
+# Phase-18 Activation Decision Package
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, `PHASE18_TRANSITION_DECISION.md`, and the Phase-18
+Platform Constitution RFC set. In case of conflict, those documents prevail.
+
+**Status:** ACTIVATION DECISION PACKAGE CANDIDATE / PHASE-18 NOT ACTIVATED
+**Decision package date:** 2026-06-05
+**Authority basis:** `phase17-official-closure` at
+`416a5392afbe217e16d26a59e2e1716fdfa9c8f6`, the reviewed Phase-18 Platform
+Constitution RFC set, and
+`docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`.
+**Attribution:** Kenan AY - informational documentation metadata only; not
+runtime, merge, execution, install, trust, capability, workspace, plugin,
+Semantic CLI, AI Runtime, syscall, kernel ABI, or phase pointer authority.
+
+## Decision Candidate
+
+Phase-18 may be activated only as **Platform Constitution**.
+
+Activation, if later accepted through a separate exact-SHA pointer transition,
+means the Phase-18 Platform Constitution contracts become the active roadmap
+authority for module, package, capability, workspace, trust classification,
+plugin boundary, and Platform ABI validation design.
+
+This document does not activate Phase-18 and does not change
+`docs/roadmap/CURRENT_PHASE`.
+
+## Core Rule
+
+```text
+Constitution != Runtime
+```
+
+A manifest schema is not a manifest parser. A capability contract is not a
+capability engine. A workspace lifecycle specification is not a workspace
+runtime. A plugin boundary contract is not a plugin loader. A Platform ABI
+Validation Gate specification is not a runtime validator.
+
+The Platform Constitution may become active before any Platform Runtime exists.
+That activation must not be interpreted as permission to implement, load,
+install, enable, execute, mount, issue, trust, or run anything.
+
+## Activation Scope
+
+If Phase-18 is later activated, activation grants only:
+
+1. Active roadmap ownership for Phase-18 as Platform Constitution.
+2. Authority to maintain the accepted Platform Constitution reference set.
+3. Authority to prepare non-runtime examples and review checklists that do not
+   grant access, execute code, or create loader behavior.
+4. Authority to prepare later implementation RFCs for Phase-19 or another
+   explicitly reviewed phase.
+
+Activation does not grant runtime implementation authority.
+
+## Activation Does Not Authorize Implementation
+
+Phase-18 activation must not authorize:
+
+1. Runtime implementation.
+2. Package installation.
+3. Package execution.
+4. Workspace creation.
+5. Real filesystem mounts or logical mount runtime binding.
+6. Plugin loading.
+7. Plugin autoload.
+8. Capability issuance.
+9. Capability token minting.
+10. Trust assignment.
+11. Registry publication.
+12. Runtime loader creation.
+13. Semantic CLI execution authority.
+14. AI Runtime authority.
+15. New syscalls.
+16. Kernel ABI expansion.
+17. Ring0 policy.
+
+Any such work requires a separate reviewed phase decision, implementation RFC,
+evidence plan, and acceptance boundary.
+
+## Activation Preconditions
+
+The following preconditions are mandatory before any `CURRENT_PHASE=18`
+pointer transition may be considered:
+
+| ID | Precondition | Required result |
+|---|---|---|
+| A1 | Phase-17 official closure remains verified | `phase17-official-closure` resolves to `416a5392afbe217e16d26a59e2e1716fdfa9c8f6` |
+| A2 | Phase-18 transition decision exists | `PHASE18_TRANSITION_DECISION.md` remains accepted as Platform Constitution direction |
+| A3 | Platform Constitution RFC set exists | Module Manifest, Package Metadata, Trust Classification, Capability Contract, Workspace Lifecycle, Plugin Boundary, and Platform ABI Validation Gate are present |
+| A4 | Cross-consistency review accepted | `CROSS_CONSISTENCY_REVIEW.md` records PASS or is superseded by a newer accepted review |
+| A5 | Constitution/runtime separation explicit | This package preserves `Constitution != Runtime` |
+| A6 | Kernel ABI frozen | Syscall IDs remain `1000-1011`, syscall count remains `12`, ABI version remains `0x00010001` |
+| A7 | Kernel expansion absent | No new syscall, Ring0 policy, kernel loader, or kernel plugin system is bundled |
+| A8 | Authority separation intact | Trust, validation, manifest, package, workspace, plugin, and capability records do not grant each other's authority |
+| A9 | Local validation clean | Spec purity, naming, governance, drift activation, and diff checks pass for the candidate SHA |
+| A10 | Remote validation clean | Required GitHub checks, including strict `ci-freeze` and Dev Loop, pass on the exact activation candidate SHA |
+| A11 | Activation PR exact-SHA scoped | Activation evidence references the exact commit being considered |
+| A12 | Pointer transition separate | `CURRENT_PHASE=18` is performed only in a separate pointer-transition change after this package is accepted |
+
+Missing, stale, ambiguous, or partially satisfied preconditions fail closed.
+
+## Required Pointer Transition Shape
+
+The later pointer-transition change, if proposed, must be narrow:
+
+1. Update `docs/roadmap/CURRENT_PHASE` from `17` to `18`.
+2. Update status surfaces to say Phase-18 is active only as Platform
+   Constitution.
+3. Reference this activation decision package and the accepted exact-SHA
+   validation results.
+4. Avoid runtime implementation, source changes, package loader code,
+   workspace runtime code, plugin host code, capability token issuer code,
+   trust issuer code, Semantic CLI authority, AI Runtime authority, syscall
+   changes, and kernel ABI changes.
+
+If the pointer transition includes implementation work, it must be rejected.
+
+## Fail-Closed Denial Conditions
+
+Phase-18 activation must be denied if any of the following are true:
+
+1. `CURRENT_PHASE` is changed in the same PR that first introduces this
+   decision package.
+2. Cross-consistency review is missing, stale, or contradicted.
+3. Kernel ABI expansion is present or implied.
+4. A new syscall is present or implied.
+5. Ring0 policy is present or implied.
+6. Any document treats trust as capability.
+7. Any document treats validation PASS as authority grant.
+8. Any document treats plugin compatibility as loading.
+9. Any document treats workspace admission as runtime mount creation.
+10. Any document treats capability decision records or receipts as bearer
+    tokens.
+11. Any document treats Semantic CLI or AI Runtime output as execution
+    authority.
+12. Runtime implementation is bundled with activation.
+13. Required local or remote checks fail.
+14. Activation evidence is not exact-SHA scoped.
+
+The safe default is no activation.
+
+## Activation Evidence Package
+
+The accepted activation evidence package must include:
+
+1. Exact activation candidate SHA.
+2. Local validation summary.
+3. Remote `ci-freeze` run id and conclusion.
+4. Remote Dev Loop run id and conclusion.
+5. Governance/spec/naming/evidence boundary run conclusions.
+6. Confirmation that `CURRENT_PHASE` remained `17` until the later pointer
+   transition change.
+7. Confirmation that no runtime implementation or kernel ABI change was
+   included.
+
+CI PASS is not activation by itself. It is only an input to the reviewed
+activation decision.
+
+## Relationship To Phase-19
+
+Phase-19 is the earliest planned phase for Platform Runtime MVP work.
+
+Phase-18 activation must not pull Phase-19 work forward. Package installers,
+runtime loaders, workspace runtime bindings, plugin host execution, capability
+token issuance, trust issuer implementation, registry services, Semantic CLI
+integration, and AI Runtime foundations remain outside Phase-18 unless a
+separate reviewed decision changes the roadmap.
+
+## Decision Package Conclusion
+
+This package is ready for review as an activation decision candidate.
+
+It does not activate Phase-18. The next safe action after accepting this
+package is a separate, narrow `CURRENT_PHASE=18` pointer-transition proposal
+that preserves Platform Constitution scope and excludes runtime
+implementation.

--- a/PHASE18_TRANSITION_DECISION.md
+++ b/PHASE18_TRANSITION_DECISION.md
@@ -101,6 +101,9 @@ must pass a cross-consistency review that confirms terminology, dependency
 order, validation order, and authority separation remain fail-closed. The
 current review record is
 `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`.
+The activation decision package candidate is `PHASE18_ACTIVATION_DECISION.md`;
+it does not change `CURRENT_PHASE` and it preserves the rule
+`Constitution != Runtime`.
 
 ## Non-Goals
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **CURRENT_PHASE:** `17` (`Phase-17 OFFICIALLY CLOSED`; Phase-18 ayrı transition olmadan aktif değildir)
 **Freeze Zinciri:** `make ci-freeze` = 40 kapılı strict suite (normative spec-purity dahil) | `make ci-freeze-local` = local performance authority
 **Authority Durumu:** Issue #145 tek-maintainer authority kararıyla giderildi; PR #142, PR #144, PR #148, PR #149, PR #151, PR #150, PR #152 ve Phase-17 closure decision package birleşti. Closure exact-SHA kanıtı `main` SHA `416a5392` üzerinde yenilendi, gerekli uzak acceptance kontrolleri PASS verdi ve `phase17-official-closure` tag'i aynı SHA'ya doğrulandı
-**Yakın Hedef:** Phase-18 Platform Constitution RFC setini cross-review etmek ve ayri activation decision package hazirlamak; mevcut somut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`, `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md`, `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`, `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md` ve `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`, explicit pointer transition olmadan Phase-18 aktive edilmez
+**Yakın Hedef:** `PHASE18_ACTIVATION_DECISION.md` paketini review etmek; mevcut somut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`, `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md`, `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`, `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`, `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md` ve `PHASE18_ACTIVATION_DECISION.md`, explicit pointer transition olmadan Phase-18 aktive edilmez
 **Ring0 Export Ceiling:** `193 symbols` (current enforced ceiling)
 **Performance Baseline Candidate:** `gha-ubuntu24-20260518.149.1-X64` (authorized run `26370359958` artifact'i PR'a import edildi; SHA `f129d4aa` locked acceptance PASS verdi, ancak tek basina closure authority değildir)
 **Development Status:** Phase-16 OFFICIALLY CLOSED ✅ | Phase-17 OFFICIALLY CLOSED ✅ | SINGLE-MAINTAINER AUTHORITY ALIGNED (#145 RESOLVED) ✅ | PR #142/#144/#148/#149/#151/#150/#152 + closure decision package MERGED ✅ | EXACT-SHA REMOTE EVIDENCE PASS ✅ | Phase-18 TRANSITION DECISION PACKAGE ONLY
@@ -68,7 +68,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 - **Evidence:** A, B, C karakterleri başarıyla syscall üzerinden basıldı
 - **Result:** Ring3 infrastructure PROVEN, syscall path WORKING, instruction retirement VALIDATED
 
-**Next Focus:** Phase-18 Platform Constitution RFC setini cross-review etmek ve ayri activation decision package hazirlamak; mevcut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`, `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md`, `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`, `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md` ve `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`, `CURRENT_PHASE` explicit pointer transition olmadan `18` yapılmayacaktır.
+**Next Focus:** `PHASE18_ACTIVATION_DECISION.md` paketini review etmek; mevcut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`, `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md`, `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`, `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`, `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md` ve `PHASE18_ACTIVATION_DECISION.md`, `CURRENT_PHASE` explicit pointer transition olmadan `18` yapılmayacaktır.
 
 ## Authority Model
 
@@ -318,6 +318,7 @@ Phase 12 trust layer kapsamında tamamlananlar:
 - **Phase-18 Plugin Boundary Contract:** `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`
 - **Phase-18 Platform ABI Validation Gate:** `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`
 - **Phase-18 Cross-Consistency Review:** `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`
+- **Phase-18 Activation Decision Package:** `PHASE18_ACTIVATION_DECISION.md`
 - **Documentation Index:** `docs/development/DOCUMENTATION_INDEX.md`
 - **Ring3 User-Leaf Rule:** `docs/governance/RING3_USER_LEAF_ALLOCATION_RULE.md`
 - **Ring3 Runtime Closure Note:** `docs/governance/RING3_RUNTIME_CLOSURE_NOTE.md`
@@ -355,7 +356,8 @@ AykenOS iki lisans modeli ile dağıtılır:
 - Plugin boundary contract RFC draft: `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`; plugin loading/autoload/execution ve capability/trust/workspace inheritance yok.
 - Platform ABI validation gate RFC draft: `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`; validation PASS authority grant degildir.
 - Phase-18 cross-consistency review: `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`; review PASS activation degildir.
-- Separate Phase-18 activation decision package; `CURRENT_PHASE=18` ancak explicit pointer transition ve exact-SHA checks ile degerlendirilir.
+- Phase-18 activation decision package: `PHASE18_ACTIVATION_DECISION.md`; `Constitution != Runtime`, package kabulü `CURRENT_PHASE=18` yapmaz.
+- Separate `CURRENT_PHASE=18` pointer-transition proposal; ancak activation package kabul edildikten ve exact-SHA checks PASS verdikten sonra degerlendirilir.
 
 **Orta Vadeli:**
 - Phase-19 Platform Runtime MVP.
@@ -370,7 +372,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 
 ---
 
-**Son Güncelleme:** 05 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=17; Module Manifest, Capability Contract, Workspace Lifecycle, Package Metadata, Trust Classification, Plugin Boundary ve Platform ABI Validation Gate RFC draft'lari Phase-18 Platform Constitution pre-activation setine eklendi; Cross-Consistency Review activation blocker olarak kaydedildi; explicit transition olmadan Phase-18 aktif değildir.
+**Son Güncelleme:** 05 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=17; Module Manifest, Capability Contract, Workspace Lifecycle, Package Metadata, Trust Classification, Plugin Boundary ve Platform ABI Validation Gate RFC draft'lari Phase-18 Platform Constitution pre-activation setine eklendi; Cross-Consistency Review ve `PHASE18_ACTIVATION_DECISION.md` activation blocker olarak kaydedildi; explicit transition olmadan Phase-18 aktif değildir.
 **Düzenleyen / Geliştiren / Oluşturan / Mimari Sorumlu:** Kenan AY *(metadata only; runtime/karar yetkisi değildir).*
 
 **© 2026 Kenan AY — AykenOS Project**

--- a/docs/development/DOCUMENTATION_INDEX.md
+++ b/docs/development/DOCUMENTATION_INDEX.md
@@ -17,7 +17,7 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict
 - **Execution Pipeline:** `Phase-17` officially closed — tag `phase17-official-closure` at `416a5392`
 - **Formal Governance Pointer:** `CURRENT_PHASE=17`
 - **Active Phase:** Phase-17 OFFICIALLY CLOSED / Phase-18 TRANSITION NOT ACTIVATED
-- **Active Execution Priority:** Cross-review the Phase-18 Platform Constitution RFC set through `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`, then prepare a separate activation decision package without changing `CURRENT_PHASE=17`
+- **Active Execution Priority:** Review `PHASE18_ACTIVATION_DECISION.md` without changing `CURRENT_PHASE=17`
 - **Scope Boundary:** Phase-18 is not active until an explicit `CURRENT_PHASE` pointer transition; kernel expansion, new syscalls, Ring0 policy and AI Runtime authority remain forbidden for Phase-18
 
 ## Primary Truth Sources
@@ -42,14 +42,15 @@ Current repo truth icin once su dosyalari referans alin:
 17. `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md` — **plugin boundary compatibility RFC draft**
 18. `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md` — **Platform ABI validation order/receipt RFC draft**
 19. `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md` — **Phase-18 RFC set cross-consistency review; not activation**
-20. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
-21. `reports/phase15_official_closure/closure_index.json`
-22. `reports/phase13_official_closure_candidate/closure_index.json`
-23. `reports/phase12_official_closure_candidate/closure_manifest.json`
-24. `reports/phase10_phase11_official_closure_index.json`
-25. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
-26. `Makefile`
-27. `.github/workflows/ci-freeze.yml`
+20. `PHASE18_ACTIVATION_DECISION.md` — **Phase-18 activation decision package candidate; not pointer transition**
+21. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
+22. `reports/phase15_official_closure/closure_index.json`
+23. `reports/phase13_official_closure_candidate/closure_index.json`
+24. `reports/phase12_official_closure_candidate/closure_manifest.json`
+25. `reports/phase10_phase11_official_closure_index.json`
+26. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
+27. `Makefile`
+28. `.github/workflows/ci-freeze.yml`
 
 Phase-14 workstream numbering ve aktif durum yorumu icin canonical truth source:
 
@@ -91,13 +92,14 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 13. `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`
 14. `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`
 15. `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`
-16. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
-17. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
-18. `docs/specs/phase16-ayken-orchestration/README.md`
-19. `docs/specs/authority-lineage-v1/README.md`
-20. `docs/specs/phase14-distributed-observability/README.md`
-21. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
-22. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
+16. `PHASE18_ACTIVATION_DECISION.md` — activation decision package candidate
+17. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
+18. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
+19. `docs/specs/phase16-ayken-orchestration/README.md`
+20. `docs/specs/authority-lineage-v1/README.md`
+21. `docs/specs/phase14-distributed-observability/README.md`
+22. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
+23. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
 
 ## Phase-18 Reference Set
 1. `PHASE18_TRANSITION_DECISION.md`
@@ -110,6 +112,7 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 8. `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`
 9. `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`
 10. `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`
+11. `PHASE18_ACTIVATION_DECISION.md`
 
 ## Phase-14 Reference Set
 ### Architecture and Observability Surfaces
@@ -221,7 +224,8 @@ Eski raporlarda gecen blocker veya progress ifadeleri tarihsel baglam icindir.
 Current status yorumlari icin Phase-17 official closure otoritesi,
 `docs/roadmap/CURRENT_PHASE` ve aktif stabilization roadmap birlikte
 kullanilmalidir. Yeni ozellik veya Phase-18 aktivasyonu,
-`PHASE18_TRANSITION_DECISION.md` review edilip explicit `CURRENT_PHASE`
-transition yapilmadan current execution plani olarak sunulamaz.
+`PHASE18_TRANSITION_DECISION.md` ve `PHASE18_ACTIVATION_DECISION.md` review
+edilip explicit `CURRENT_PHASE` transition yapilmadan current execution plani
+olarak sunulamaz.
 
-**Son Guncelleme:** 2026-06-04
+**Son Guncelleme:** 2026-06-05

--- a/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
+++ b/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
@@ -354,6 +354,11 @@ Phase-18 transition su kararlari korumadan aktif uygulama planina donusemez:
    spec'leri fail-closed olarak review edilmeden implementation phase baslamaz.
 10. Cross-consistency review kabul edilmeden activation decision package
     hazirlanmis sayilmaz.
+11. `PHASE18_ACTIVATION_DECISION.md` kabul edilmeden `CURRENT_PHASE=18`
+    pointer transition'i degerlendirilemez.
+12. Constitution Runtime degildir; activation runtime implementation,
+    package install, workspace creation, plugin loading, capability issuance
+    veya trust assignment yetkisi vermez.
 
 ## 7. PR Sequence and Coordination Matrix
 
@@ -384,6 +389,7 @@ Phase-18 transition su kararlari korumadan aktif uygulama planina donusemez:
 | Phase-18 Plugin Boundary Contract | DOCS-ONLY / PRE-ACTIVATION RFC | Host interface, extension point, compatibility, binding lifecycle ve fail-closed plugin boundary sinirlarini tanimlamak | `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md` | Plugin loading/autoload/execution yok; capability/trust/workspace inheritance yok |
 | Phase-18 Platform ABI Validation Gate | DOCS-ONLY / PRE-ACTIVATION RFC | Manifest, package, trust, capability, workspace ve plugin boundary input'larini deterministik fail-closed validation order ile baglamak | `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md` | Validation PASS authority grant degil; install/enable/execute/load/mount/capability/trust grant yok |
 | Phase-18 Cross-Consistency Review | DOCS-ONLY / PRE-ACTIVATION REVIEW | Yedi Phase-18 RFC'nin terminology, dependency order, validation order ve authority separation acisindan celismedigini kaydetmek | `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md` | Review PASS activation degil; activation package ve explicit pointer transition gerekir |
+| Phase-18 Activation Decision Package | DOCS-ONLY / ACTIVATION CANDIDATE / PHASE-18 NOT ACTIVATED | Phase-18 aktivasyonu icin precondition, exact-SHA, fail-closed denial ve Constitution != Runtime sinirlarini kaydetmek | `PHASE18_ACTIVATION_DECISION.md` | Package kabulü `CURRENT_PHASE=18` yapmaz; runtime implementation, capability issuance, trust assignment, workspace creation veya plugin loading yetkisi yok |
 
 PR koordinasyon kurallari:
 
@@ -1069,7 +1075,8 @@ Bu roadmap su olaylarda guncellenir:
 23. Phase-18 Plugin Boundary Contract review/merge sonucu.
 24. Phase-18 Platform ABI Validation Gate review/merge sonucu.
 25. Phase-18 Cross-Consistency Review sonucu.
-26. Yeni feature/ABI/authority surface onerisinin incelenmesi.
+26. Phase-18 Activation Decision Package review/merge sonucu.
+27. Yeni feature/ABI/authority surface onerisinin incelenmesi.
 
 ## References
 
@@ -1097,6 +1104,7 @@ Bu roadmap su olaylarda guncellenir:
 - `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`
 - `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`
 - `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`
+- `PHASE18_ACTIVATION_DECISION.md`
 - `PHASE18_ROADMAP.md`
 - `shared/abi/syscall_v2.h`
 - `shared/abi/ayken_abi.h`

--- a/docs/roadmap/CURRENT_PHASE
+++ b/docs/roadmap/CURRENT_PHASE
@@ -7,5 +7,5 @@ CURRENT_PHASE=17
 # Proposed Phase-18 direction: Platform Constitution, not kernel expansion.
 # Active execution roadmap: docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
 # Remote evidence: ci-freeze 26712333892, Performance Gate 26715068398, Phase-17 lifecycle/determinism/public-e2e/worker/timeout/performance lanes all PASS on 416a5392.
-# Immediate work package: review the Phase-18 Platform Constitution set through docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md and then prepare a separate activation decision package; do not activate Phase-18 without an explicit pointer transition.
+# Immediate work package: review PHASE18_ACTIVATION_DECISION.md; do not activate Phase-18 without a later explicit pointer transition.
 # Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu: Kenan AY (informational metadata only).

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -2,7 +2,7 @@
 This document is subordinate to `ARCHITECTURE_FREEZE.md`. In case of conflict,
 the freeze contract prevails.
 
-**Last authority sync:** 2026-05-31 (Phase-17 official closure tag verification)
+**Last authority sync:** 2026-06-05 (Phase-18 activation decision package candidate)
 **Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu:** Kenan AY
 **Attribution boundary:** Documentation metadata only; not runtime or merge authority.
 
@@ -45,7 +45,10 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 14. `../specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`:
    Phase-18 RFC set capraz tutarlilik review kaydi; activation veya runtime
    implementation yetkisi degildir.
-15. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
+15. `../../PHASE18_ACTIVATION_DECISION.md`: Phase-18 activation decision
+   package candidate; `CURRENT_PHASE` pointer transition'i veya runtime
+   implementation yetkisi degildir.
+16. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
    planlamasi; aktif Phase-18 otoritesi degildir.
 
 ## Current Status
@@ -54,7 +57,7 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 |---|---|
 | Son resmi kapanis | Phase-17 OFFICIALLY CLOSED (`phase17-official-closure` at `416a5392`) |
 | Aktif faz | Phase-17 OFFICIALLY CLOSED / Phase-18 transition not activated |
-| Aktif odak | Phase-18 Platform Constitution RFC set cross-review and activation decision package preparation; no activation without explicit pointer transition |
+| Aktif odak | Phase-18 Platform Constitution activation decision package review; no activation without separate explicit pointer transition |
 | ABI | Canonical `1000-1011` / 12 syscall, ABI version `0x00010001` |
 | Phase-18 | TRANSITION DECISION PACKAGE ONLY; kernel expansion and new syscalls forbidden unless a separate phase RFC/closure authority exists |
 
@@ -83,7 +86,7 @@ current execution priority otoritesi degildir:
 
 ---
 
-**Next action:** Phase-18 activation decision package ayri dokuman olarak
-hazirlanir; `CURRENT_PHASE` explicit pointer transition ile `18` yapilmadan
-once `CROSS_CONSISTENCY_REVIEW.md` kabul edilir ve required freeze/governance
-checks exact-SHA uzerinde PASS verir.
+**Next action:** `../../PHASE18_ACTIVATION_DECISION.md` review edilir;
+`CURRENT_PHASE` explicit pointer transition ile `18` yapilmadan once
+activation package kabul edilir ve required freeze/governance checks exact-SHA
+uzerinde PASS verir.

--- a/docs/specs/phase18-platform-constitution/README.md
+++ b/docs/specs/phase18-platform-constitution/README.md
@@ -45,6 +45,18 @@ current seven-RFC Platform Constitution set. This result is a documentation
 review only. It does not activate Phase-18 and does not authorize
 implementation.
 
+## Activation Boundary
+
+`../../../PHASE18_ACTIVATION_DECISION.md` is the separate activation decision
+package candidate. It does not activate Phase-18, does not change
+`CURRENT_PHASE=17`, and does not authorize runtime implementation.
+
+The mandatory activation rule is:
+
+```text
+Constitution != Runtime
+```
+
 ## Non-Authority Rule
 
 No file in this directory may grant:


### PR DESCRIPTION
## Summary
- add PHASE18_ACTIVATION_DECISION.md as a docs-only activation decision package candidate
- record activation preconditions A1-A12, fail-closed denial conditions, and exact-SHA evidence requirements
- add the explicit Constitution != Runtime rule and sync roadmap/index references

## Authority boundary
- does not activate Phase-18
- does not change CURRENT_PHASE=17
- does not authorize runtime implementation, package install/execution, workspace creation, plugin loading, capability issuance, trust assignment, Semantic CLI authority, AI Runtime authority, new syscalls, or kernel ABI expansion

## Local validation
- git diff HEAD^..HEAD --check
- make ci-gate-spec-purity
- make ci-gate-naming-compliance
- make ci-gate-governance
- make ci-gate-drift-activation
- python3 tools/ci/validate_phase17_closure_candidate.py --expected-subject-sha 416a5392afbe217e16d26a59e2e1716fdfa9c8f6