### PR TITLE
docs: activate phase18 platform constitution pointer

### DIFF
--- a/AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md
+++ b/AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md
@@ -2,26 +2,27 @@
 
 **Durum tarihi:** 2026-05-23
 **Uygulama ek kaydi:** 2026-05-24/26 (Phase-17 S1.E2E, PR-2B fixture worker completion, PR-3 IRQ timeout-race, PR-4 local performance readiness, PR-4A/PR-4B variance isolation, full-freeze timer witness integration repair, validation flag matrix, issue #145 tek-maintainer authority giderimi, PR #142/#144 merge, PR #148 performance authority onarimi, accepted-main exact-SHA remote evidence PASS ve Phase-17 closure-candidate kaydi)
-**Authority sync:** 2026-05-31 (`phase17-official-closure` verified at `416a5392`; Phase-18 transition not activated)
+**Authority sync:** 2026-06-05 (`CURRENT_PHASE=18`; Phase-18 active as Platform Constitution only)
 **Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu:** Kenan AY
 **Dijital imza siniri:** Bu atif yalnizca insan-okunur dokumantasyon ve metadata icindir; runtime log, karar veya yetki kaynagi degildir.
 
 > Authority note: This report preserves the 2026-05-23 stabilization narrative.
 > Current phase authority is `docs/roadmap/CURRENT_PHASE`, the Phase-17
-> official closure package, and `PHASE18_TRANSITION_DECISION.md` as a
-> docs-only Platform Constitution transition package.
+> official closure package, `PHASE18_TRANSITION_DECISION.md`, and
+> `PHASE18_ACTIVATION_DECISION.md`. Phase-18 is active only as Platform
+> Constitution and does not authorize runtime implementation.
 
 ## Yetkili Durum
 
 | Konu | Repo gercegi | Sonuc |
 |---|---|---|
 | Son resmi kapanis | `phase17-official-closure` etiketi `416a5392` uzerinde dogrulandi | Phase-17 OFFICIALLY CLOSED |
-| Aktif faz | `CURRENT_PHASE=17` | Phase-17 OFFICIALLY CLOSED / Phase-18 transition not activated |
+| Aktif faz | `CURRENT_PHASE=18` | Phase-18 ACTIVE / Platform Constitution only |
 | Step 5 | PR #134, merge `71d10691` | Marker-validation dilimi mainline'a birlesti |
 | Phase-17 kapanisi | `reports/phase17_official_closure_candidate/` official closure package ve verified tag mevcut | Closure authority exact-SHA subject ile sinirlidir; Phase-18'i aktive etmez |
 | Phase-17.5 | PR #142, PR #144, PR #148, PR #149/#151/#150, PR #152 ve closure decision package `main`e kabul edildi | Accepted subject SHA `416a5392` icin bounded evidence resmi closure'a baglandi |
-| Phase-18 | `PHASE18_TRANSITION_DECISION.md` | Platform Constitution transition package; aktif faz degildir |
-| Aktif execution roadmap | `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + `PHASE18_TRANSITION_DECISION.md` review | Explicit `CURRENT_PHASE` transition olmadan Phase-18 baslatilmaz |
+| Phase-18 | `PHASE18_TRANSITION_DECISION.md` + `PHASE18_ACTIVATION_DECISION.md` | Platform Constitution active; runtime implementation yetkisi degildir |
+| Aktif execution roadmap | `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution reference set | Phase-19 veya ayri implementation karari olmadan runtime baslatilmaz |
 | Canonical performance baseline | `scripts/ci/perf-baseline.lock.json` | Accepted `main` SHA `416a5392`: standalone Performance Gate `26715068398` ve scoped Phase-17 acceptance `26712374737` PASS; closure tag dogrulandi |
 | Review enforcement | Issue #145 tek-maintainer ADR'i, `@kenanay` CODEOWNERS accountability metadata'si ve canli `main` `freeze` protection paritesi ile kapatildi | Bagimsiz self-review iddiasi yoktur; remote CI ve kayitli maintainer karari merge siniridir |
 

--- a/PHASE18_ACTIVATION_DECISION.md
+++ b/PHASE18_ACTIVATION_DECISION.md
@@ -4,7 +4,7 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
 `ARCHITECTURE_FREEZE.md`, `PHASE18_TRANSITION_DECISION.md`, and the Phase-18
 Platform Constitution RFC set. In case of conflict, those documents prevail.
 
-**Status:** ACTIVATION DECISION PACKAGE CANDIDATE / PHASE-18 NOT ACTIVATED
+**Status:** ACCEPTED ACTIVATION DECISION / PHASE-18 ACTIVE AS PLATFORM CONSTITUTION
 **Decision package date:** 2026-06-05
 **Authority basis:** `phase17-official-closure` at
 `416a5392afbe217e16d26a59e2e1716fdfa9c8f6`, the reviewed Phase-18 Platform
@@ -14,17 +14,17 @@ Constitution RFC set, and
 runtime, merge, execution, install, trust, capability, workspace, plugin,
 Semantic CLI, AI Runtime, syscall, kernel ABI, or phase pointer authority.
 
-## Decision Candidate
+## Decision
 
-Phase-18 may be activated only as **Platform Constitution**.
+Phase-18 is activated only as **Platform Constitution**.
 
-Activation, if later accepted through a separate exact-SHA pointer transition,
-means the Phase-18 Platform Constitution contracts become the active roadmap
-authority for module, package, capability, workspace, trust classification,
-plugin boundary, and Platform ABI validation design.
+Activation means the Phase-18 Platform Constitution contracts are the active
+roadmap authority for module, package, capability, workspace, trust
+classification, plugin boundary, and Platform ABI validation design.
 
-This document does not activate Phase-18 and does not change
-`docs/roadmap/CURRENT_PHASE`.
+The separate pointer transition sets `docs/roadmap/CURRENT_PHASE` to `18`.
+That pointer activates only the constitutional specification surface. It does
+not authorize runtime implementation.
 
 ## Core Rule
 
@@ -43,7 +43,7 @@ install, enable, execute, mount, issue, trust, or run anything.
 
 ## Activation Scope
 
-If Phase-18 is later activated, activation grants only:
+Phase-18 activation grants only:
 
 1. Active roadmap ownership for Phase-18 as Platform Constitution.
 2. Authority to maintain the accepted Platform Constitution reference set.
@@ -81,8 +81,8 @@ evidence plan, and acceptance boundary.
 
 ## Activation Preconditions
 
-The following preconditions are mandatory before any `CURRENT_PHASE=18`
-pointer transition may be considered:
+The following preconditions were mandatory before the `CURRENT_PHASE=18`
+pointer transition could be considered:
 
 | ID | Precondition | Required result |
 |---|---|---|
@@ -101,9 +101,9 @@ pointer transition may be considered:
 
 Missing, stale, ambiguous, or partially satisfied preconditions fail closed.
 
-## Required Pointer Transition Shape
+## Pointer Transition Shape
 
-The later pointer-transition change, if proposed, must be narrow:
+The pointer-transition change must remain narrow:
 
 1. Update `docs/roadmap/CURRENT_PHASE` from `17` to `18`.
 2. Update status surfaces to say Phase-18 is active only as Platform
@@ -143,20 +143,20 @@ The safe default is no activation.
 
 ## Activation Evidence Package
 
-The accepted activation evidence package must include:
+The accepted activation evidence package includes or requires:
 
 1. Exact activation candidate SHA.
 2. Local validation summary.
 3. Remote `ci-freeze` run id and conclusion.
 4. Remote Dev Loop run id and conclusion.
 5. Governance/spec/naming/evidence boundary run conclusions.
-6. Confirmation that `CURRENT_PHASE` remained `17` until the later pointer
-   transition change.
+6. Confirmation that `CURRENT_PHASE` remained `17` until this separate
+   pointer-transition change.
 7. Confirmation that no runtime implementation or kernel ABI change was
    included.
 
 CI PASS is not activation by itself. It is only an input to the reviewed
-activation decision.
+activation decision and pointer transition.
 
 ## Relationship To Phase-19
 
@@ -170,9 +170,7 @@ separate reviewed decision changes the roadmap.
 
 ## Decision Package Conclusion
 
-This package is ready for review as an activation decision candidate.
+This package is accepted as the Phase-18 activation decision.
 
-It does not activate Phase-18. The next safe action after accepting this
-package is a separate, narrow `CURRENT_PHASE=18` pointer-transition proposal
-that preserves Platform Constitution scope and excludes runtime
-implementation.
+The resulting `CURRENT_PHASE=18` pointer transition preserves Platform
+Constitution scope and excludes runtime implementation.

--- a/PHASE18_TRANSITION_DECISION.md
+++ b/PHASE18_TRANSITION_DECISION.md
@@ -4,7 +4,7 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH and
 `ARCHITECTURE_FREEZE.md`. In case of conflict, the foundational oath and the
 freeze contract prevail.
 
-**Status:** TRANSITION DECISION PACKAGE / PHASE-18 NOT ACTIVATED
+**Status:** ACCEPTED TRANSITION DECISION / PHASE-18 ACTIVE AS PLATFORM CONSTITUTION
 **Decision date:** 2026-05-31
 **Authority basis:** `phase17-official-closure` at
 `416a5392afbe217e16d26a59e2e1716fdfa9c8f6`
@@ -20,10 +20,9 @@ classification, and plugin boundaries on top of the frozen execution substrate.
 Phase-18 is therefore the **Platform Constitution** phase, not a continuation
 of kernel runtime bring-up and not a new syscall phase.
 
-This package records the intended Phase-18 direction. It does not by itself
-change `docs/roadmap/CURRENT_PHASE` to `18`. Activation requires an explicit
-transition update that points `CURRENT_PHASE` and the active roadmap surfaces to
-this decision.
+This package records the Phase-18 direction. It did not by itself change
+`docs/roadmap/CURRENT_PHASE` to `18`; the separate activation decision and
+pointer transition now bind Phase-18 to Platform Constitution scope.
 
 ## Closure Preconditions Already Satisfied
 
@@ -88,22 +87,20 @@ Required Platform Constitution outputs:
 7. Platform ABI validation gate (`docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`).
 8. Minimal reference examples that do not create new runtime authority.
 
-Initial pre-activation spec work starts with the Module Manifest Schema,
-Capability Contract Specification, Workspace Lifecycle Specification, Package
-Metadata Schema, Trust Classification Model, Plugin Boundary Contract, and
-Platform ABI Validation Gate. This does not activate Phase-18 and does not
-grant capability, package install, package execution, workspace, trust
-assignment, plugin loading, validation authority, semantic, or AI Runtime
+The accepted Platform Constitution spec set consists of the Module Manifest
+Schema, Capability Contract Specification, Workspace Lifecycle Specification,
+Package Metadata Schema, Trust Classification Model, Plugin Boundary Contract,
+and Platform ABI Validation Gate. This activation does not grant capability,
+package install, package execution, workspace runtime, trust assignment,
+plugin loading, validation authority, semantic authority, or AI Runtime
 authority.
 
-Before an activation decision package can be considered, the current RFC set
-must pass a cross-consistency review that confirms terminology, dependency
-order, validation order, and authority separation remain fail-closed. The
-current review record is
+Before activation, the RFC set passed a cross-consistency review that confirms
+terminology, dependency order, validation order, and authority separation
+remain fail-closed. The current review record is
 `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`.
-The activation decision package candidate is `PHASE18_ACTIVATION_DECISION.md`;
-it does not change `CURRENT_PHASE` and it preserves the rule
-`Constitution != Runtime`.
+The accepted activation decision package is `PHASE18_ACTIVATION_DECISION.md`;
+it preserves the rule `Constitution != Runtime`.
 
 ## Non-Goals
 
@@ -205,18 +202,19 @@ AI Runtime is intentionally outside Phase-18. Its non-determinism, authority
 ambiguity, hallucination risk, and verification difficulty require a later
 foundation after the platform contracts are explicit.
 
-## Fail-Closed Activation Rule
+## Fail-Closed Scope Rule
 
-Phase-18 must remain inactive if any of the following are true:
+Phase-18 Platform Constitution authority must fail closed if any of the
+following are true:
 
-1. `CURRENT_PHASE` has not been explicitly transitioned.
-2. Platform Constitution scope is ambiguous.
-3. Kernel ABI expansion is bundled into the transition.
-4. Trust classification is treated as capability grant.
-5. AI Runtime or Semantic CLI is made an execution authority.
+1. Platform Constitution scope is ambiguous.
+2. Kernel ABI expansion is bundled into the phase.
+3. Trust classification is treated as capability grant.
+4. AI Runtime or Semantic CLI is made an execution authority.
+5. Runtime implementation is treated as authorized by activation.
 6. Required closure references cannot be verified.
 
-The safe default is no activation.
+The safe default is no runtime authority.
 
 ## Supersession Notice
 

--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **Remote CI (Phase-13):** `ci-freeze#23706742211 = success` (PR #81)
 **Remote CI (Phase-15):** `ci-freeze#24213727039 = success` (PR #104) | tag `phase15-official-closure`
 **Remote CI (Phase-16):** Verification Layer MVP complete (2026-04-25)
-**CURRENT_PHASE:** `17` (`Phase-17 OFFICIALLY CLOSED`; Phase-18 ayrı transition olmadan aktif değildir)
+**CURRENT_PHASE:** `18` (`Phase-18 ACTIVE: Platform Constitution`; runtime implementation yetkisi değildir)
 **Freeze Zinciri:** `make ci-freeze` = 40 kapılı strict suite (normative spec-purity dahil) | `make ci-freeze-local` = local performance authority
 **Authority Durumu:** Issue #145 tek-maintainer authority kararıyla giderildi; PR #142, PR #144, PR #148, PR #149, PR #151, PR #150, PR #152 ve Phase-17 closure decision package birleşti. Closure exact-SHA kanıtı `main` SHA `416a5392` üzerinde yenilendi, gerekli uzak acceptance kontrolleri PASS verdi ve `phase17-official-closure` tag'i aynı SHA'ya doğrulandı
-**Yakın Hedef:** `PHASE18_ACTIVATION_DECISION.md` paketini review etmek; mevcut somut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`, `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md`, `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`, `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`, `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md` ve `PHASE18_ACTIVATION_DECISION.md`, explicit pointer transition olmadan Phase-18 aktive edilmez
+**Yakın Hedef:** Phase-18 Platform Constitution kapsamını korumak; mevcut somut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`, `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md`, `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`, `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`, `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md` ve `PHASE18_ACTIVATION_DECISION.md`; Phase-18 runtime, loader, installer, workspace runtime, plugin loading, capability issuance veya trust assignment yetkisi vermez
 **Ring0 Export Ceiling:** `193 symbols` (current enforced ceiling)
 **Performance Baseline Candidate:** `gha-ubuntu24-20260518.149.1-X64` (authorized run `26370359958` artifact'i PR'a import edildi; SHA `f129d4aa` locked acceptance PASS verdi, ancak tek basina closure authority değildir)
-**Development Status:** Phase-16 OFFICIALLY CLOSED ✅ | Phase-17 OFFICIALLY CLOSED ✅ | SINGLE-MAINTAINER AUTHORITY ALIGNED (#145 RESOLVED) ✅ | PR #142/#144/#148/#149/#151/#150/#152 + closure decision package MERGED ✅ | EXACT-SHA REMOTE EVIDENCE PASS ✅ | Phase-18 TRANSITION DECISION PACKAGE ONLY
+**Development Status:** Phase-16 OFFICIALLY CLOSED ✅ | Phase-17 OFFICIALLY CLOSED ✅ | SINGLE-MAINTAINER AUTHORITY ALIGNED (#145 RESOLVED) ✅ | PR #142/#144/#148/#149/#151/#150/#152 + closure decision package MERGED ✅ | EXACT-SHA REMOTE EVIDENCE PASS ✅ | Phase-18 PLATFORM CONSTITUTION ACTIVE ✅
 
-**Proje Durumu:** Core OS Phase 4.5 TAMAMLANDI ✅ | Phase 10-17 kapanış kayıtları mevcut ✅ | Phase 17 Execution Pipeline OFFICIALLY CLOSED ✅ (2026-05-31) | CURRENT_PHASE=17 🔄 | Phase-18 ayrı transition olmadan aktif değil 🔒 | Architecture Freeze ACTIVE ✅
+**Proje Durumu:** Core OS Phase 4.5 TAMAMLANDI ✅ | Phase 10-17 kapanış kayıtları mevcut ✅ | Phase 17 Execution Pipeline OFFICIALLY CLOSED ✅ (2026-05-31) | CURRENT_PHASE=18 ✅ | Phase-18 Platform Constitution aktif 🔒 | Architecture Freeze ACTIVE ✅
 **Boot/Kernel Bring-up:** UEFI→kernel handoff doğrulandı ✅ | Ring3 process preparation operasyonel ✅ | ELF64 loader çalışıyor ✅ | User address space creation aktif ✅ | Syscall roundtrip doğrulandı ✅ | IRQ-tail preempt doğrulama hattı mevcut ✅
 **Phase 10 Status:** Runtime determinism officially closed ✅ | remote `ci-freeze` run `22797401328`
 **Phase 11 Status:** Replay + KPL + proof bundle officially closed ✅
@@ -40,9 +40,9 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **Phase 15 Status:** OFFICIALLY CLOSED ✅ | tag `phase15-official-closure` at `48970cd0` | remote `ci-freeze` run `24213727039` (PR #104) | BCIB Execution Engine v3: three-layer architecture, 293 tests PASS, 12 property tests PASS | `ayken-cli` v0.1 (Faz A wrapper) shipped | `tools/ayken-cli/`
 **Phase 16 Status:** OFFICIALLY CLOSED ✅ | Verification Layer MVP COMPLETE | Evidence chain integrity verified | Trust anchor established | `make verify-system` → 3 gates → PASS | Constitutional rule enforcement active | Fail-closed behavior confirmed
 **Phase 17 Status:** OFFICIALLY CLOSED ✅ | tag `phase17-official-closure` at `416a5392` | full `ci-freeze` (`26712333892`), locked performance (`26715068398`, `26712374737`) ve Phase-17 QEMU evidence lanes (`26712374742`, `26712374736`, `26712374727`, `26712374744`, `26712374728`) PASS | `reports/phase17_official_closure_candidate/`
-**Phase 18 Status:** TRANSITION DECISION PACKAGE ONLY | Proposed direction: Platform Constitution; kernel expansion/new syscalls/AI authority forbidden unless a separate phase RFC and closure authority exists
+**Phase 18 Status:** ACTIVE AS PLATFORM CONSTITUTION | Runtime implementation, kernel expansion, new syscalls, Ring0 policy and AI authority remain forbidden unless a separate phase RFC and closure authority exists
 **Architecture Quick Map:** `docs/specs/phase12-trust-layer/AYKENOS_GATE_ARCHITECTURE.md`
-**Active Execution Roadmap:** `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution RFC set | accepted `main` SHA `416a5392` uzerinde bounded uzak evidence PASS; official closure tag doğrulandı; Phase-18 explicit transition gerektirir
+**Active Execution Roadmap:** `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution RFC set | accepted `main` SHA `416a5392` uzerinde bounded uzak evidence PASS; official closure tag doğrulandı; Phase-18 Platform Constitution pointer'i aktiftir
 **Canonical Technical Definition:** AykenOS is a deterministic verification architecture that separates kernel execution, verification semantics, evidence artifacts, and distributed diagnostics into explicit layers. The kernel provides mechanism, userspace verification services produce artifact-bound verdicts and receipts, and parity/topology surfaces expose cross-node observability without elevating diagnostics into authority or consensus.
 
 ⚠️ **CI Mode:** `ci-freeze` workflow varsayılan olarak **CONSTITUTIONAL** modda çalışır (`PERF_BASELINE_MODE=constitutional`); provisional yol yalnız diagnosis/baseline artifact adayıdır ve acceptance/closure otoritesi değildir. Ayrıntı: [Constitutional CI Mode](docs/operations/CONSTITUTIONAL_CI_MODE.md), [Provisional CI Mode](docs/operations/PROVISIONAL_CI_MODE.md) ve [Performance Baseline Policy](docs/operations/PERF_BASELINE_POLICY.md).
@@ -51,13 +51,13 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 
 ## Phase Status
 
-- **Current Phase:** `17`
-- **Status:** `OFFICIALLY CLOSED / PHASE-18 TRANSITION NOT ACTIVATED`
+- **Current Phase:** `18`
+- **Status:** `ACTIVE / PLATFORM CONSTITUTION ONLY`
 - **Last Official Closure:** `17` (Execution Pipeline, 2026-05-31)
-- **Candidate Next Phase:** `18` (Platform Constitution; transition decision package only)
+- **Candidate Next Phase:** `19` (Platform Runtime MVP; separate decision required)
 - **Verification Layer:** `COMPLETE` (MVP delivered 2026-04-25)
 - **Closure Index:** `reports/phase17_official_closure_candidate/closure_index.json`
-- **Phase-17 Authority Note:** `phase17-official-closure` resolves to the reviewed exact-SHA evidence subject; Phase-18 activation still requires a separate transition decision.
+- **Phase-18 Authority Note:** `CURRENT_PHASE=18` activates Platform Constitution only; runtime implementation still requires a separate decision.
 
 ## 🎯 Latest Breakthrough (2026-04-24)
 
@@ -68,7 +68,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 - **Evidence:** A, B, C karakterleri başarıyla syscall üzerinden basıldı
 - **Result:** Ring3 infrastructure PROVEN, syscall path WORKING, instruction retirement VALIDATED
 
-**Next Focus:** `PHASE18_ACTIVATION_DECISION.md` paketini review etmek; mevcut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`, `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md`, `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`, `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`, `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md` ve `PHASE18_ACTIVATION_DECISION.md`, `CURRENT_PHASE` explicit pointer transition olmadan `18` yapılmayacaktır.
+**Next Focus:** Phase-18 Platform Constitution kapsamını korumak; mevcut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`, `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md`, `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`, `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`, `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md` ve `PHASE18_ACTIVATION_DECISION.md`; Phase-19 runtime MVP icin ayri karar gerekir.
 
 ## Authority Model
 
@@ -344,20 +344,20 @@ AykenOS iki lisans modeli ile dağıtılır:
 
 ## 🎯 Sonraki Hedefler
 
-**Kısa Vadeli (Phase-18 Transition):**
-- `PHASE18_TRANSITION_DECISION.md` merged; this is not Phase-18 activation.
-- `CURRENT_PHASE` transition decision; explicit pointer update olmadan Phase-18 aktive edilmez.
-- Platform ABI schema draft.
-- Module manifest schema RFC draft: `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`.
-- Capability contract RFC draft: `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`.
-- Workspace lifecycle contract RFC draft: `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`.
-- Package metadata schema RFC draft: `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`; identity/version/publisher/hash/signature/dependency/compatibility only.
-- Trust classification model RFC draft: `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md`; trust level capability grant degildir.
-- Plugin boundary contract RFC draft: `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`; plugin loading/autoload/execution ve capability/trust/workspace inheritance yok.
-- Platform ABI validation gate RFC draft: `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`; validation PASS authority grant degildir.
+**Kısa Vadeli (Phase-18 Platform Constitution):**
+- `CURRENT_PHASE=18`; Phase-18 yalniz Platform Constitution olarak aktiftir.
+- `PHASE18_TRANSITION_DECISION.md` ve `PHASE18_ACTIVATION_DECISION.md` accepted authority inputs olarak korunur.
+- Platform ABI schema authority maintained; runtime implementation yetkisi yoktur.
+- Module manifest schema active spec: `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`.
+- Capability contract active spec: `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`.
+- Workspace lifecycle contract active spec: `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`.
+- Package metadata schema active spec: `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`; identity/version/publisher/hash/signature/dependency/compatibility only.
+- Trust classification model active spec: `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md`; trust level capability grant degildir.
+- Plugin boundary contract active spec: `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`; plugin loading/autoload/execution ve capability/trust/workspace inheritance yok.
+- Platform ABI validation gate active spec: `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`; validation PASS authority grant degildir.
 - Phase-18 cross-consistency review: `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`; review PASS activation degildir.
-- Phase-18 activation decision package: `PHASE18_ACTIVATION_DECISION.md`; `Constitution != Runtime`, package kabulü `CURRENT_PHASE=18` yapmaz.
-- Separate `CURRENT_PHASE=18` pointer-transition proposal; ancak activation package kabul edildikten ve exact-SHA checks PASS verdikten sonra degerlendirilir.
+- Phase-18 activation decision package: `PHASE18_ACTIVATION_DECISION.md`; `Constitution != Runtime`, activation runtime implementation yetkisi vermez.
+- Phase-19 runtime MVP icin ayri implementation RFC/evidence plan/closure boundary hazirlanmadikca package installer, workspace runtime, plugin loader, capability issuer veya trust issuer yazilmaz.
 
 **Orta Vadeli:**
 - Phase-19 Platform Runtime MVP.
@@ -372,7 +372,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 
 ---
 
-**Son Güncelleme:** 05 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=17; Module Manifest, Capability Contract, Workspace Lifecycle, Package Metadata, Trust Classification, Plugin Boundary ve Platform ABI Validation Gate RFC draft'lari Phase-18 Platform Constitution pre-activation setine eklendi; Cross-Consistency Review ve `PHASE18_ACTIVATION_DECISION.md` activation blocker olarak kaydedildi; explicit transition olmadan Phase-18 aktif değildir.
+**Son Güncelleme:** 05 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=18; Module Manifest, Capability Contract, Workspace Lifecycle, Package Metadata, Trust Classification, Plugin Boundary, Platform ABI Validation Gate, Cross-Consistency Review ve `PHASE18_ACTIVATION_DECISION.md` Phase-18 Platform Constitution authority seti olarak aktiftir; runtime implementation Phase-19 veya ayrı karar olmadan yetkili değildir.
 **Düzenleyen / Geliştiren / Oluşturan / Mimari Sorumlu:** Kenan AY *(metadata only; runtime/karar yetkisi değildir).*
 
 **© 2026 Kenan AY — AykenOS Project**

--- a/docs/development/DOCUMENTATION_INDEX.md
+++ b/docs/development/DOCUMENTATION_INDEX.md
@@ -4,7 +4,7 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict
 **Last Updated:** 2026-06-05
 **Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu:** Kenan AY
 **Attribution Boundary:** Human-readable documentation metadata only; not runtime authority or execution evidence.
-**Current Authority Basis:** `phase17-official-closure` + `CURRENT_PHASE=17` + `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`
+**Current Authority Basis:** `phase17-official-closure` + `CURRENT_PHASE=18` + `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`
 
 ## Current Status
 - **Runtime:** `Phase-10` officially closed — `ci-freeze` run `22797401328`
@@ -15,16 +15,16 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict
 - **BCIB Execution Engine v3:** `Phase-15` officially closed — `ci-freeze` run `24213727039` (PR #104)
 - **Verification Layer MVP:** `Phase-16` officially closed — `ci-freeze` run `25214669681`, tag `phase16-official-closure`
 - **Execution Pipeline:** `Phase-17` officially closed — tag `phase17-official-closure` at `416a5392`
-- **Formal Governance Pointer:** `CURRENT_PHASE=17`
-- **Active Phase:** Phase-17 OFFICIALLY CLOSED / Phase-18 TRANSITION NOT ACTIVATED
-- **Active Execution Priority:** Review `PHASE18_ACTIVATION_DECISION.md` without changing `CURRENT_PHASE=17`
-- **Scope Boundary:** Phase-18 is not active until an explicit `CURRENT_PHASE` pointer transition; kernel expansion, new syscalls, Ring0 policy and AI Runtime authority remain forbidden for Phase-18
+- **Formal Governance Pointer:** `CURRENT_PHASE=18`
+- **Active Phase:** Phase-18 ACTIVE / Platform Constitution only
+- **Active Execution Priority:** Maintain Phase-18 Platform Constitution authority without runtime implementation
+- **Scope Boundary:** Phase-18 activation does not authorize runtime implementation; kernel expansion, new syscalls, Ring0 policy and AI Runtime authority remain forbidden for Phase-18
 
 ## Primary Truth Sources
 Current repo truth icin once su dosyalari referans alin:
 
 1. `ARCHITECTURE_FREEZE.md`
-2. `docs/roadmap/CURRENT_PHASE` — `CURRENT_PHASE=17`
+2. `docs/roadmap/CURRENT_PHASE` — `CURRENT_PHASE=18`
 3. `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` — **active execution roadmap**
 4. `AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md` — **current status report**
 5. `README.md`
@@ -33,16 +33,16 @@ Current repo truth icin once su dosyalari referans alin:
 8. `reports/phase17_official_closure_candidate/closure_decision_record.json`
 9. `reports/phase17_official_closure_candidate/closure_manifest.json`
 10. `reports/phase17_official_closure_candidate/closure_index.json`
-11. `PHASE18_TRANSITION_DECISION.md` — **Phase-18 Platform Constitution transition package; not active pointer**
-12. `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md` — **first pre-activation Platform Constitution RFC draft**
-13. `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md` — **capability request/decision/receipt/revocation RFC draft**
-14. `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md` — **workspace admission/logical-mount lifecycle RFC draft**
-15. `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md` — **package metadata evidence-only RFC draft**
-16. `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md` — **trust classification policy-input RFC draft**
-17. `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md` — **plugin boundary compatibility RFC draft**
-18. `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md` — **Platform ABI validation order/receipt RFC draft**
+11. `PHASE18_TRANSITION_DECISION.md` — **accepted Phase-18 Platform Constitution transition package**
+12. `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md` — **active Platform Constitution module manifest RFC**
+13. `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md` — **active capability request/decision/receipt/revocation RFC**
+14. `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md` — **active workspace admission/logical-mount lifecycle RFC**
+15. `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md` — **active package metadata evidence-only RFC**
+16. `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md` — **active trust classification policy-input RFC**
+17. `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md` — **active plugin boundary compatibility RFC**
+18. `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md` — **active Platform ABI validation order/receipt RFC**
 19. `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md` — **Phase-18 RFC set cross-consistency review; not activation**
-20. `PHASE18_ACTIVATION_DECISION.md` — **Phase-18 activation decision package candidate; not pointer transition**
+20. `PHASE18_ACTIVATION_DECISION.md` — **accepted Phase-18 activation decision package; runtime not authorized**
 21. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
 22. `reports/phase15_official_closure/closure_index.json`
 23. `reports/phase13_official_closure_candidate/closure_index.json`
@@ -78,7 +78,7 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 
 ## Roadmap and Status Surfaces
 1. `docs/roadmap/README.md`
-2. `docs/roadmap/CURRENT_PHASE` — `CURRENT_PHASE=17`
+2. `docs/roadmap/CURRENT_PHASE` — `CURRENT_PHASE=18`
 3. `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`
 4. `docs/roadmap/freeze-enforcement-workflow.md`
 5. `AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md`
@@ -92,7 +92,7 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 13. `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`
 14. `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`
 15. `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`
-16. `PHASE18_ACTIVATION_DECISION.md` — activation decision package candidate
+16. `PHASE18_ACTIVATION_DECISION.md` — accepted activation decision package
 17. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
 18. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
 19. `docs/specs/phase16-ayken-orchestration/README.md`

--- a/docs/governance/CI_GATE_INVENTORY_AND_DEBT_CONTROL_2026_05_25.md
+++ b/docs/governance/CI_GATE_INVENTORY_AND_DEBT_CONTROL_2026_05_25.md
@@ -6,7 +6,7 @@ promote a diagnostic lane, change runtime behavior, or grant closure.
 
 **Status:** S2 OPERATIONAL INVENTORY / REVIEW INPUT
 **Effective date:** 2026-05-25
-**Current phase:** Phase-17 officially closed; Phase-18 transition not activated
+**Current phase:** Phase-18 active as Platform Constitution only; runtime implementation not authorized
 **Accepted-main evidence subject:** `e0286c7b64c15e27f810e634713a07652def169c`
 (`ci-gate-phase17-performance-acceptance` run `26421686338` PASS and full
 `ci-freeze` run `26421295459` PASS)

--- a/docs/operations/BASELINE_RENEWAL_PROCEDURE.md
+++ b/docs/operations/BASELINE_RENEWAL_PROCEDURE.md
@@ -2,7 +2,7 @@
 
 **Effective date:** 2026-05-25
 **Current authority:** `github-hosted-ubuntu-24.04-x64`
-**Current phase:** Phase-17 officially closed; Phase-18 transition not activated
+**Current phase:** Phase-18 active as Platform Constitution only; runtime implementation not authorized
 **Authority boundary:** A generated lock artifact is not acceptance or merge
 authority. Import requires Kenan AY's recorded maintainer decision and
 subsequent constitutional remote PASS; it is not Phase-17 closure.

--- a/docs/operations/CONSTITUTIONAL_CI_MODE.md
+++ b/docs/operations/CONSTITUTIONAL_CI_MODE.md
@@ -3,7 +3,7 @@
 ## Status: DEFAULT FREEZE / LOCKED PERFORMANCE AUTHORITY
 
 **Effective date:** 2026-05-25
-**Current phase:** Phase-17 officially closed; Phase-18 transition not activated
+**Current phase:** Phase-18 active as Platform Constitution only; runtime implementation not authorized
 **Previous remotely tested S2-D head before accepted-main restack:** `342deab6`
 (`ci-gate-phase17-performance-acceptance` run `26391379459` PASS and full
 `ci-freeze` run `26391379462` PASS)

--- a/docs/operations/PERF_BASELINE_POLICY.md
+++ b/docs/operations/PERF_BASELINE_POLICY.md
@@ -2,7 +2,7 @@
 
 **Effective date:** 2026-05-25
 **Current authority:** `github-hosted-ubuntu-24.04-x64`
-**Current phase:** Phase-17 officially closed; Phase-18 transition not activated
+**Current phase:** Phase-18 active as Platform Constitution only; runtime implementation not authorized
 **Authority boundary:** A baseline renewal is an artifact-import procedure
 recorded by Kenan AY and followed by constitutional remote checks. It does
 not by itself grant merge authority or establish Phase-17 closure.

--- a/docs/operations/PROVISIONAL_CI_MODE.md
+++ b/docs/operations/PROVISIONAL_CI_MODE.md
@@ -3,7 +3,7 @@
 ## Status: DIAGNOSTIC / BASELINE-CANDIDATE ONLY
 
 **Effective date:** 2026-05-25
-**Current phase:** Phase-17 officially closed; Phase-18 transition not activated
+**Current phase:** Phase-18 active as Platform Constitution only; runtime implementation not authorized
 **Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu:** Kenan AY
 **Attribution boundary:** Documentation metadata only; not runtime, evidence,
 baseline, merge or closure authority.

--- a/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
+++ b/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
@@ -5,7 +5,7 @@ the freeze contract prevails.
 
 **Status:** ACTIVE EXECUTION ROADMAP
 **Effective date:** 2026-05-23
-**Current phase authority:** `CURRENT_PHASE=17` (Phase-17 officially closed; Phase-18 transition not activated)
+**Current phase authority:** `CURRENT_PHASE=18` (Phase-18 active as Platform Constitution only)
 **Last official closure:** Phase-17 (`phase17-official-closure` at `416a5392`)
 **Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu:** Kenan AY
 **Dijital imza siniri:** Bu atif dokumantasyon metadata'sidir; runtime
@@ -65,8 +65,9 @@ Aktif urun cekirdegi su dort parcadir:
 
 ### 2.3 Urun Olmayan veya Ertelenen Alanlar
 
-Phase-18 explicit transition karari aktif pointer'a baglanana kadar
-asagidakiler aktif implementation backlog'u degildir:
+Phase-18 aktif pointer'i Platform Constitution ile sinirlidir. Ayri Phase-19
+veya implementation karari olmadan asagidakiler aktif implementation
+backlog'u degildir:
 
 - Yeni syscall veya ABI surface genisletmesi.
 - ARM64/RISC-V/real-hardware feature genisletmesi.
@@ -74,11 +75,11 @@ asagidakiler aktif implementation backlog'u degildir:
   donusturulmesi.
 - Yeni AI orchestration ozellikleri veya model sonucunun authoritative
   execution verdict'i olarak kullanilmasi.
-- Phase-18'in aktif faz olarak ilan edilmesi.
+- Phase-18'in runtime implementation fazi olarak yorumlanmasi.
 - Trust classification'in capability grant gibi kullanilmasi.
 
 Bu alanlarda belge veya izole arastirma tutulabilir; production merge icin
-Phase-18 Platform Constitution transition kapisini asamaz.
+Phase-18 Platform Constitution sinirini asamaz.
 
 ## 3. Bugunku Repo Gercegi
 
@@ -91,7 +92,7 @@ Phase-18 Platform Constitution transition kapisini asamaz.
 | Governance | Spec-purity, fail-closed marker isolation, validation matrix ve S2 inventory kabul edildi | #145 tek-maintainer authority paritesiyle giderildi; closure yine ayrik reviewed karardir |
 | Review enforcement | `@kenanay` CODEOWNERS accountability metadata'si ve canli `main` required `freeze` protection'i tek-maintainer ADR'iyle hizalandi | Issue #145 RESOLVED; bagimsiz self-review iddiasi veya closure yetkisi kurulmaz |
 | Performance stability | PR-4 local readiness FAIL tarihsel kayit; PR-4A/PR-4B diagnostic; governed renewal ve workflow authority repair accepted | Accepted `main` SHA `416a5392`: Performance Gate `26715068398` ve scoped Phase-17 acceptance `26712374737` PASS; official tag dogrulandi |
-| Phase-18 | Transition decision package only | Platform Constitution review edilir; `CURRENT_PHASE` explicit transition olmadan baslatilmaz |
+| Phase-18 | Active as Platform Constitution only | Runtime implementation, loader, installer, workspace runtime, plugin loading, capability issuance ve trust assignment yetkisi yoktur |
 
 ## 4. Stratejik Karar: Stabilization-First
 
@@ -106,7 +107,8 @@ Oncelik sirasi:
 4. Module/package/workspace/capability/trust/plugin kontratlarini fail-closed
    tanimlamak.
 5. BCIB/SMP/race validation backlog'unu gorunur tutmak ama ana yon yapmamak.
-6. Ancak bunlardan sonra explicit Phase-18 activation pointer'i.
+6. Phase-18 active pointer'i sonrasi da runtime implementation icin ayri
+   Phase-19 veya reviewed implementation karari.
 
 ## 5. Technical Debt Control Rules
 
@@ -330,16 +332,19 @@ nondeterministic verification verdict'i uretmez.
   gostergeleri olarak izlenir.
 - Constitutional rules yalniz gercek mimari invariant'lari korur.
 
-### S5 - Phase-18 Activation Decision
+### S5 - Phase-18 Platform Constitution Activation
 
-**Status:** TRANSITION DECISION PACKAGE PENDING / NOT ACTIVE
+**Status:** ACTIVE AS PLATFORM CONSTITUTION / RUNTIME IMPLEMENTATION NOT AUTHORIZED
 
-Phase-17 closure precondition'lari artik saglanmistir, ancak Phase-18 yine de
-aktif degildir. Phase-18 icin authority adayi `PHASE18_TRANSITION_DECISION.md`
-olmalidir; eski `PHASE18_ROADMAP.md` tarihsel runtime-validation backlog'u
-olarak tutulur.
+Phase-17 closure precondition'lari saglanmistir ve Phase-18 yalniz Platform
+Constitution olarak aktiftir. Phase-18 authority zinciri
+`PHASE18_TRANSITION_DECISION.md`, Phase-18 RFC seti,
+`CROSS_CONSISTENCY_REVIEW.md`, `PHASE18_ACTIVATION_DECISION.md` ve
+`CURRENT_PHASE=18` pointer'i ile sinirlidir. Eski `PHASE18_ROADMAP.md`
+tarihsel runtime-validation backlog'u olarak tutulur.
 
-Phase-18 transition su kararlari korumadan aktif uygulama planina donusemez:
+Phase-18 active scope su kararlari korumadan implementation planina
+donusemez:
 
 1. Phase-18 = Platform Constitution.
 2. Kernel ABI expansion forbidden.
@@ -348,14 +353,14 @@ Phase-18 transition su kararlari korumadan aktif uygulama planina donusemez:
 5. AI Runtime authority forbidden.
 6. Kernel ABI ile Platform ABI ayrimi acik.
 7. Trust level capability grant degildir.
-8. `CURRENT_PHASE` ancak explicit transition ile `18` yapilir.
+8. `CURRENT_PHASE=18` yalniz Platform Constitution authority kurar.
 9. Module Manifest, Capability Contract, Workspace Lifecycle, Package Metadata,
    Trust Classification, Plugin Boundary ve Platform ABI Validation Gate
    spec'leri fail-closed olarak review edilmeden implementation phase baslamaz.
 10. Cross-consistency review kabul edilmeden activation decision package
     hazirlanmis sayilmaz.
-11. `PHASE18_ACTIVATION_DECISION.md` kabul edilmeden `CURRENT_PHASE=18`
-    pointer transition'i degerlendirilemez.
+11. `PHASE18_ACTIVATION_DECISION.md` accepted activation basis olarak
+    korunur.
 12. Constitution Runtime degildir; activation runtime implementation,
     package install, workspace creation, plugin loading, capability issuance
     veya trust assignment yetkisi vermez.
@@ -379,17 +384,17 @@ Phase-18 transition su kararlari korumadan aktif uygulama planina donusemez:
 | PR #148 | MERGED (`e0286c7b`) / POST-MERGE PASS | Standalone Performance Gate workflow'unu locked authority modeliyle hizalamak | Workflow only; runtime/threshold degisikligi yok | Performance `26421295487`, freeze `26421295459` PASS |
 | PR #149/#151/#150 | MERGED (`7a42d312`) / EXACT-SHA REFRESHED | Closure-candidate record, governed baseline renewal ve ci-freeze prerequisite dedup | Candidate package, performance authority and CI prerequisite wiring | Historical refresh subject `7a42d312`; official tag ayridir |
 | PR #152 | MERGED (`416a5392`) / EXACT-SHA REFRESHED | Closure-candidate record'u accepted main subject'e yenilemek | Candidate manifest/index ve status docs | Refresh subject `416a5392`; official tag ayridir |
-| Phase-17 closure decision package | OFFICIAL CLOSURE CONFIRMED / PHASE-18 NOT ACTIVATED | Exact-SHA PASS kanitlarini verified official tag subject karar kaydina baglamak | Candidate manifest/index, decision record ve status docs | Candidate integrity + verified tag target; Phase-18 ayridir |
-| Phase-18 transition decision package | DOCS-ONLY / PHASE-18 NOT ACTIVATED | Phase-18'i Platform Constitution olarak sinirlamak | `PHASE18_TRANSITION_DECISION.md`, roadmap/index/current status sync | Kernel expansion/new syscall/AI authority forbidden; explicit pointer transition gerekir |
-| Phase-18 Module Manifest Schema | DOCS-ONLY / PRE-ACTIVATION RFC | Modülün kimlik, entrypoint, artifact ve capability request beyanini fail-closed tanimlamak | `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md` | Capability/trust/workspace authority grant yok; unknown fields fail-closed |
-| Phase-18 Capability Contract Specification | DOCS-ONLY / PRE-ACTIVATION RFC | Capability request, authorization decision, receipt ve revocation sinirlarini fail-closed tanimlamak | `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md` | Manifest self-grant yok; trust capability grant degil; token/receipt ayrimi korunur |
-| Phase-18 Workspace Lifecycle Specification | DOCS-ONLY / PRE-ACTIVATION RFC | Workspace admission, logical mount, disable, quarantine, revocation ve removal sinirlarini fail-closed tanimlamak | `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md` | Workspace declaration mount grant degil; mount capability grant degil; runtime loader yok |
-| Phase-18 Package Metadata Schema | DOCS-ONLY / PRE-ACTIVATION RFC | Package identity, version, publisher, hash, signature, dependency ve Platform ABI compatibility metadata'sini fail-closed tanimlamak | `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md` | Trust/capability/workspace/execution/mount/loader grant yok; package digest metadata icinde self-declare edilmez |
-| Phase-18 Trust Classification Model | DOCS-ONLY / PRE-ACTIVATION RFC | Trust vocabulary, evidence input, classification lifecycle ve policy-effect sinirlarini fail-closed tanimlamak | `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md` | Trust level capability grant degil; install/enable/execute/load/mount authority yok |
-| Phase-18 Plugin Boundary Contract | DOCS-ONLY / PRE-ACTIVATION RFC | Host interface, extension point, compatibility, binding lifecycle ve fail-closed plugin boundary sinirlarini tanimlamak | `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md` | Plugin loading/autoload/execution yok; capability/trust/workspace inheritance yok |
-| Phase-18 Platform ABI Validation Gate | DOCS-ONLY / PRE-ACTIVATION RFC | Manifest, package, trust, capability, workspace ve plugin boundary input'larini deterministik fail-closed validation order ile baglamak | `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md` | Validation PASS authority grant degil; install/enable/execute/load/mount/capability/trust grant yok |
-| Phase-18 Cross-Consistency Review | DOCS-ONLY / PRE-ACTIVATION REVIEW | Yedi Phase-18 RFC'nin terminology, dependency order, validation order ve authority separation acisindan celismedigini kaydetmek | `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md` | Review PASS activation degil; activation package ve explicit pointer transition gerekir |
-| Phase-18 Activation Decision Package | DOCS-ONLY / ACTIVATION CANDIDATE / PHASE-18 NOT ACTIVATED | Phase-18 aktivasyonu icin precondition, exact-SHA, fail-closed denial ve Constitution != Runtime sinirlarini kaydetmek | `PHASE18_ACTIVATION_DECISION.md` | Package kabulü `CURRENT_PHASE=18` yapmaz; runtime implementation, capability issuance, trust assignment, workspace creation veya plugin loading yetkisi yok |
+| Phase-17 closure decision package | OFFICIAL CLOSURE CONFIRMED / PHASE-18 SEPARATE | Exact-SHA PASS kanitlarini verified official tag subject karar kaydina baglamak | Candidate manifest/index, decision record ve status docs | Candidate integrity + verified tag target; Phase-18 runtime authority kurmaz |
+| Phase-18 transition decision package | ACCEPTED / PLATFORM CONSTITUTION ACTIVE | Phase-18'i Platform Constitution olarak sinirlamak | `PHASE18_TRANSITION_DECISION.md`, roadmap/index/current status sync | Kernel expansion/new syscall/AI authority forbidden |
+| Phase-18 Module Manifest Schema | ACTIVE CONSTITUTION SPEC | Modülün kimlik, entrypoint, artifact ve capability request beyanini fail-closed tanimlamak | `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md` | Capability/trust/workspace authority grant yok; unknown fields fail-closed |
+| Phase-18 Capability Contract Specification | ACTIVE CONSTITUTION SPEC | Capability request, authorization decision, receipt ve revocation sinirlarini fail-closed tanimlamak | `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md` | Manifest self-grant yok; trust capability grant degil; token/receipt ayrimi korunur |
+| Phase-18 Workspace Lifecycle Specification | ACTIVE CONSTITUTION SPEC | Workspace admission, logical mount, disable, quarantine, revocation ve removal sinirlarini fail-closed tanimlamak | `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md` | Workspace declaration mount grant degil; mount capability grant degil; runtime loader yok |
+| Phase-18 Package Metadata Schema | ACTIVE CONSTITUTION SPEC | Package identity, version, publisher, hash, signature, dependency ve Platform ABI compatibility metadata'sini fail-closed tanimlamak | `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md` | Trust/capability/workspace/execution/mount/loader grant yok; package digest metadata icinde self-declare edilmez |
+| Phase-18 Trust Classification Model | ACTIVE CONSTITUTION SPEC | Trust vocabulary, evidence input, classification lifecycle ve policy-effect sinirlarini fail-closed tanimlamak | `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md` | Trust level capability grant degil; install/enable/execute/load/mount authority yok |
+| Phase-18 Plugin Boundary Contract | ACTIVE CONSTITUTION SPEC | Host interface, extension point, compatibility, binding lifecycle ve fail-closed plugin boundary sinirlarini tanimlamak | `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md` | Plugin loading/autoload/execution yok; capability/trust/workspace inheritance yok |
+| Phase-18 Platform ABI Validation Gate | ACTIVE CONSTITUTION SPEC | Manifest, package, trust, capability, workspace ve plugin boundary input'larini deterministik fail-closed validation order ile baglamak | `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md` | Validation PASS authority grant degil; install/enable/execute/load/mount/capability/trust grant yok |
+| Phase-18 Cross-Consistency Review | ACCEPTED REVIEW | Yedi Phase-18 RFC'nin terminology, dependency order, validation order ve authority separation acisindan celismedigini kaydetmek | `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md` | Review PASS runtime implementation degil |
+| Phase-18 Activation Decision Package | ACCEPTED / PLATFORM CONSTITUTION ACTIVE | Phase-18 aktivasyonu icin precondition, exact-SHA, fail-closed denial ve Constitution != Runtime sinirlarini kaydetmek | `PHASE18_ACTIVATION_DECISION.md` | Activation runtime implementation, capability issuance, trust assignment, workspace creation veya plugin loading yetkisi vermez |
 
 PR koordinasyon kurallari:
 
@@ -1002,7 +1007,8 @@ closure manifest/tag'i yerine gecmez.
 **Authority boundary:** Exact-SHA remote PASS closure-candidate hazirlamaya
 yeterli kanittir; official closure degildir. `phase17-official-closure`
 yalniz reviewed karar kaydi ve uygun tag-subject dogrulamasi sonrasinda
-uretilebilir. Phase-18 aktif degildir.
+uretilebilir. Phase-18 yalniz Platform Constitution olarak aktiftir; runtime
+implementation yetkisi yoktur.
 
 ### 2026-05-31 - Current Main Exact-SHA Refresh
 
@@ -1076,7 +1082,8 @@ Bu roadmap su olaylarda guncellenir:
 24. Phase-18 Platform ABI Validation Gate review/merge sonucu.
 25. Phase-18 Cross-Consistency Review sonucu.
 26. Phase-18 Activation Decision Package review/merge sonucu.
-27. Yeni feature/ABI/authority surface onerisinin incelenmesi.
+27. Phase-18 `CURRENT_PHASE=18` pointer transition sonucu.
+28. Yeni feature/ABI/authority surface onerisinin incelenmesi.
 
 ## References
 

--- a/docs/roadmap/CURRENT_PHASE
+++ b/docs/roadmap/CURRENT_PHASE
@@ -1,11 +1,11 @@
-CURRENT_PHASE=17
-# Status authority synchronized: 2026-05-31 (Phase-17 official closure tag verification)
+CURRENT_PHASE=18
+# Status authority synchronized: 2026-06-05 (Phase-18 Platform Constitution pointer transition)
 # Phase-16 OFFICIALLY CLOSED - 2026-04-25 - tag: phase16-official-closure
 # Phase-17 OFFICIALLY CLOSED - 2026-05-31 - tag: phase17-official-closure at 416a5392.
 # Phase-17 closure evidence remains bounded to the reviewed exact-SHA runtime/QEMU, freeze, and performance runs.
-# Phase-18 is TRANSITION DECISION PACKAGE ONLY until a separate pointer transition activates it.
-# Proposed Phase-18 direction: Platform Constitution, not kernel expansion.
+# Phase-18 is ACTIVE as Platform Constitution only, not as runtime implementation.
+# Phase-18 direction: Platform Constitution, not kernel expansion.
 # Active execution roadmap: docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
 # Remote evidence: ci-freeze 26712333892, Performance Gate 26715068398, Phase-17 lifecycle/determinism/public-e2e/worker/timeout/performance lanes all PASS on 416a5392.
-# Immediate work package: review PHASE18_ACTIVATION_DECISION.md; do not activate Phase-18 without a later explicit pointer transition.
+# Immediate work package: maintain Phase-18 Platform Constitution authority; Phase-19 runtime work requires a separate decision.
 # Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu: Kenan AY (informational metadata only).

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -2,7 +2,7 @@
 This document is subordinate to `ARCHITECTURE_FREEZE.md`. In case of conflict,
 the freeze contract prevails.
 
-**Last authority sync:** 2026-06-05 (Phase-18 activation decision package candidate)
+**Last authority sync:** 2026-06-05 (Phase-18 Platform Constitution pointer transition)
 **Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu:** Kenan AY
 **Attribution boundary:** Documentation metadata only; not runtime or merge authority.
 
@@ -12,42 +12,41 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 ## Current Authority Chain
 
 1. `../../ARCHITECTURE_FREEZE.md`: frozen mimari invariants ve merge siniri.
-2. `CURRENT_PHASE`: formal aktif faz pointer'i (`CURRENT_PHASE=17`).
+2. `CURRENT_PHASE`: formal aktif faz pointer'i (`CURRENT_PHASE=18`).
 3. `CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`: aktif execution
    roadmap; kapsam daraltma, technical debt kontrolu ve PR sirasi.
 4. `../../AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md`: mevcut changeset ve
    dogrulama raporu.
 5. `freeze-enforcement-workflow.md`: strict CI/gate order kontrati.
-6. `../../PHASE18_TRANSITION_DECISION.md`: Phase-18 Platform Constitution
-   transition package; aktif faz pointer'i degildir.
+6. `../../PHASE18_TRANSITION_DECISION.md`: accepted Phase-18 Platform
+   Constitution transition package.
 7. `../specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`:
-   ilk Phase-18 Platform Constitution RFC draft'i; authority grant degildir.
+   active Phase-18 Platform Constitution module manifest RFC; authority grant degildir.
 8. `../specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`:
-   capability request, decision, receipt ve revocation RFC draft'i; token veya
+   capability request, decision, receipt ve revocation active RFC; token veya
    trust grant degildir.
 9. `../specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`:
    workspace admission, logical mount, disable, quarantine, revocation ve
-   removal RFC draft'i; mount veya capability grant degildir.
+   removal active RFC; mount veya capability grant degildir.
 10. `../specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`:
    package identity, version, publisher, hash, signature, dependency ve
-   Platform ABI compatibility RFC draft'i; trust/capability/workspace/execution
+   Platform ABI compatibility active RFC; trust/capability/workspace/execution
    grant degildir.
 11. `../specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md`:
    trust vocabulary, evidence inputs, classification lifecycle ve fail-closed
-   policy effects RFC draft'i; capability veya runtime authority grant degildir.
+   policy effects active RFC; capability veya runtime authority grant degildir.
 12. `../specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`:
    host interface, extension point, compatibility ve binding lifecycle RFC
-   draft'i; plugin loading veya capability/trust/workspace authority grant
+   active RFC; plugin loading veya capability/trust/workspace authority grant
    degildir.
 13. `../specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`:
    Platform ABI validation order, input bundle, stage result ve validation
-   receipt RFC draft'i; validation PASS authority grant degildir.
+   receipt active RFC; validation PASS authority grant degildir.
 14. `../specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`:
    Phase-18 RFC set capraz tutarlilik review kaydi; activation veya runtime
    implementation yetkisi degildir.
-15. `../../PHASE18_ACTIVATION_DECISION.md`: Phase-18 activation decision
-   package candidate; `CURRENT_PHASE` pointer transition'i veya runtime
-   implementation yetkisi degildir.
+15. `../../PHASE18_ACTIVATION_DECISION.md`: accepted Phase-18 activation
+   decision package; runtime implementation yetkisi degildir.
 16. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
    planlamasi; aktif Phase-18 otoritesi degildir.
 
@@ -56,21 +55,23 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 | Konu | Durum |
 |---|---|
 | Son resmi kapanis | Phase-17 OFFICIALLY CLOSED (`phase17-official-closure` at `416a5392`) |
-| Aktif faz | Phase-17 OFFICIALLY CLOSED / Phase-18 transition not activated |
-| Aktif odak | Phase-18 Platform Constitution activation decision package review; no activation without separate explicit pointer transition |
+| Aktif faz | Phase-18 ACTIVE / Platform Constitution only |
+| Aktif odak | Phase-18 Platform Constitution authority maintenance; runtime implementation remains out of scope |
 | ABI | Canonical `1000-1011` / 12 syscall, ABI version `0x00010001` |
-| Phase-18 | TRANSITION DECISION PACKAGE ONLY; kernel expansion and new syscalls forbidden unless a separate phase RFC/closure authority exists |
+| Phase-18 | ACTIVE AS PLATFORM CONSTITUTION; kernel expansion, runtime implementation and new syscalls forbidden unless a separate phase RFC/closure authority exists |
 
 ## Active Execution Rule
 
 Phase-17 resmi kapanis tag'i `416a5392` uzerinde uretilip dogrulanmistir.
-Phase-18 icin ayri transition karari aktif pointer'a baglanana kadar production
-roadmap'e yeni syscall, kernel ABI genislemesi, Ring0 policy, authority-genisleten
-observability veya AI orchestration isi alinmaz. Bounded runtime/QEMU lanes,
-strict `ci-freeze`, standalone locked Performance Gate ve scoped Phase-17
-performance acceptance accepted `main` SHA `416a5392` uzerinde PASS vermistir.
-Bu closure, Phase-18 activation veya genis BCIB semantic/race/SMP kapsami kurmaz.
-Phase-18'in proposed direction'i Platform Constitution'dir: module/package,
+Phase-18 aktif pointer'i yalniz Platform Constitution kapsamindadir.
+Production roadmap'e yeni syscall, kernel ABI genislemesi, Ring0 policy,
+runtime loader, package installer, workspace runtime, plugin loading,
+capability issuer, trust issuer, authority-genisleten observability veya AI
+orchestration isi alinmaz. Bounded runtime/QEMU lanes, strict `ci-freeze`,
+standalone locked Performance Gate ve scoped Phase-17 performance acceptance
+accepted `main` SHA `416a5392` uzerinde PASS vermistir. Bu closure, genis
+BCIB semantic/race/SMP kapsami veya Phase-19 runtime implementation kurmaz.
+Phase-18'in active direction'i Platform Constitution'dir: module/package,
 workspace, capability, trust classification ve plugin boundary kontratlari.
 
 ## Historical References
@@ -86,7 +87,6 @@ current execution priority otoritesi degildir:
 
 ---
 
-**Next action:** `../../PHASE18_ACTIVATION_DECISION.md` review edilir;
-`CURRENT_PHASE` explicit pointer transition ile `18` yapilmadan once
-activation package kabul edilir ve required freeze/governance checks exact-SHA
-uzerinde PASS verir.
+**Next action:** Phase-18 Platform Constitution kapsaminda authority drift
+kontrolu surdurulur; Phase-19 Platform Runtime MVP icin ayri implementation
+RFC, evidence plan ve closure boundary hazirlanmadan runtime isi baslatilmaz.

--- a/docs/roadmap/freeze-enforcement-workflow.md
+++ b/docs/roadmap/freeze-enforcement-workflow.md
@@ -20,9 +20,10 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict
 
 Aktif is sirasi `CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`
 tarafindan belirlenir. Phase-17 resmi closure artik `phase17-official-closure`
-tag'iyle kurulmustur. Phase-18 explicit pointer transition yapilana kadar
-feature expansion degil, `PHASE18_TRANSITION_DECISION.md` icindeki Platform
-Constitution sinirinin review edilmesi onceliklidir.
+tag'iyle kurulmustur. Phase-18 `CURRENT_PHASE=18` pointer'iyle yalniz
+Platform Constitution olarak aktiftir; feature/runtime expansion degil,
+`PHASE18_TRANSITION_DECISION.md` ve `PHASE18_ACTIVATION_DECISION.md`
+sinirlarinin korunmasi onceliklidir.
 
 ---
 

--- a/docs/roadmap/overview.md
+++ b/docs/roadmap/overview.md
@@ -5,8 +5,7 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict
 > preserves the 2026-04-24 evidence view and is not the current phase or
 > execution roadmap authority. Use `CURRENT_PHASE` and
 > `CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`; Phase-17 is the last
-> official closure and Phase-18 is not active until a separate Platform
-> Constitution transition decision is accepted.
+> official closure and Phase-18 is active only as Platform Constitution.
 
 ## Scope
 Bu belge, roadmap durumunu dogrudan repo kodu, Make hedefleri, local evidence run'lari ve remote `ci-freeze` confirmation uzerinden ozetler.

--- a/docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md
+++ b/docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md
@@ -4,7 +4,7 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
 `ARCHITECTURE_FREEZE.md`, `PHASE18_TRANSITION_DECISION.md`, and
 `MODULE_MANIFEST_SCHEMA.md`. In case of conflict, those documents prevail.
 
-**Status:** RFC-DRAFT / PRE-ACTIVATION SPEC
+**Status:** ACTIVE CONSTITUTION SPEC / RUNTIME NOT AUTHORIZED
 **Contract id:** `ayken.platform.capability.contract.v1`
 **Authority boundary:** Documentation/specification only; not a runtime
 capability issuer, not a kernel token format, not a trust grant, and not
@@ -509,9 +509,7 @@ Invalid because wildcard scope is forbidden.
 
 ## Activation Boundary
 
-This RFC is not sufficient to activate Phase-18. Phase-18 activation still
-requires an explicit `CURRENT_PHASE` pointer transition and reviewed acceptance
-of the required Platform Constitution set.
+This RFC is part of the active Phase-18 Platform Constitution set.
 
 This RFC does not authorize implementation work that widens the kernel ABI,
 adds syscalls, places policy in Ring0, or makes semantic/AI systems execution

--- a/docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md
+++ b/docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md
@@ -4,7 +4,7 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
 `ARCHITECTURE_FREEZE.md`, `PHASE18_TRANSITION_DECISION.md`, and the Phase-18
 Platform Constitution RFC set. In case of conflict, those documents prevail.
 
-**Status:** REVIEW-DRAFT / PRE-ACTIVATION REVIEW
+**Status:** ACCEPTED REVIEW / PHASE-18 ACTIVATION INPUT
 **Review date:** 2026-06-05
 **Review id:** `ayken.platform.phase18.cross_consistency.review.v1`
 **Authority boundary:** Documentation/review record only; not Phase-18
@@ -17,17 +17,17 @@ Runtime authority, and not kernel ABI expansion.
 
 This review answers the activation-preparation question:
 
-Do the Phase-18 Platform Constitution RFC drafts define a coherent
+Do the Phase-18 Platform Constitution RFCs define a coherent
 fail-closed Platform ABI boundary without contradicting each other or widening
 the frozen kernel execution substrate?
 
-This document does not activate Phase-18 and does not change
-`CURRENT_PHASE=17`. It records cross-document consistency findings and the
-remaining blockers before an activation decision package can be considered.
+This document did not by itself activate Phase-18. It records cross-document
+consistency findings used by `PHASE18_ACTIVATION_DECISION.md` and the later
+`CURRENT_PHASE=18` pointer transition.
 
 ## Reviewed Inputs
 
-The reviewed Phase-18 pre-activation set is:
+The reviewed Phase-18 Platform Constitution set is:
 
 1. `PHASE18_TRANSITION_DECISION.md`
 2. `docs/specs/phase18-platform-constitution/README.md`
@@ -41,7 +41,7 @@ The reviewed Phase-18 pre-activation set is:
 
 ## Review Verdict
 
-**Verdict:** PASS WITH ACTIVATION BLOCKERS
+**Verdict:** PASS
 
 No activation-blocking contradiction is identified across the reviewed RFC set.
 The documents consistently preserve the frozen kernel ABI, keep Phase-18 as a
@@ -49,8 +49,7 @@ Platform Constitution phase, and separate declarations, classifications,
 decisions, receipts, compatibility records, and validation receipts from
 runtime authority.
 
-This PASS is a review finding only. It does not activate Phase-18 and does not
-authorize implementation.
+This PASS is a review finding only. It does not authorize implementation.
 
 ## Core Consistency Finding
 
@@ -216,12 +215,12 @@ activation documents and examples:
 5. `validated` can sound like acceptance or execution.
    Current RFC text states validation is a denial boundary only.
 
-These are not contradictions. They are activation-package vocabulary risks.
+These are not contradictions. They are ongoing Phase-18 vocabulary risks.
 
-## Required Activation Blockers
+## Activation Preconditions Checked
 
-Before `CURRENT_PHASE=18` can be considered, the activation decision package
-must explicitly confirm:
+The accepted activation decision package and pointer transition explicitly
+confirm:
 
 1. This cross-consistency review is accepted or superseded by a newer reviewed
    cross-consistency record.
@@ -233,17 +232,16 @@ must explicitly confirm:
    issuer, Semantic CLI authority, or AI Runtime authority.
 6. Platform ABI Validation Gate remains a validation-order spec and not a
    runtime authority implementation.
-7. Required local and remote governance/freeze checks pass on the exact
+7. Required local and remote governance/freeze checks must pass on the exact
    activation candidate SHA.
-8. Activation is recorded through an explicit `CURRENT_PHASE` pointer
+8. Activation is recorded through an explicit `CURRENT_PHASE=18` pointer
    transition. CI PASS alone is not activation.
 
 ## Review Conclusion
 
-The Phase-18 pre-activation RFC set is internally coherent enough to proceed
-to an activation decision package draft.
+The Phase-18 RFC set is internally coherent enough to serve as the active
+Platform Constitution reference set.
 
-The safe next step is not implementation and not automatic `CURRENT_PHASE=18`.
-The safe next step is a separate Phase-18 activation decision package that
-references this review, preserves the frozen kernel ABI, and keeps Platform
-Runtime work out of Phase-18 unless a later phase decision authorizes it.
+The safe next step after activation is still not implementation. Platform
+Runtime work remains outside Phase-18 unless a later phase decision authorizes
+it.

--- a/docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md
+++ b/docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md
@@ -4,7 +4,7 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
 `ARCHITECTURE_FREEZE.md`, and `PHASE18_TRANSITION_DECISION.md`. In case of
 conflict, those documents prevail.
 
-**Status:** RFC-DRAFT / PRE-ACTIVATION SPEC
+**Status:** ACTIVE CONSTITUTION SPEC / RUNTIME NOT AUTHORIZED
 **Schema id:** `ayken.platform.module.manifest.v1`
 **Canonical file name:** `ayken.module.json`
 **Authority boundary:** Documentation/specification only; not an installer,
@@ -422,7 +422,7 @@ Reason: Phase-18 does not add syscalls.
 
 ## Activation Boundary
 
-This RFC draft is not sufficient to activate Phase-18. Phase-18 activation still
-requires an explicit `CURRENT_PHASE` pointer transition and acceptance of the
-remaining Platform Constitution contracts required by
-`PHASE18_TRANSITION_DECISION.md`.
+This RFC is part of the active Phase-18 Platform Constitution set. It does not
+authorize runtime implementation, package installation, workspace creation,
+plugin loading, capability issuance, trust assignment, Semantic CLI authority,
+AI Runtime authority, new syscalls, or kernel ABI expansion.

--- a/docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md
+++ b/docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md
@@ -6,7 +6,7 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
 `WORKSPACE_LIFECYCLE_SPECIFICATION.md`. In case of conflict, those documents
 prevail.
 
-**Status:** RFC-DRAFT / PRE-ACTIVATION SPEC
+**Status:** ACTIVE CONSTITUTION SPEC / RUNTIME NOT AUTHORIZED
 **Schema id:** `ayken.platform.package.metadata.v1`
 **Canonical file name:** `ayken.package.json`
 **Authority boundary:** Documentation/specification only; not an installer,
@@ -544,9 +544,7 @@ Invalid because absolute host paths are forbidden.
 
 ## Activation Boundary
 
-This RFC is not sufficient to activate Phase-18. Phase-18 activation still
-requires an explicit `CURRENT_PHASE` pointer transition and reviewed acceptance
-of the required Platform Constitution set.
+This RFC is part of the active Phase-18 Platform Constitution set.
 
 This RFC does not authorize implementation work that widens the kernel ABI,
 adds syscalls, places policy in Ring0, creates runtime loaders, admits

--- a/docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md
+++ b/docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md
@@ -7,7 +7,7 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
 `TRUST_CLASSIFICATION_MODEL.md`, and `PLUGIN_BOUNDARY_CONTRACT.md`. In case of
 conflict, those documents prevail.
 
-**Status:** RFC-DRAFT / PRE-ACTIVATION SPEC
+**Status:** ACTIVE CONSTITUTION SPEC / RUNTIME NOT AUTHORIZED
 **Contract id:** `ayken.platform.abi.validation.gate.v1`
 **Authority boundary:** Documentation/specification only; not a validator
 implementation, installer, registry, runtime loader, capability grant, trust
@@ -719,9 +719,7 @@ Invalid because AI Runtime is not a Phase-18 authority source.
 
 ## Activation Boundary
 
-This RFC is not sufficient to activate Phase-18. Phase-18 activation still
-requires an explicit `CURRENT_PHASE` pointer transition and reviewed acceptance
-of the required Platform Constitution set.
+This RFC is part of the active Phase-18 Platform Constitution set.
 
 This RFC does not authorize implementation work that widens the kernel ABI,
 adds syscalls, places policy in Ring0, creates runtime loaders, admits

--- a/docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md
+++ b/docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md
@@ -6,7 +6,7 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
 `WORKSPACE_LIFECYCLE_SPECIFICATION.md`, `PACKAGE_METADATA_SCHEMA.md`, and
 `TRUST_CLASSIFICATION_MODEL.md`. In case of conflict, those documents prevail.
 
-**Status:** RFC-DRAFT / PRE-ACTIVATION SPEC
+**Status:** ACTIVE CONSTITUTION SPEC / RUNTIME NOT AUTHORIZED
 **Contract id:** `ayken.platform.plugin.boundary.v1`
 **Authority boundary:** Documentation/specification only; not a plugin loader,
 installer, runtime host, capability grant, trust grant, workspace admission,
@@ -618,9 +618,7 @@ Invalid because AI Runtime is not a Phase-18 authority source.
 
 ## Activation Boundary
 
-This RFC is not sufficient to activate Phase-18. Phase-18 activation still
-requires an explicit `CURRENT_PHASE` pointer transition and reviewed acceptance
-of the required Platform Constitution set.
+This RFC is part of the active Phase-18 Platform Constitution set.
 
 This RFC does not authorize implementation work that widens the kernel ABI,
 adds syscalls, places policy in Ring0, creates runtime loaders, installs or

--- a/docs/specs/phase18-platform-constitution/README.md
+++ b/docs/specs/phase18-platform-constitution/README.md
@@ -4,19 +4,22 @@ This directory is subordinate to PHASE 0 - FOUNDATIONAL OATH,
 `ARCHITECTURE_FREEZE.md`, and `PHASE18_TRANSITION_DECISION.md`. In case of
 conflict, those documents prevail.
 
-**Status:** PRE-ACTIVATION SPEC SET / PHASE-18 NOT ACTIVATED
+**Status:** ACTIVE PLATFORM CONSTITUTION SPEC SET / RUNTIME NOT AUTHORIZED
 **Authority basis:** `phase17-official-closure` at `416a5392`
 **Attribution:** Documentation metadata only; not runtime, merge, or execution
 authority.
 
 ## Purpose
 
-This directory defines the Platform Constitution contracts that must exist
-before the ayken platform can safely accept modules, packages, workspaces,
+This directory defines the active Phase-18 Platform Constitution contracts for
+how the ayken platform can safely describe modules, packages, workspaces,
 plugins, and later semantic systems above the frozen kernel execution
 substrate.
 
-These specs do not activate Phase-18 and do not change `CURRENT_PHASE=17`.
+These specs do not authorize runtime implementation, package installation,
+workspace creation, plugin loading, capability issuance, trust assignment,
+Semantic CLI authority, AI Runtime authority, new syscalls, or kernel ABI
+expansion.
 
 ## Current Specs
 
@@ -35,21 +38,21 @@ These specs do not activate Phase-18 and do not change `CURRENT_PHASE=17`.
 7. `PLATFORM_ABI_VALIDATION_GATE.md` - RFC for deterministic validation order,
    input bundles, stage results, validation receipts, and fail-closed
    cross-contract separation.
-8. `CROSS_CONSISTENCY_REVIEW.md` - pre-activation review record for
-   cross-document terminology, dependency order, and authority separation.
+8. `CROSS_CONSISTENCY_REVIEW.md` - accepted review record for cross-document
+   terminology, dependency order, and authority separation.
 
 ## Current Review Result
 
-`CROSS_CONSISTENCY_REVIEW.md` records `PASS WITH ACTIVATION BLOCKERS` for the
-current seven-RFC Platform Constitution set. This result is a documentation
-review only. It does not activate Phase-18 and does not authorize
-implementation.
+`CROSS_CONSISTENCY_REVIEW.md` records the accepted cross-document review for
+the current seven-RFC Platform Constitution set. This result is a documentation
+review only. It does not authorize implementation.
 
 ## Activation Boundary
 
-`../../../PHASE18_ACTIVATION_DECISION.md` is the separate activation decision
-package candidate. It does not activate Phase-18, does not change
-`CURRENT_PHASE=17`, and does not authorize runtime implementation.
+`../../../PHASE18_ACTIVATION_DECISION.md` is the accepted activation decision
+package. `../../../docs/roadmap/CURRENT_PHASE` is now `18`. This activates
+only Platform Constitution authority and does not authorize runtime
+implementation.
 
 The mandatory activation rule is:
 

--- a/docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md
+++ b/docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md
@@ -6,7 +6,7 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
 `WORKSPACE_LIFECYCLE_SPECIFICATION.md`, and `PACKAGE_METADATA_SCHEMA.md`. In
 case of conflict, those documents prevail.
 
-**Status:** RFC-DRAFT / PRE-ACTIVATION SPEC
+**Status:** ACTIVE CONSTITUTION SPEC / RUNTIME NOT AUTHORIZED
 **Contract id:** `ayken.platform.trust.classification.v1`
 **Authority boundary:** Documentation/specification only; not a trust issuer,
 installer, registry, runtime loader, capability grant, workspace admission,
@@ -427,9 +427,7 @@ Invalid because AI Runtime is not a Phase-18 authority source.
 
 ## Activation Boundary
 
-This RFC is not sufficient to activate Phase-18. Phase-18 activation still
-requires an explicit `CURRENT_PHASE` pointer transition and reviewed acceptance
-of the required Platform Constitution set.
+This RFC is part of the active Phase-18 Platform Constitution set.
 
 This RFC does not authorize implementation work that widens the kernel ABI,
 adds syscalls, places policy in Ring0, creates runtime loaders, admits

--- a/docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md
+++ b/docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md
@@ -5,7 +5,7 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
 `MODULE_MANIFEST_SCHEMA.md`, and `CAPABILITY_CONTRACT_SPECIFICATION.md`. In
 case of conflict, those documents prevail.
 
-**Status:** RFC-DRAFT / PRE-ACTIVATION SPEC
+**Status:** ACTIVE CONSTITUTION SPEC / RUNTIME NOT AUTHORIZED
 **Contract id:** `ayken.platform.workspace.lifecycle.v1`
 **Authority boundary:** Documentation/specification only; not an installer,
 runtime mount implementation, capability grant, trust grant, kernel mapping
@@ -462,9 +462,7 @@ authority.
 
 ## Activation Boundary
 
-This RFC is not sufficient to activate Phase-18. Phase-18 activation still
-requires an explicit `CURRENT_PHASE` pointer transition and reviewed acceptance
-of the required Platform Constitution set.
+This RFC is part of the active Phase-18 Platform Constitution set.
 
 This RFC does not authorize implementation work that widens the kernel ABI,
 adds syscalls, places policy in Ring0, creates runtime mounts, or makes

--- a/docs/steering/product.md
+++ b/docs/steering/product.md
@@ -91,13 +91,13 @@ These rules are enforced by CI gates and MUST NOT be violated:
 - **Phase 16 Verification Layer**: OFFICIALLY CLOSED (MVP complete, evidence chain verified, trust anchor established)
 - **Phase 17 Execution Pipeline**: OFFICIALLY CLOSED (`phase17-official-closure` at `416a5392`)
 - **Constitutional System**: Phases 1-17 COMPLETE (governance framework active)
-- **Architecture Freeze**: ACTIVE (Phase-18 transition requires explicit pointer decision)
+- **Architecture Freeze**: ACTIVE (Phase-18 active as Platform Constitution only)
 - **Worktree-Local Ring3 Rule**: executable user-leaf rule is live under `ci-gate-ring3-user-leaf-rule`; broader Phase10-A2 strict/global authority remains separate
 - **CI Enforcement**: strict freeze chain includes dedicated `Ring3 User Leaf Rule` before broader `Ring3 Execution Phase10a2`, followed by low-half scaffold, mailbox/runtime gates, alias proof, Phase-13 kill-switch enforcement, and Phase-16 verification layer gates
 - **Pre-CI Discipline**: Local advisory (5 core gates, ~60-90s, fail-closed) + verification layer integration
-- **CURRENT_PHASE**: `17` (Phase-17 officially closed; Phase-18 transition not activated)
-- **Current Execution Priority**: review `PHASE18_TRANSITION_DECISION.md` as a docs-only Platform Constitution transition package
-- **Phase-18**: TRANSITION DECISION PACKAGE ONLY until explicit `CURRENT_PHASE` pointer transition
+- **CURRENT_PHASE**: `18` (Phase-18 active as Platform Constitution only)
+- **Current Execution Priority**: maintain Phase-18 Platform Constitution authority without runtime implementation
+- **Phase-18**: ACTIVE PLATFORM CONSTITUTION; runtime implementation requires a separate decision
 - **Scope Decision**: kernel expansion, new syscalls, Ring0 policy, AI Runtime authority and authority-surface growth remain deferred outside Phase-18 Platform Constitution scope
 
 ## License


### PR DESCRIPTION
## Summary

- Set `docs/roadmap/CURRENT_PHASE` to `18`.
- Mark Phase-18 as active only as Platform Constitution.
- Synchronize README, roadmap, operations, governance, steering, status, and Phase-18 spec surfaces.
- Preserve `Constitution != Runtime`: no runtime implementation, loader, installer, workspace runtime, plugin loading, capability issuance, trust assignment, Semantic CLI authority, AI Runtime authority, syscall, or kernel ABI authority is granted.

## Authority Boundary

This is a docs-only pointer transition. It does not change code, runtime behavior, syscall ABI, kernel ABI, performance baseline, branch protection, or CI configuration.

Phase-19 Platform Runtime MVP still requires a separate implementation decision, RFC, evidence plan, and closure boundary.

## Local Validation

- `git diff HEAD^..HEAD --check`
- `make ci-gate-spec-purity`
- `make ci-gate-naming-compliance`
- `make ci-gate-governance`
- `make ci-gate-drift-activation`
- `make ci-gate-abi`
- `make ci-gate-constitutional`
- `python3 tools/ci/validate_phase17_closure_candidate.py --expected-subject-sha 416a5392afbe217e16d26a59e2e1716fdfa9c8f6`

All passed locally on commit `117e066e`.