### PR TITLE
docs: add phase18 authority drift guard

### DIFF
--- a/AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md
+++ b/AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md
@@ -9,8 +9,11 @@
 > Authority note: This report preserves the 2026-05-23 stabilization narrative.
 > Current phase authority is `docs/roadmap/CURRENT_PHASE`, the Phase-17
 > official closure package, `PHASE18_TRANSITION_DECISION.md`, and
-> `PHASE18_ACTIVATION_DECISION.md`. Phase-18 is active only as Platform
-> Constitution and does not authorize runtime implementation.
+> `PHASE18_ACTIVATION_DECISION.md`. Post-activation Phase-18 maintenance is
+> reviewed against
+> `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`.
+> Phase-18 is active only as Platform Constitution and does not authorize
+> runtime implementation.
 
 ## Yetkili Durum
 
@@ -21,8 +24,8 @@
 | Step 5 | PR #134, merge `71d10691` | Marker-validation dilimi mainline'a birlesti |
 | Phase-17 kapanisi | `reports/phase17_official_closure_candidate/` official closure package ve verified tag mevcut | Closure authority exact-SHA subject ile sinirlidir; Phase-18'i aktive etmez |
 | Phase-17.5 | PR #142, PR #144, PR #148, PR #149/#151/#150, PR #152 ve closure decision package `main`e kabul edildi | Accepted subject SHA `416a5392` icin bounded evidence resmi closure'a baglandi |
-| Phase-18 | `PHASE18_TRANSITION_DECISION.md` + `PHASE18_ACTIVATION_DECISION.md` | Platform Constitution active; runtime implementation yetkisi degildir |
-| Aktif execution roadmap | `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution reference set | Phase-19 veya ayri implementation karari olmadan runtime baslatilmaz |
+| Phase-18 | `PHASE18_TRANSITION_DECISION.md` + `PHASE18_ACTIVATION_DECISION.md` + `AUTHORITY_DRIFT_GUARD.md` | Platform Constitution active; runtime implementation yetkisi degildir |
+| Aktif execution roadmap | `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution reference set | Phase-19 veya ayri implementation karari olmadan runtime baslatilmaz; authority drift review guard korunur |
 | Canonical performance baseline | `scripts/ci/perf-baseline.lock.json` | Accepted `main` SHA `416a5392`: standalone Performance Gate `26715068398` ve scoped Phase-17 acceptance `26712374737` PASS; closure tag dogrulandi |
 | Review enforcement | Issue #145 tek-maintainer ADR'i, `@kenanay` CODEOWNERS accountability metadata'si ve canli `main` `freeze` protection paritesi ile kapatildi | Bagimsiz self-review iddiasi yoktur; remote CI ve kayitli maintainer karari merge siniridir |
 

--- a/PHASE18_ACTIVATION_DECISION.md
+++ b/PHASE18_ACTIVATION_DECISION.md
@@ -168,6 +168,18 @@ token issuance, trust issuer implementation, registry services, Semantic CLI
 integration, and AI Runtime foundations remain outside Phase-18 unless a
 separate reviewed decision changes the roadmap.
 
+## Post-Activation Authority Drift Guard
+
+After the `CURRENT_PHASE=18` pointer transition, Phase-18 maintenance is
+reviewed against
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`.
+
+That guard protects `Constitution != Runtime` after activation. It does not
+authorize runtime implementation, package installation, workspace creation,
+plugin loading, capability issuance, trust assignment, Semantic CLI execution
+authority, AI Runtime authority, new syscalls, kernel ABI expansion, or Ring0
+policy.
+
 ## Decision Package Conclusion
 
 This package is accepted as the Phase-18 activation decision.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **CURRENT_PHASE:** `18` (`Phase-18 ACTIVE: Platform Constitution`; runtime implementation yetkisi değildir)
 **Freeze Zinciri:** `make ci-freeze` = 40 kapılı strict suite (normative spec-purity dahil) | `make ci-freeze-local` = local performance authority
 **Authority Durumu:** Issue #145 tek-maintainer authority kararıyla giderildi; PR #142, PR #144, PR #148, PR #149, PR #151, PR #150, PR #152 ve Phase-17 closure decision package birleşti. Closure exact-SHA kanıtı `main` SHA `416a5392` üzerinde yenilendi, gerekli uzak acceptance kontrolleri PASS verdi ve `phase17-official-closure` tag'i aynı SHA'ya doğrulandı
-**Yakın Hedef:** Phase-18 Platform Constitution kapsamını korumak; mevcut somut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`, `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md`, `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`, `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`, `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md` ve `PHASE18_ACTIVATION_DECISION.md`; Phase-18 runtime, loader, installer, workspace runtime, plugin loading, capability issuance veya trust assignment yetkisi vermez
+**Yakın Hedef:** Phase-18 Platform Constitution kapsamını korumak; mevcut somut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`, `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md`, `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`, `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`, `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`, `PHASE18_ACTIVATION_DECISION.md` ve `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`; Phase-18 runtime, loader, installer, workspace runtime, plugin loading, capability issuance veya trust assignment yetkisi vermez
 **Ring0 Export Ceiling:** `193 symbols` (current enforced ceiling)
 **Performance Baseline Candidate:** `gha-ubuntu24-20260518.149.1-X64` (authorized run `26370359958` artifact'i PR'a import edildi; SHA `f129d4aa` locked acceptance PASS verdi, ancak tek basina closure authority değildir)
 **Development Status:** Phase-16 OFFICIALLY CLOSED ✅ | Phase-17 OFFICIALLY CLOSED ✅ | SINGLE-MAINTAINER AUTHORITY ALIGNED (#145 RESOLVED) ✅ | PR #142/#144/#148/#149/#151/#150/#152 + closure decision package MERGED ✅ | EXACT-SHA REMOTE EVIDENCE PASS ✅ | Phase-18 PLATFORM CONSTITUTION ACTIVE ✅
@@ -40,7 +40,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **Phase 15 Status:** OFFICIALLY CLOSED ✅ | tag `phase15-official-closure` at `48970cd0` | remote `ci-freeze` run `24213727039` (PR #104) | BCIB Execution Engine v3: three-layer architecture, 293 tests PASS, 12 property tests PASS | `ayken-cli` v0.1 (Faz A wrapper) shipped | `tools/ayken-cli/`
 **Phase 16 Status:** OFFICIALLY CLOSED ✅ | Verification Layer MVP COMPLETE | Evidence chain integrity verified | Trust anchor established | `make verify-system` → 3 gates → PASS | Constitutional rule enforcement active | Fail-closed behavior confirmed
 **Phase 17 Status:** OFFICIALLY CLOSED ✅ | tag `phase17-official-closure` at `416a5392` | full `ci-freeze` (`26712333892`), locked performance (`26715068398`, `26712374737`) ve Phase-17 QEMU evidence lanes (`26712374742`, `26712374736`, `26712374727`, `26712374744`, `26712374728`) PASS | `reports/phase17_official_closure_candidate/`
-**Phase 18 Status:** ACTIVE AS PLATFORM CONSTITUTION | Runtime implementation, kernel expansion, new syscalls, Ring0 policy and AI authority remain forbidden unless a separate phase RFC and closure authority exists
+**Phase 18 Status:** ACTIVE AS PLATFORM CONSTITUTION | Authority drift guard active | Runtime implementation, kernel expansion, new syscalls, Ring0 policy and AI authority remain forbidden unless a separate phase RFC and closure authority exists
 **Architecture Quick Map:** `docs/specs/phase12-trust-layer/AYKENOS_GATE_ARCHITECTURE.md`
 **Active Execution Roadmap:** `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution RFC set | accepted `main` SHA `416a5392` uzerinde bounded uzak evidence PASS; official closure tag doğrulandı; Phase-18 Platform Constitution pointer'i aktiftir
 **Canonical Technical Definition:** AykenOS is a deterministic verification architecture that separates kernel execution, verification semantics, evidence artifacts, and distributed diagnostics into explicit layers. The kernel provides mechanism, userspace verification services produce artifact-bound verdicts and receipts, and parity/topology surfaces expose cross-node observability without elevating diagnostics into authority or consensus.
@@ -68,7 +68,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 - **Evidence:** A, B, C karakterleri başarıyla syscall üzerinden basıldı
 - **Result:** Ring3 infrastructure PROVEN, syscall path WORKING, instruction retirement VALIDATED
 
-**Next Focus:** Phase-18 Platform Constitution kapsamını korumak; mevcut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`, `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md`, `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`, `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`, `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md` ve `PHASE18_ACTIVATION_DECISION.md`; Phase-19 runtime MVP icin ayri karar gerekir.
+**Next Focus:** Phase-18 Platform Constitution kapsamını korumak; mevcut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`, `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md`, `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`, `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`, `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`, `PHASE18_ACTIVATION_DECISION.md` ve `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`; Phase-19 runtime MVP icin ayri karar gerekir.
 
 ## Authority Model
 
@@ -319,6 +319,7 @@ Phase 12 trust layer kapsamında tamamlananlar:
 - **Phase-18 Platform ABI Validation Gate:** `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`
 - **Phase-18 Cross-Consistency Review:** `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`
 - **Phase-18 Activation Decision Package:** `PHASE18_ACTIVATION_DECISION.md`
+- **Phase-18 Authority Drift Guard:** `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`
 - **Documentation Index:** `docs/development/DOCUMENTATION_INDEX.md`
 - **Ring3 User-Leaf Rule:** `docs/governance/RING3_USER_LEAF_ALLOCATION_RULE.md`
 - **Ring3 Runtime Closure Note:** `docs/governance/RING3_RUNTIME_CLOSURE_NOTE.md`
@@ -357,6 +358,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 - Platform ABI validation gate active spec: `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`; validation PASS authority grant degildir.
 - Phase-18 cross-consistency review: `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`; review PASS activation degildir.
 - Phase-18 activation decision package: `PHASE18_ACTIVATION_DECISION.md`; `Constitution != Runtime`, activation runtime implementation yetkisi vermez.
+- Phase-18 authority drift guard: `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`; active review guard'dir, runtime veya Phase-19 authority grant degildir.
 - Phase-19 runtime MVP icin ayri implementation RFC/evidence plan/closure boundary hazirlanmadikca package installer, workspace runtime, plugin loader, capability issuer veya trust issuer yazilmaz.
 
 **Orta Vadeli:**
@@ -372,7 +374,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 
 ---
 
-**Son Güncelleme:** 05 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=18; Module Manifest, Capability Contract, Workspace Lifecycle, Package Metadata, Trust Classification, Plugin Boundary, Platform ABI Validation Gate, Cross-Consistency Review ve `PHASE18_ACTIVATION_DECISION.md` Phase-18 Platform Constitution authority seti olarak aktiftir; runtime implementation Phase-19 veya ayrı karar olmadan yetkili değildir.
+**Son Güncelleme:** 05 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=18; Module Manifest, Capability Contract, Workspace Lifecycle, Package Metadata, Trust Classification, Plugin Boundary, Platform ABI Validation Gate, Cross-Consistency Review, `PHASE18_ACTIVATION_DECISION.md` ve `AUTHORITY_DRIFT_GUARD.md` Phase-18 Platform Constitution authority seti olarak aktiftir; runtime implementation Phase-19 veya ayrı karar olmadan yetkili değildir.
 **Düzenleyen / Geliştiren / Oluşturan / Mimari Sorumlu:** Kenan AY *(metadata only; runtime/karar yetkisi değildir).*
 
 **© 2026 Kenan AY — AykenOS Project**

--- a/docs/development/DOCUMENTATION_INDEX.md
+++ b/docs/development/DOCUMENTATION_INDEX.md
@@ -43,14 +43,15 @@ Current repo truth icin once su dosyalari referans alin:
 18. `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md` — **active Platform ABI validation order/receipt RFC**
 19. `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md` — **Phase-18 RFC set cross-consistency review; not activation**
 20. `PHASE18_ACTIVATION_DECISION.md` — **accepted Phase-18 activation decision package; runtime not authorized**
-21. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
-22. `reports/phase15_official_closure/closure_index.json`
-23. `reports/phase13_official_closure_candidate/closure_index.json`
-24. `reports/phase12_official_closure_candidate/closure_manifest.json`
-25. `reports/phase10_phase11_official_closure_index.json`
-26. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
-27. `Makefile`
-28. `.github/workflows/ci-freeze.yml`
+21. `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md` — **active Phase-18 authority drift review guard; runtime not authorized**
+22. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
+23. `reports/phase15_official_closure/closure_index.json`
+24. `reports/phase13_official_closure_candidate/closure_index.json`
+25. `reports/phase12_official_closure_candidate/closure_manifest.json`
+26. `reports/phase10_phase11_official_closure_index.json`
+27. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
+28. `Makefile`
+29. `.github/workflows/ci-freeze.yml`
 
 Phase-14 workstream numbering ve aktif durum yorumu icin canonical truth source:
 
@@ -93,13 +94,14 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 14. `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`
 15. `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`
 16. `PHASE18_ACTIVATION_DECISION.md` — accepted activation decision package
-17. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
-18. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
-19. `docs/specs/phase16-ayken-orchestration/README.md`
-20. `docs/specs/authority-lineage-v1/README.md`
-21. `docs/specs/phase14-distributed-observability/README.md`
-22. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
-23. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
+17. `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md` — active authority drift review guard
+18. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
+19. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
+20. `docs/specs/phase16-ayken-orchestration/README.md`
+21. `docs/specs/authority-lineage-v1/README.md`
+22. `docs/specs/phase14-distributed-observability/README.md`
+23. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
+24. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
 
 ## Phase-18 Reference Set
 1. `PHASE18_TRANSITION_DECISION.md`
@@ -113,6 +115,7 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 9. `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`
 10. `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`
 11. `PHASE18_ACTIVATION_DECISION.md`
+12. `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`
 
 ## Phase-14 Reference Set
 ### Architecture and Observability Surfaces

--- a/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
+++ b/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
@@ -340,8 +340,10 @@ Phase-17 closure precondition'lari saglanmistir ve Phase-18 yalniz Platform
 Constitution olarak aktiftir. Phase-18 authority zinciri
 `PHASE18_TRANSITION_DECISION.md`, Phase-18 RFC seti,
 `CROSS_CONSISTENCY_REVIEW.md`, `PHASE18_ACTIVATION_DECISION.md` ve
-`CURRENT_PHASE=18` pointer'i ile sinirlidir. Eski `PHASE18_ROADMAP.md`
-tarihsel runtime-validation backlog'u olarak tutulur.
+`CURRENT_PHASE=18` pointer'i ile sinirlidir. Post-activation maintenance
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md` ile
+review edilir. Eski `PHASE18_ROADMAP.md` tarihsel runtime-validation
+backlog'u olarak tutulur.
 
 Phase-18 active scope su kararlari korumadan implementation planina
 donusemez:
@@ -364,6 +366,9 @@ donusemez:
 12. Constitution Runtime degildir; activation runtime implementation,
     package install, workspace creation, plugin loading, capability issuance
     veya trust assignment yetkisi vermez.
+13. `AUTHORITY_DRIFT_GUARD.md` Phase-18 review guard'idir; runtime, loader,
+    issuer, workspace runtime, plugin host, Semantic CLI, AI Runtime veya
+    Phase-19 authority grant degildir.
 
 ## 7. PR Sequence and Coordination Matrix
 
@@ -395,6 +400,7 @@ donusemez:
 | Phase-18 Platform ABI Validation Gate | ACTIVE CONSTITUTION SPEC | Manifest, package, trust, capability, workspace ve plugin boundary input'larini deterministik fail-closed validation order ile baglamak | `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md` | Validation PASS authority grant degil; install/enable/execute/load/mount/capability/trust grant yok |
 | Phase-18 Cross-Consistency Review | ACCEPTED REVIEW | Yedi Phase-18 RFC'nin terminology, dependency order, validation order ve authority separation acisindan celismedigini kaydetmek | `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md` | Review PASS runtime implementation degil |
 | Phase-18 Activation Decision Package | ACCEPTED / PLATFORM CONSTITUTION ACTIVE | Phase-18 aktivasyonu icin precondition, exact-SHA, fail-closed denial ve Constitution != Runtime sinirlarini kaydetmek | `PHASE18_ACTIVATION_DECISION.md` | Activation runtime implementation, capability issuance, trust assignment, workspace creation veya plugin loading yetkisi vermez |
+| Phase-18 Authority Drift Guard | ACTIVE REVIEW GUARD / DOCS-ONLY | Phase-18 aktifken constitutional text'in runtime, loader, issuer, workspace, plugin, trust, capability veya AI/Semantic authority'ye kaymasini fail-closed review etmek | `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md` | Guard runtime implementation, CI gate, merge authority, Phase-19 activation veya authority grant degildir |
 
 PR koordinasyon kurallari:
 
@@ -1083,7 +1089,8 @@ Bu roadmap su olaylarda guncellenir:
 25. Phase-18 Cross-Consistency Review sonucu.
 26. Phase-18 Activation Decision Package review/merge sonucu.
 27. Phase-18 `CURRENT_PHASE=18` pointer transition sonucu.
-28. Yeni feature/ABI/authority surface onerisinin incelenmesi.
+28. Phase-18 Authority Drift Guard review/merge sonucu.
+29. Yeni feature/ABI/authority surface onerisinin incelenmesi.
 
 ## References
 
@@ -1112,6 +1119,7 @@ Bu roadmap su olaylarda guncellenir:
 - `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`
 - `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`
 - `PHASE18_ACTIVATION_DECISION.md`
+- `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`
 - `PHASE18_ROADMAP.md`
 - `shared/abi/syscall_v2.h`
 - `shared/abi/ayken_abi.h`

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -47,7 +47,10 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
    implementation yetkisi degildir.
 15. `../../PHASE18_ACTIVATION_DECISION.md`: accepted Phase-18 activation
    decision package; runtime implementation yetkisi degildir.
-16. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
+16. `../specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`:
+   active Phase-18 review guard; runtime implementation, loader, issuer veya
+   Phase-19 authority grant degildir.
+17. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
    planlamasi; aktif Phase-18 otoritesi degildir.
 
 ## Current Status
@@ -87,6 +90,7 @@ current execution priority otoritesi degildir:
 
 ---
 
-**Next action:** Phase-18 Platform Constitution kapsaminda authority drift
-kontrolu surdurulur; Phase-19 Platform Runtime MVP icin ayri implementation
-RFC, evidence plan ve closure boundary hazirlanmadan runtime isi baslatilmaz.
+**Next action:** Phase-18 Platform Constitution kapsaminda
+`AUTHORITY_DRIFT_GUARD.md` review guard'i korunur; Phase-19 Platform Runtime
+MVP icin ayri decision package, implementation RFC, evidence plan ve closure
+boundary hazirlanmadan runtime isi baslatilmaz.

--- a/docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md
+++ b/docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md
@@ -1,0 +1,206 @@
+# Phase-18 Authority Drift Guard
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, `PHASE18_TRANSITION_DECISION.md`,
+`PHASE18_ACTIVATION_DECISION.md`, and the Phase-18 Platform Constitution
+reference set. In case of conflict, those documents prevail.
+
+**Status:** ACTIVE REVIEW GUARD / RUNTIME NOT AUTHORIZED
+**Review guard id:** `ayken.platform.phase18.authority_drift_guard.v1`
+**Authority boundary:** Documentation/review guard only; not a CI gate, merge
+authority, closure authority, runtime validator, manifest parser, package
+installer, registry, runtime loader, workspace runtime, mount authority,
+plugin host, capability issuer, trust issuer, execution authority, Semantic
+CLI authority, AI Runtime authority, syscall, or kernel ABI expansion.
+
+## Purpose
+
+Phase-18 is active only as Platform Constitution. This guard defines how
+future Phase-18 edits are reviewed so constitutional contracts do not drift
+into runtime authority.
+
+The guard does not authorize implementation. It exists to keep the active
+specification set from becoming an implicit package installer, loader,
+workspace runtime, capability engine, trust service, plugin host, Semantic CLI
+authority, or AI Runtime authority.
+
+## Core Rule
+
+```text
+Phase-18 authority is constitutional, not operational.
+```
+
+The mandatory invariant remains:
+
+```text
+Constitution != Runtime
+```
+
+A schema is not a parser. A contract is not an engine. A lifecycle state is
+not a runtime object. A validation receipt is not an authority grant. An
+accepted Platform Constitution does not install, load, mount, issue, trust,
+execute, or run anything.
+
+## Protected Separations
+
+Future Phase-18 edits must preserve these separations:
+
+1. Constitution != Runtime.
+2. Manifest != Parser.
+3. Package metadata != Installer.
+4. Package compatibility != Install permission.
+5. Trust classification != Capability.
+6. Trust classification != Execution permission.
+7. Capability contract != Token issuer.
+8. Capability receipt != Bearer token.
+9. Workspace lifecycle != Workspace runtime.
+10. Workspace admission != Mount creation.
+11. Logical mount record != Real filesystem mount.
+12. Plugin boundary != Plugin loader.
+13. Plugin compatibility != Loading.
+14. Plugin binding decision != Execution.
+15. Platform ABI validation != Authority grant.
+16. Validation receipt != Runtime handle.
+17. Review PASS != Activation by itself.
+18. CI PASS != Runtime authority.
+19. Semantic CLI output != Execution verdict authority.
+20. AI Runtime output != Execution verdict authority.
+21. Platform ABI != Kernel ABI expansion.
+22. Phase-18 active pointer != Phase-19 runtime permission.
+
+Unknown, ambiguous, or mixed authority interpretations fail closed.
+
+## Allowed Phase-18 Maintenance
+
+Phase-18 may continue to accept documentation-only maintenance that preserves
+the active Platform Constitution boundary:
+
+1. Clarifying accepted RFC text without changing authority.
+2. Adding non-runtime examples that explicitly deny install, load, mount,
+   execute, issue, or trust effects.
+3. Maintaining glossary, terminology, review checklist, and cross-consistency
+   records.
+4. Recording future-facing references as non-authoritative placeholders.
+5. Tightening fail-closed wording for ambiguous terms.
+6. Updating roadmap and index references to point at accepted documents.
+7. Preparing Phase-19 decision inputs without implementing Phase-19 runtime.
+
+Allowed maintenance must remain documentation-only unless a separate reviewed
+phase decision explicitly authorizes implementation.
+
+## Forbidden Phase-18 Drift
+
+The following work is forbidden in Phase-18 unless a separate reviewed phase
+decision, implementation RFC, evidence plan, and acceptance boundary exists:
+
+1. Manifest parser implementation.
+2. Package installer implementation.
+3. Package registry publication service.
+4. Runtime package loader.
+5. Package install, enable, update, or execution path.
+6. Workspace runtime implementation.
+7. Real mount creation or runtime mount binding.
+8. Plugin loader, autoload, host execution, or plugin runtime.
+9. Capability token issuer.
+10. Capability runtime binding engine.
+11. Trust issuer or trust assignment service.
+12. Platform ABI runtime validator binary with authority effects.
+13. Semantic CLI execution authority.
+14. AI Runtime authority.
+15. New syscall.
+16. Kernel ABI expansion.
+17. Ring0 policy.
+18. Kernel plugin system.
+19. Loader handles, runtime handles, or bearer tokens in constitution records.
+20. Treating evidence, diagnostics, review, or CI output as runtime control
+    input.
+
+If any Phase-18 PR contains one of these surfaces, the review outcome must be
+deny or move the work to a separate phase package.
+
+## Drift Trigger Vocabulary
+
+The following terms require extra review whenever added or changed in
+Phase-18 documents:
+
+| Term | Safe Phase-18 meaning | Drift risk |
+|---|---|---|
+| `validated` | All required validation stages passed for an exact input bundle | May be misread as install, trust, enable, or execute |
+| `trusted` | Evidence classification accepted by policy | May be misread as capability or privilege hierarchy |
+| `approved` | Decision record for a requested scope | May be misread as bearer token issuance |
+| `admitted` | Workspace policy state | May be misread as mount creation |
+| `enabled` | Lifecycle state after review | May be misread as loader or execution state |
+| `compatible` | Compatibility input for later review | May be misread as plugin loading |
+| `binding` | Review record or declared relationship | May be misread as runtime handle |
+| `receipt` | Evidence record | May be misread as bearer token |
+| `issuer` | Future authority placeholder only | May be misread as active service |
+| `loader` | Future implementation placeholder only | May be misread as Phase-18 runtime |
+| `runtime` | Out-of-scope future phase unless explicitly denied | May be misread as active implementation |
+| `execute` | Forbidden as Phase-18 authority | May be misread as permission |
+
+Use of these terms is not automatically invalid. It is valid only when the
+surrounding text keeps the term non-authoritative.
+
+## Review Checklist
+
+Every Phase-18 documentation PR should answer:
+
+1. Does the change preserve `Constitution != Runtime`?
+2. Does the change avoid new syscalls and kernel ABI expansion?
+3. Does the change avoid Ring0 policy?
+4. Does the change keep trust separate from capability?
+5. Does the change keep validation separate from authority?
+6. Does the change keep plugin compatibility separate from loading?
+7. Does the change keep workspace lifecycle separate from mount creation?
+8. Does the change keep capability receipts separate from tokens?
+9. Does the change keep package metadata separate from install or execution?
+10. Does the change keep Semantic CLI and AI Runtime outputs
+    non-authoritative?
+11. Does every example deny install, load, mount, execute, issue, and trust
+    effects unless a later phase is explicitly referenced?
+12. Does the change avoid adding runtime source code, workflow authority, or
+    gate authority under Phase-18?
+
+If any answer is no or unclear, the change fails this guard.
+
+## Fail-Closed Review Matrix
+
+| Condition | Required result |
+|---|---|
+| Constitution text implies parser implementation | Reject or move to Phase-19 decision package |
+| Package metadata text implies install or execution | Reject |
+| Trust text implies capability or execution authority | Reject |
+| Capability receipt text implies bearer token | Reject |
+| Workspace lifecycle text implies real mount creation | Reject |
+| Plugin compatibility text implies load, autoload, or execution | Reject |
+| Validation PASS implies authority grant | Reject |
+| CI PASS implies runtime authority | Reject |
+| Semantic CLI or AI output implies execution authority | Reject |
+| New syscall or kernel ABI expansion appears | Reject before Phase-18 review |
+| Runtime code is bundled with Phase-18 constitution maintenance | Reject or split |
+| Node or CI maintenance is bundled with Phase-18 authority change | Split into separate maintenance PR |
+| Phase-19 runtime planning is bundled with Phase-18 guard maintenance | Split into separate decision package |
+
+## Relationship To Phase-19
+
+Phase-19 is the earliest planned place for Platform Runtime MVP work. This
+guard does not start Phase-19.
+
+Phase-19 requires a separate Runtime MVP Decision Package before any runtime
+implementation is considered. That package must define its own scope,
+non-goals, evidence plan, validation boundaries, and fail-closed acceptance
+rules.
+
+Until then, Phase-18 may describe the constitutional rules a future runtime
+must obey, but it must not implement the runtime or grant operational
+authority.
+
+## Non-Authority Conclusion
+
+This guard is an active Phase-18 review surface. It protects against authority
+drift after activation.
+
+It does not authorize runtime implementation, package installation, workspace
+creation, plugin loading, capability issuance, trust assignment, Semantic CLI
+execution authority, AI Runtime authority, new syscalls, kernel ABI expansion,
+or Ring0 policy.

--- a/docs/specs/phase18-platform-constitution/README.md
+++ b/docs/specs/phase18-platform-constitution/README.md
@@ -21,7 +21,7 @@ workspace creation, plugin loading, capability issuance, trust assignment,
 Semantic CLI authority, AI Runtime authority, new syscalls, or kernel ABI
 expansion.
 
-## Current Specs
+## Current Specs And Guards
 
 1. `MODULE_MANIFEST_SCHEMA.md` - first RFC for the declarative module manifest.
 2. `CAPABILITY_CONTRACT_SPECIFICATION.md` - RFC for request, decision,
@@ -40,12 +40,18 @@ expansion.
    cross-contract separation.
 8. `CROSS_CONSISTENCY_REVIEW.md` - accepted review record for cross-document
    terminology, dependency order, and authority separation.
+9. `AUTHORITY_DRIFT_GUARD.md` - active review guard for preventing
+   constitutional text from drifting into runtime authority.
 
 ## Current Review Result
 
 `CROSS_CONSISTENCY_REVIEW.md` records the accepted cross-document review for
 the current seven-RFC Platform Constitution set. This result is a documentation
 review only. It does not authorize implementation.
+
+`AUTHORITY_DRIFT_GUARD.md` defines the ongoing Phase-18 review guard for
+future edits. It is not a runtime validator, CI gate, loader, issuer, or
+implementation authority.
 
 ## Activation Boundary
 


### PR DESCRIPTION
## Summary
- add Phase-18 Authority Drift Guard as an active docs-only review surface
- connect the guard to the Phase-18 spec README, activation decision, roadmap, documentation index, root README, and current status report
- preserve Constitution != Runtime and keep runtime, loader, issuer, workspace, plugin, trust, capability, Semantic CLI, AI Runtime, syscall, and kernel ABI authority out of Phase-18

## Validation
- git diff --check
- make ci-gate-spec-purity
- make ci-gate-naming-compliance
- make ci-gate-drift-activation
- make ci-gate-abi
- make ci-gate-constitutional
- make ci-gate-governance
- python3 tools/ci/validate_phase17_closure_candidate.py --expected-subject-sha 416a5392afbe217e16d26a59e2e1716fdfa9c8f6

## Scope
Docs-only. No runtime implementation, workflows, kernel ABI changes, syscalls, package installer, workspace runtime, plugin loader, capability issuer, trust issuer, Semantic CLI authority, AI Runtime authority, or Node maintenance.