### PR TITLE
docs: add phase19 runtime decision

### DIFF
--- a/AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md
+++ b/AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md
@@ -14,6 +14,8 @@
 > `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`.
 > High-risk wording is audited in
 > `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`.
+> Phase-19 runtime planning is bounded by `PHASE19_RUNTIME_DECISION.md`,
+> which does not activate Phase-19 or authorize implementation.
 > Phase-18 is active only as Platform Constitution and does not authorize
 > runtime implementation.
 
@@ -27,7 +29,8 @@
 | Phase-17 kapanisi | `reports/phase17_official_closure_candidate/` official closure package ve verified tag mevcut | Closure authority exact-SHA subject ile sinirlidir; Phase-18'i aktive etmez |
 | Phase-17.5 | PR #142, PR #144, PR #148, PR #149/#151/#150, PR #152 ve closure decision package `main`e kabul edildi | Accepted subject SHA `416a5392` icin bounded evidence resmi closure'a baglandi |
 | Phase-18 | `PHASE18_TRANSITION_DECISION.md` + `PHASE18_ACTIVATION_DECISION.md` + `AUTHORITY_DRIFT_GUARD.md` + `TERMINOLOGY_AUDIT.md` | Platform Constitution active; runtime implementation yetkisi degildir |
-| Aktif execution roadmap | `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution reference set | Phase-19 veya ayri implementation karari olmadan runtime baslatilmaz; authority drift review guard ve terminology audit korunur |
+| Phase-19 | `PHASE19_RUNTIME_DECISION.md` | Runtime MVP decision boundary only; `CURRENT_PHASE=19` veya implementation yetkisi yoktur |
+| Aktif execution roadmap | `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution reference set | Phase-19 pointer transition, runtime RFC seti ve ayri implementation karari olmadan runtime baslatilmaz; authority drift review guard ve terminology audit korunur |
 | Canonical performance baseline | `scripts/ci/perf-baseline.lock.json` | Accepted `main` SHA `416a5392`: standalone Performance Gate `26715068398` ve scoped Phase-17 acceptance `26712374737` PASS; closure tag dogrulandi |
 | Review enforcement | Issue #145 tek-maintainer ADR'i, `@kenanay` CODEOWNERS accountability metadata'si ve canli `main` `freeze` protection paritesi ile kapatildi | Bagimsiz self-review iddiasi yoktur; remote CI ve kayitli maintainer karari merge siniridir |
 

--- a/PHASE19_RUNTIME_DECISION.md
+++ b/PHASE19_RUNTIME_DECISION.md
@@ -1,0 +1,237 @@
+# Phase-19 Platform Runtime Decision Package
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, `PHASE18_TRANSITION_DECISION.md`,
+`PHASE18_ACTIVATION_DECISION.md`, the Phase-18 Platform Constitution
+reference set, `AUTHORITY_DRIFT_GUARD.md`, and `TERMINOLOGY_AUDIT.md`. In
+case of conflict, those documents prevail until a separate reviewed Phase-19
+activation and closure authority exists.
+
+**Status:** DECISION PACKAGE / PHASE-19 NOT ACTIVE / IMPLEMENTATION NOT AUTHORIZED
+**Decision package date:** 2026-06-05
+**Decision id:** `ayken.phase19.platform_runtime_decision.v1`
+**Authority boundary:** Documentation decision only; not a phase pointer
+transition, runtime implementation, package installer, module loader,
+workspace runtime, real mount authority, plugin host, capability issuer,
+trust issuer, Semantic CLI authority, AI Runtime authority, syscall, kernel
+ABI expansion, merge authority, or closure authority.
+
+## Decision
+
+Phase-19 may be proposed only as **Platform Runtime MVP**.
+
+This package does not activate Phase-19. `CURRENT_PHASE` remains `18` until a
+separate exact-SHA pointer transition is reviewed and accepted.
+
+This package does not authorize runtime source code. It authorizes only the
+preparation of a future Phase-19 runtime RFC set that preserves the Phase-18
+Platform Constitution boundaries.
+
+## Core Rule
+
+```text
+Runtime decision != runtime implementation
+```
+
+The existence of this decision package must not be read as permission to
+implement a manifest parser, package installer, module loader, workspace
+runtime, plugin host, capability issuer, trust issuer, Semantic CLI execution
+path, AI Runtime, registry service, or agent system.
+
+The safe default remains no runtime.
+
+## Phase-19 Runtime Definition
+
+For Phase-19 planning, "Platform Runtime MVP" means a narrowly scoped
+userspace control surface that may later evaluate Phase-18 constitutional
+inputs and emit deterministic evidence records.
+
+The planned runtime is:
+
+1. Userspace only.
+2. Built above the frozen syscall v2 ABI.
+3. Bound to Phase-18 manifest, package, trust, capability, workspace, plugin,
+   and Platform ABI validation contracts.
+4. Evidence-producing and fail-closed.
+5. Non-authoritative unless a later accepted implementation RFC grants a
+   specific bounded behavior.
+
+The planned runtime is not:
+
+1. A kernel feature.
+2. A new syscall surface.
+3. A package manager.
+4. A registry.
+5. A module loader.
+6. A plugin loader.
+7. A real filesystem mount engine.
+8. A capability token issuer.
+9. A trust issuer.
+10. Semantic CLI authority.
+11. AI Runtime authority.
+12. Agent authority.
+
+## Candidate MVP Shape
+
+The earliest safe Phase-19 MVP candidate is a deterministic admission and
+receipt pipeline:
+
+```text
+static input bundle
+  -> manifest/package shape validation
+  -> Platform ABI validation decision
+  -> workspace admission record
+  -> runtime receipt
+```
+
+This candidate shape is not implementation authority. It is a planning
+boundary for future RFCs.
+
+The MVP candidate must not install, load, mount, execute, issue, trust,
+publish, or schedule anything.
+
+## First Running Thing
+
+If a later Phase-19 implementation RFC is accepted, the first permitted
+running artifact must be a minimal userspace admission harness.
+
+That harness may only prove the following bounded behavior:
+
+1. It consumes a static, test-owned input bundle.
+2. It checks the bundle against accepted Phase-18 declarative contracts.
+3. It emits a deterministic receipt.
+4. It fails closed on unknown fields, missing links, stale hashes, invalid
+   dependency declarations, authority drift, or ambiguous terms.
+
+It must not execute the described package or module.
+
+## Future Runtime RFC Set
+
+Before any Phase-19 implementation PR, the following runtime RFC set must be
+prepared and accepted:
+
+1. `RUNTIME_LIFECYCLE_SPECIFICATION.md`
+2. `RUNTIME_INPUT_BUNDLE_SPECIFICATION.md`
+3. `PLATFORM_VALIDATION_INTEGRATION_SPECIFICATION.md`
+4. `WORKSPACE_ADMISSION_RUNTIME_SPECIFICATION.md`
+5. `RUNTIME_RECEIPT_SPECIFICATION.md`
+6. `RUNTIME_EVIDENCE_PLAN.md`
+7. `RUNTIME_NON_GOALS_AND_DENIALS.md`
+
+`MODULE_LOADING_MODEL.md`, `PLUGIN_INSTANTIATION_MODEL.md`, package
+execution, real workspace mounts, capability issuance, trust assignment,
+Semantic CLI authority, AI Runtime authority, and agent behavior are not part
+of the initial Phase-19 MVP decision.
+
+If a future document uses the word `loading`, it must first prove that it is a
+non-loader admission model or move to a later phase decision.
+
+## Phase-19 Does Not Authorize
+
+This decision package must not authorize:
+
+1. `CURRENT_PHASE=19`.
+2. Runtime implementation.
+3. Package installation.
+4. Package execution.
+5. Module loading.
+6. Plugin loading or plugin instantiation.
+7. Workspace creation.
+8. Real filesystem mounts.
+9. Capability token minting.
+10. Capability issuance.
+11. Trust assignment.
+12. Registry publication.
+13. Semantic CLI execution authority.
+14. AI Runtime authority.
+15. Agent systems.
+16. New syscalls.
+17. Kernel ABI expansion.
+18. Ring0 policy.
+19. Kernel loader behavior.
+20. Observability-as-authority.
+
+Any such work requires a separate reviewed decision, RFC set, evidence plan,
+and acceptance boundary.
+
+## Preconditions For Phase-19 Activation Consideration
+
+Phase-19 pointer transition cannot be considered unless all of the following
+are true:
+
+| ID | Precondition | Required result |
+|---|---|---|
+| P19-A1 | Phase-17 closure remains verified | `phase17-official-closure` resolves to `416a5392afbe217e16d26a59e2e1716fdfa9c8f6` |
+| P19-A2 | Phase-18 remains active as Platform Constitution only | `CURRENT_PHASE=18` remains true before the separate pointer transition |
+| P19-A3 | Phase-18 Authority Drift Guard remains active | `AUTHORITY_DRIFT_GUARD.md` rejects runtime drift |
+| P19-A4 | Phase-18 Terminology Audit remains active | high-risk words remain non-authoritative |
+| P19-A5 | Runtime RFC set exists | all required Phase-19 runtime RFCs are accepted |
+| P19-A6 | Runtime non-goals are explicit | installer, loader, execution, issuer, trust, AI, Semantic CLI, and agent authority are denied |
+| P19-A7 | Kernel ABI remains frozen | syscall IDs remain `1000-1011`, count remains `12`, ABI version remains `0x00010001` |
+| P19-A8 | Exact-SHA CI passes | strict `ci-freeze` and Dev Loop pass on the candidate SHA |
+| P19-A9 | Implementation is separated | pointer transition does not include runtime source code |
+| P19-A10 | Evidence plan is accepted | runtime evidence paths, receipts, negative cases, and fail-closed behavior are defined |
+
+Missing, stale, ambiguous, or partially satisfied preconditions fail closed.
+
+## Runtime RFC Acceptance Criteria
+
+Future Phase-19 runtime RFCs must define:
+
+1. Exact input bundle boundaries.
+2. Deterministic state transitions.
+3. Receipt schema and digest binding.
+4. Negative cases for unknown, stale, contradictory, or authority-granting
+   inputs.
+5. Explicit relationship to Phase-18 Platform ABI Validation Gate.
+6. Local and remote evidence paths.
+7. Performance measurement scope if runtime hot paths are touched.
+8. Production default behavior.
+9. Removal or closure conditions for validation-only paths.
+10. Non-authority wording consistent with `TERMINOLOGY_AUDIT.md`.
+
+An RFC that grants runtime behavior without these criteria must be rejected.
+
+## Fail-Closed Denial Conditions
+
+Phase-19 planning must be denied if any of the following are true:
+
+1. This package is used to update `CURRENT_PHASE` directly.
+2. Runtime source code is bundled with this decision package.
+3. A manifest schema is treated as an active parser.
+4. Package metadata is treated as install or execute authority.
+5. Workspace admission is treated as a real mount.
+6. Plugin compatibility is treated as loading.
+7. Trust classification is treated as capability grant.
+8. A validation receipt is treated as a bearer token.
+9. Semantic CLI output is treated as runtime authority.
+10. AI output is treated as runtime authority.
+11. New syscall or kernel ABI expansion is present.
+12. Required Phase-19 runtime RFCs are missing.
+13. Required local or remote checks fail.
+14. Exact-SHA evidence is missing.
+
+The safe default is no Phase-19 activation.
+
+## Relationship To Later Phases
+
+Phase-19 is limited to Platform Runtime MVP planning and, after a separate
+accepted activation, a bounded runtime MVP.
+
+The following remain later-phase work:
+
+1. Phase-20 Capability Ecosystem / Module Registry.
+2. Phase-21 Semantic CLI Integration.
+3. Phase-22 AI Runtime Foundation.
+4. Phase-23+ Agent Systems.
+
+Those later phases must not be pulled into Phase-19 by terminology, examples,
+or convenience.
+
+## Decision Package Conclusion
+
+This package defines the safe Phase-19 Runtime MVP decision boundary.
+
+It does not activate Phase-19. It does not authorize implementation. It
+preserves the rule that Phase-18 remains the active Platform Constitution
+until a separate reviewed pointer transition changes `CURRENT_PHASE`.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **CURRENT_PHASE:** `18` (`Phase-18 ACTIVE: Platform Constitution`; runtime implementation yetkisi değildir)
 **Freeze Zinciri:** `make ci-freeze` = 40 kapılı strict suite (normative spec-purity dahil) | `make ci-freeze-local` = local performance authority
 **Authority Durumu:** Issue #145 tek-maintainer authority kararıyla giderildi; PR #142, PR #144, PR #148, PR #149, PR #151, PR #150, PR #152 ve Phase-17 closure decision package birleşti. Closure exact-SHA kanıtı `main` SHA `416a5392` üzerinde yenilendi, gerekli uzak acceptance kontrolleri PASS verdi ve `phase17-official-closure` tag'i aynı SHA'ya doğrulandı
-**Yakın Hedef:** Phase-18 Platform Constitution kapsamını korumak; mevcut somut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`, `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md`, `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`, `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`, `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`, `PHASE18_ACTIVATION_DECISION.md`, `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md` ve `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`; Phase-18 runtime, loader, installer, workspace runtime, plugin loading, capability issuance veya trust assignment yetkisi vermez
+**Yakın Hedef:** Phase-18 Platform Constitution kapsamını korumak; mevcut somut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`, `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md`, `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`, `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`, `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`, `PHASE18_ACTIVATION_DECISION.md`, `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`, `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md` ve `PHASE19_RUNTIME_DECISION.md`; Phase-19 decision `CURRENT_PHASE=19` veya runtime implementation yetkisi vermez
 **Ring0 Export Ceiling:** `193 symbols` (current enforced ceiling)
 **Performance Baseline Candidate:** `gha-ubuntu24-20260518.149.1-X64` (authorized run `26370359958` artifact'i PR'a import edildi; SHA `f129d4aa` locked acceptance PASS verdi, ancak tek basina closure authority değildir)
 **Development Status:** Phase-16 OFFICIALLY CLOSED ✅ | Phase-17 OFFICIALLY CLOSED ✅ | SINGLE-MAINTAINER AUTHORITY ALIGNED (#145 RESOLVED) ✅ | PR #142/#144/#148/#149/#151/#150/#152 + closure decision package MERGED ✅ | EXACT-SHA REMOTE EVIDENCE PASS ✅ | Phase-18 PLATFORM CONSTITUTION ACTIVE ✅
@@ -41,6 +41,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **Phase 16 Status:** OFFICIALLY CLOSED ✅ | Verification Layer MVP COMPLETE | Evidence chain integrity verified | Trust anchor established | `make verify-system` → 3 gates → PASS | Constitutional rule enforcement active | Fail-closed behavior confirmed
 **Phase 17 Status:** OFFICIALLY CLOSED ✅ | tag `phase17-official-closure` at `416a5392` | full `ci-freeze` (`26712333892`), locked performance (`26715068398`, `26712374737`) ve Phase-17 QEMU evidence lanes (`26712374742`, `26712374736`, `26712374727`, `26712374744`, `26712374728`) PASS | `reports/phase17_official_closure_candidate/`
 **Phase 18 Status:** ACTIVE AS PLATFORM CONSTITUTION | Authority drift guard and terminology audit active | Runtime implementation, kernel expansion, new syscalls, Ring0 policy and AI authority remain forbidden unless a separate phase RFC and closure authority exists
+**Phase 19 Status:** DECISION PACKAGE ONLY | `PHASE19_RUNTIME_DECISION.md` defines Platform Runtime MVP boundaries; `CURRENT_PHASE=19` and runtime implementation are not authorized
 **Architecture Quick Map:** `docs/specs/phase12-trust-layer/AYKENOS_GATE_ARCHITECTURE.md`
 **Active Execution Roadmap:** `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution RFC set | accepted `main` SHA `416a5392` uzerinde bounded uzak evidence PASS; official closure tag doğrulandı; Phase-18 Platform Constitution pointer'i aktiftir
 **Canonical Technical Definition:** AykenOS is a deterministic verification architecture that separates kernel execution, verification semantics, evidence artifacts, and distributed diagnostics into explicit layers. The kernel provides mechanism, userspace verification services produce artifact-bound verdicts and receipts, and parity/topology surfaces expose cross-node observability without elevating diagnostics into authority or consensus.
@@ -54,7 +55,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 - **Current Phase:** `18`
 - **Status:** `ACTIVE / PLATFORM CONSTITUTION ONLY`
 - **Last Official Closure:** `17` (Execution Pipeline, 2026-05-31)
-- **Candidate Next Phase:** `19` (Platform Runtime MVP; separate decision required)
+- **Candidate Next Phase:** `19` (Platform Runtime MVP; `PHASE19_RUNTIME_DECISION.md` defines the decision boundary, but Phase-19 is not active)
 - **Verification Layer:** `COMPLETE` (MVP delivered 2026-04-25)
 - **Closure Index:** `reports/phase17_official_closure_candidate/closure_index.json`
 - **Phase-18 Authority Note:** `CURRENT_PHASE=18` activates Platform Constitution only; runtime implementation still requires a separate decision.
@@ -68,7 +69,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 - **Evidence:** A, B, C karakterleri başarıyla syscall üzerinden basıldı
 - **Result:** Ring3 infrastructure PROVEN, syscall path WORKING, instruction retirement VALIDATED
 
-**Next Focus:** Phase-18 Platform Constitution kapsamını korumak; mevcut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`, `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md`, `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`, `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`, `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`, `PHASE18_ACTIVATION_DECISION.md`, `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md` ve `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`; Phase-19 runtime MVP icin ayri karar gerekir.
+**Next Focus:** Phase-18 Platform Constitution kapsamını korumak ve `PHASE19_RUNTIME_DECISION.md` ile tanimlanan Runtime MVP sinirini runtime koduna donusturmeden Phase-19 RFC hazirligina ayirmak. Phase-19 active pointer, implementation RFC seti, evidence plan ve closure boundary ayri karar gerektirir.
 
 ## Authority Model
 
@@ -321,6 +322,7 @@ Phase 12 trust layer kapsamında tamamlananlar:
 - **Phase-18 Activation Decision Package:** `PHASE18_ACTIVATION_DECISION.md`
 - **Phase-18 Authority Drift Guard:** `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`
 - **Phase-18 Terminology Audit:** `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`
+- **Phase-19 Runtime Decision Package:** `PHASE19_RUNTIME_DECISION.md`
 - **Documentation Index:** `docs/development/DOCUMENTATION_INDEX.md`
 - **Ring3 User-Leaf Rule:** `docs/governance/RING3_USER_LEAF_ALLOCATION_RULE.md`
 - **Ring3 Runtime Closure Note:** `docs/governance/RING3_RUNTIME_CLOSURE_NOTE.md`
@@ -361,6 +363,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 - Phase-18 activation decision package: `PHASE18_ACTIVATION_DECISION.md`; `Constitution != Runtime`, activation runtime implementation yetkisi vermez.
 - Phase-18 authority drift guard: `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`; active review guard'dir, runtime veya Phase-19 authority grant degildir.
 - Phase-18 terminology audit: `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`; high-risk vocabulary icin accepted audit kaydidir, runtime authority degildir.
+- Phase-19 runtime decision package: `PHASE19_RUNTIME_DECISION.md`; Platform Runtime MVP sinirini tanimlar, `CURRENT_PHASE=19` veya runtime implementation yetkisi vermez.
 - Phase-19 runtime MVP icin ayri implementation RFC/evidence plan/closure boundary hazirlanmadikca package installer, workspace runtime, plugin loader, capability issuer veya trust issuer yazilmaz.
 
 **Orta Vadeli:**
@@ -376,7 +379,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 
 ---
 
-**Son Güncelleme:** 05 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=18; Module Manifest, Capability Contract, Workspace Lifecycle, Package Metadata, Trust Classification, Plugin Boundary, Platform ABI Validation Gate, Cross-Consistency Review, `PHASE18_ACTIVATION_DECISION.md`, `AUTHORITY_DRIFT_GUARD.md` ve `TERMINOLOGY_AUDIT.md` Phase-18 Platform Constitution authority seti olarak aktiftir; runtime implementation Phase-19 veya ayrı karar olmadan yetkili değildir.
+**Son Güncelleme:** 05 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=18; Module Manifest, Capability Contract, Workspace Lifecycle, Package Metadata, Trust Classification, Plugin Boundary, Platform ABI Validation Gate, Cross-Consistency Review, `PHASE18_ACTIVATION_DECISION.md`, `AUTHORITY_DRIFT_GUARD.md` ve `TERMINOLOGY_AUDIT.md` Phase-18 Platform Constitution authority seti olarak aktiftir; `PHASE19_RUNTIME_DECISION.md` Runtime MVP karar sinirini tanimlar, ancak Phase-19 aktif degildir ve runtime implementation yetkisi yoktur.
 **Düzenleyen / Geliştiren / Oluşturan / Mimari Sorumlu:** Kenan AY *(metadata only; runtime/karar yetkisi değildir).*
 
 **© 2026 Kenan AY — AykenOS Project**

--- a/docs/development/DOCUMENTATION_INDEX.md
+++ b/docs/development/DOCUMENTATION_INDEX.md
@@ -18,6 +18,7 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict
 - **Formal Governance Pointer:** `CURRENT_PHASE=18`
 - **Active Phase:** Phase-18 ACTIVE / Platform Constitution only
 - **Active Execution Priority:** Maintain Phase-18 Platform Constitution authority without runtime implementation
+- **Candidate Next Decision:** Phase-19 Runtime MVP decision package; not active phase or implementation authority
 - **Scope Boundary:** Phase-18 activation does not authorize runtime implementation; kernel expansion, new syscalls, Ring0 policy and AI Runtime authority remain forbidden for Phase-18
 
 ## Primary Truth Sources
@@ -45,14 +46,15 @@ Current repo truth icin once su dosyalari referans alin:
 20. `PHASE18_ACTIVATION_DECISION.md` — **accepted Phase-18 activation decision package; runtime not authorized**
 21. `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md` — **active Phase-18 authority drift review guard; runtime not authorized**
 22. `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md` — **accepted Phase-18 terminology audit; runtime not authorized**
-23. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
-24. `reports/phase15_official_closure/closure_index.json`
-25. `reports/phase13_official_closure_candidate/closure_index.json`
-26. `reports/phase12_official_closure_candidate/closure_manifest.json`
-27. `reports/phase10_phase11_official_closure_index.json`
-28. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
-29. `Makefile`
-30. `.github/workflows/ci-freeze.yml`
+23. `PHASE19_RUNTIME_DECISION.md` — **Phase-19 Runtime MVP decision package; Phase-19 not active**
+24. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
+25. `reports/phase15_official_closure/closure_index.json`
+26. `reports/phase13_official_closure_candidate/closure_index.json`
+27. `reports/phase12_official_closure_candidate/closure_manifest.json`
+28. `reports/phase10_phase11_official_closure_index.json`
+29. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
+30. `Makefile`
+31. `.github/workflows/ci-freeze.yml`
 
 Phase-14 workstream numbering ve aktif durum yorumu icin canonical truth source:
 
@@ -97,13 +99,14 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 16. `PHASE18_ACTIVATION_DECISION.md` — accepted activation decision package
 17. `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md` — active authority drift review guard
 18. `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md` — accepted terminology audit
-19. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
-20. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
-21. `docs/specs/phase16-ayken-orchestration/README.md`
-22. `docs/specs/authority-lineage-v1/README.md`
-23. `docs/specs/phase14-distributed-observability/README.md`
-24. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
-25. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
+19. `PHASE19_RUNTIME_DECISION.md` — Phase-19 Runtime MVP decision package; not active implementation authority
+20. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
+21. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
+22. `docs/specs/phase16-ayken-orchestration/README.md`
+23. `docs/specs/authority-lineage-v1/README.md`
+24. `docs/specs/phase14-distributed-observability/README.md`
+25. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
+26. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
 
 ## Phase-18 Reference Set
 1. `PHASE18_TRANSITION_DECISION.md`
@@ -119,6 +122,11 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 11. `PHASE18_ACTIVATION_DECISION.md`
 12. `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`
 13. `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`
+
+## Phase-19 Decision Set
+1. `PHASE19_RUNTIME_DECISION.md` — Platform Runtime MVP decision boundary;
+   does not activate `CURRENT_PHASE=19` and does not authorize
+   implementation.
 
 ## Phase-14 Reference Set
 ### Architecture and Observability Surfaces

--- a/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
+++ b/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
@@ -65,9 +65,11 @@ Aktif urun cekirdegi su dort parcadir:
 
 ### 2.3 Urun Olmayan veya Ertelenen Alanlar
 
-Phase-18 aktif pointer'i Platform Constitution ile sinirlidir. Ayri Phase-19
-veya implementation karari olmadan asagidakiler aktif implementation
-backlog'u degildir:
+Phase-18 aktif pointer'i Platform Constitution ile sinirlidir.
+`PHASE19_RUNTIME_DECISION.md` Phase-19 Runtime MVP karar sinirini tanimlar,
+ancak Phase-19'i aktif etmez ve implementation yetkisi vermez. Ayri Phase-19
+pointer transition'i, runtime RFC seti ve implementation karari olmadan
+asagidakiler aktif implementation backlog'u degildir:
 
 - Yeni syscall veya ABI surface genisletmesi.
 - ARM64/RISC-V/real-hardware feature genisletmesi.
@@ -93,6 +95,7 @@ Phase-18 Platform Constitution sinirini asamaz.
 | Review enforcement | `@kenanay` CODEOWNERS accountability metadata'si ve canli `main` required `freeze` protection'i tek-maintainer ADR'iyle hizalandi | Issue #145 RESOLVED; bagimsiz self-review iddiasi veya closure yetkisi kurulmaz |
 | Performance stability | PR-4 local readiness FAIL tarihsel kayit; PR-4A/PR-4B diagnostic; governed renewal ve workflow authority repair accepted | Accepted `main` SHA `416a5392`: Performance Gate `26715068398` ve scoped Phase-17 acceptance `26712374737` PASS; official tag dogrulandi |
 | Phase-18 | Active as Platform Constitution only | Runtime implementation, loader, installer, workspace runtime, plugin loading, capability issuance ve trust assignment yetkisi yoktur |
+| Phase-19 | Decision package only | `PHASE19_RUNTIME_DECISION.md` Runtime MVP sinirini tanimlar; `CURRENT_PHASE=19` veya implementation authority degildir |
 
 ## 4. Stratejik Karar: Stabilization-First
 
@@ -375,6 +378,32 @@ donusemez:
     `compatible`, `binding`, `receipt`, `loader` ve `runtime` terimleri
     runtime authority olarak okunamaz.
 
+### S6 - Phase-19 Runtime Decision Package
+
+**Status:** DECISION PACKAGE / PHASE-19 NOT ACTIVE / IMPLEMENTATION NOT AUTHORIZED
+
+Phase-19 icin authority adayi `PHASE19_RUNTIME_DECISION.md` olarak
+kaydedilir. Bu belge Platform Runtime MVP'nin ne oldugunu ve ne olmadigini
+tanimlar; `CURRENT_PHASE=19` pointer transition'i, runtime source code,
+package installer, module loader, workspace runtime, plugin host, capability
+issuer, trust issuer, Semantic CLI authority veya AI Runtime authority
+kurmaz.
+
+Phase-19 karar siniri su kurallari korur:
+
+1. Runtime decision runtime implementation degildir.
+2. Ilk MVP adayi deterministic admission ve receipt pipeline'i ile
+   sinirlidir.
+3. Static input bundle -> manifest/package shape validation -> Platform ABI
+   validation decision -> workspace admission record -> runtime receipt
+   akisi install/load/mount/execute/issue/trust yapmaz.
+4. Phase-19 runtime RFC seti kabul edilmeden implementation PR acilmaz.
+5. `CURRENT_PHASE=19` ancak ayri exact-SHA pointer transition karariyla
+   degerlendirilebilir.
+6. Kernel ABI `1000-1011` / 12 syscall / `0x00010001` olarak frozen kalir.
+7. Phase-20 registry/capability ecosystem, Phase-21 Semantic CLI, Phase-22 AI
+   Runtime ve Phase-23+ agent sistemleri Phase-19 MVP'ye cekilemez.
+
 ## 7. PR Sequence and Coordination Matrix
 
 | PR paketi | Durum | Tek amac | Kod/dokuman yuzeyi | Zorunlu kontrol |
@@ -407,6 +436,7 @@ donusemez:
 | Phase-18 Activation Decision Package | ACCEPTED / PLATFORM CONSTITUTION ACTIVE | Phase-18 aktivasyonu icin precondition, exact-SHA, fail-closed denial ve Constitution != Runtime sinirlarini kaydetmek | `PHASE18_ACTIVATION_DECISION.md` | Activation runtime implementation, capability issuance, trust assignment, workspace creation veya plugin loading yetkisi vermez |
 | Phase-18 Authority Drift Guard | ACTIVE REVIEW GUARD / DOCS-ONLY | Phase-18 aktifken constitutional text'in runtime, loader, issuer, workspace, plugin, trust, capability veya AI/Semantic authority'ye kaymasini fail-closed review etmek | `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md` | Guard runtime implementation, CI gate, merge authority, Phase-19 activation veya authority grant degildir |
 | Phase-18 Terminology Audit | ACCEPTED AUDIT / DOCS-ONLY | High-risk Phase-18 vocabulary'nin safe meaning, required qualifier ve forbidden reading sinirlarini kaydetmek | `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md` | Audit PASS runtime implementation, loader, issuer, token, mount, execution veya Phase-19 authority grant degildir |
+| Phase-19 Runtime Decision Package | DECISION PACKAGE / PHASE-19 NOT ACTIVE | Platform Runtime MVP'nin decision boundary, non-goal, RFC precondition ve fail-closed denial kosullarini kaydetmek | `PHASE19_RUNTIME_DECISION.md` | Package `CURRENT_PHASE=19`, runtime implementation, loader, installer, workspace runtime, capability issuer, trust issuer, Semantic CLI authority veya AI Runtime authority grant degildir |
 
 PR koordinasyon kurallari:
 
@@ -1097,7 +1127,8 @@ Bu roadmap su olaylarda guncellenir:
 27. Phase-18 `CURRENT_PHASE=18` pointer transition sonucu.
 28. Phase-18 Authority Drift Guard review/merge sonucu.
 29. Phase-18 Terminology Audit review/merge sonucu.
-30. Yeni feature/ABI/authority surface onerisinin incelenmesi.
+30. Phase-19 Runtime Decision Package review/merge sonucu.
+31. Yeni feature/ABI/authority surface onerisinin incelenmesi.
 
 ## References
 
@@ -1128,6 +1159,7 @@ Bu roadmap su olaylarda guncellenir:
 - `PHASE18_ACTIVATION_DECISION.md`
 - `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`
 - `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`
+- `PHASE19_RUNTIME_DECISION.md`
 - `PHASE18_ROADMAP.md`
 - `shared/abi/syscall_v2.h`
 - `shared/abi/ayken_abi.h`

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -2,7 +2,7 @@
 This document is subordinate to `ARCHITECTURE_FREEZE.md`. In case of conflict,
 the freeze contract prevails.
 
-**Last authority sync:** 2026-06-05 (Phase-18 Platform Constitution pointer transition)
+**Last authority sync:** 2026-06-05 (Phase-19 Runtime Decision Package)
 **Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu:** Kenan AY
 **Attribution boundary:** Documentation metadata only; not runtime or merge authority.
 
@@ -53,7 +53,10 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 17. `../specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`:
    accepted Phase-18 terminology audit; high-risk vocabulary icin runtime
    authority kurmaz.
-18. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
+18. `../../PHASE19_RUNTIME_DECISION.md`: Phase-19 Platform Runtime MVP
+   decision package; phase pointer transition veya implementation authority
+   degildir.
+19. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
    planlamasi; aktif Phase-18 otoritesi degildir.
 
 ## Current Status
@@ -63,6 +66,7 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 | Son resmi kapanis | Phase-17 OFFICIALLY CLOSED (`phase17-official-closure` at `416a5392`) |
 | Aktif faz | Phase-18 ACTIVE / Platform Constitution only |
 | Aktif odak | Phase-18 Platform Constitution authority maintenance; runtime implementation remains out of scope |
+| Aday sonraki karar | Phase-19 Platform Runtime MVP decision package; `CURRENT_PHASE=19` veya implementation authority degildir |
 | ABI | Canonical `1000-1011` / 12 syscall, ABI version `0x00010001` |
 | Phase-18 | ACTIVE AS PLATFORM CONSTITUTION; kernel expansion, runtime implementation and new syscalls forbidden unless a separate phase RFC/closure authority exists |
 
@@ -93,8 +97,8 @@ current execution priority otoritesi degildir:
 
 ---
 
-**Next action:** Phase-18 Platform Constitution kapsaminda
-`AUTHORITY_DRIFT_GUARD.md` review guard'i korunur; Phase-19 Platform Runtime
-MVP icin ayri decision package, implementation RFC, evidence plan ve closure
-boundary hazirlanmadan runtime isi baslatilmaz. High-risk vocabulary
-`TERMINOLOGY_AUDIT.md` kaydina gore denetlenir.
+**Next action:** `PHASE19_RUNTIME_DECISION.md` Phase-19 Runtime MVP sinirini
+belgeler; `CURRENT_PHASE=19` veya runtime implementation yetkisi vermez.
+Siradaki is ancak ayri Phase-19 runtime RFC seti, evidence plan ve pointer
+transition karari olabilir. High-risk vocabulary `TERMINOLOGY_AUDIT.md`
+kaydina gore denetlenir.

--- a/docs/specs/phase18-platform-constitution/README.md
+++ b/docs/specs/phase18-platform-constitution/README.md
@@ -60,6 +60,10 @@ terms such as `validated`, `trusted`, `approved`, `admitted`, `enabled`,
 `compatible`, `binding`, `receipt`, `loader`, and `runtime`. The audit PASS is
 not implementation authority.
 
+`../../../PHASE19_RUNTIME_DECISION.md` may define the future Platform Runtime
+MVP decision boundary. It is outside the Phase-18 Constitution spec set and
+does not authorize runtime implementation.
+
 ## Activation Boundary
 
 `../../../PHASE18_ACTIVATION_DECISION.md` is the accepted activation decision


### PR DESCRIPTION
## Summary
- Add `PHASE19_RUNTIME_DECISION.md` as the docs-only decision boundary for a future Platform Runtime MVP.
- Sync README, current status, roadmap, roadmap index, documentation index, and Phase-18 spec README references.
- Preserve `CURRENT_PHASE=18`; this does not activate Phase-19 or authorize implementation.

## Authority Boundary
This PR does not authorize runtime source code, package installation, module loading, workspace runtime, plugin loading, capability issuance, trust assignment, Semantic CLI authority, AI Runtime authority, new syscalls, or kernel ABI changes.

## Local Validation
- `make ci-gate-spec-purity`
- `make ci-gate-naming-compliance`
- `make ci-gate-governance`
- `make ci-gate-drift-activation`
- `make ci-gate-abi`
- `make ci-gate-constitutional`
- `python3 tools/ci/validate_phase17_closure_candidate.py --expected-subject-sha 416a5392afbe217e16d26a59e2e1716fdfa9c8f6`
- `git diff --cached --check`