### PR TITLE
docs: add phase19 runtime rfc set

### DIFF
--- a/AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md
+++ b/AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md
@@ -14,8 +14,10 @@
 > `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`.
 > High-risk wording is audited in
 > `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`.
-> Phase-19 runtime planning is bounded by `PHASE19_RUNTIME_DECISION.md`,
-> which does not activate Phase-19 or authorize implementation.
+> Phase-19 runtime planning is bounded by `PHASE19_RUNTIME_DECISION.md` and
+> the pre-implementation RFC set under
+> `docs/specs/phase19-platform-runtime/`, which do not activate Phase-19 or
+> authorize implementation.
 > Phase-18 is active only as Platform Constitution and does not authorize
 > runtime implementation.
 
@@ -29,8 +31,8 @@
 | Phase-17 kapanisi | `reports/phase17_official_closure_candidate/` official closure package ve verified tag mevcut | Closure authority exact-SHA subject ile sinirlidir; Phase-18'i aktive etmez |
 | Phase-17.5 | PR #142, PR #144, PR #148, PR #149/#151/#150, PR #152 ve closure decision package `main`e kabul edildi | Accepted subject SHA `416a5392` icin bounded evidence resmi closure'a baglandi |
 | Phase-18 | `PHASE18_TRANSITION_DECISION.md` + `PHASE18_ACTIVATION_DECISION.md` + `AUTHORITY_DRIFT_GUARD.md` + `TERMINOLOGY_AUDIT.md` | Platform Constitution active; runtime implementation yetkisi degildir |
-| Phase-19 | `PHASE19_RUNTIME_DECISION.md` | Runtime MVP decision boundary only; `CURRENT_PHASE=19` veya implementation yetkisi yoktur |
-| Aktif execution roadmap | `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution reference set | Phase-19 pointer transition, runtime RFC seti ve ayri implementation karari olmadan runtime baslatilmaz; authority drift review guard ve terminology audit korunur |
+| Phase-19 | `PHASE19_RUNTIME_DECISION.md` + `docs/specs/phase19-platform-runtime/README.md` | Runtime MVP decision/RFC boundary only; `CURRENT_PHASE=19` veya implementation yetkisi yoktur |
+| Aktif execution roadmap | `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution reference set + Phase-19 pre-implementation RFC set | Phase-19 pointer transition ve ayri implementation karari olmadan runtime baslatilmaz; authority drift review guard ve terminology audit korunur |
 | Canonical performance baseline | `scripts/ci/perf-baseline.lock.json` | Accepted `main` SHA `416a5392`: standalone Performance Gate `26715068398` ve scoped Phase-17 acceptance `26712374737` PASS; closure tag dogrulandi |
 | Review enforcement | Issue #145 tek-maintainer ADR'i, `@kenanay` CODEOWNERS accountability metadata'si ve canli `main` `freeze` protection paritesi ile kapatildi | Bagimsiz self-review iddiasi yoktur; remote CI ve kayitli maintainer karari merge siniridir |
 

--- a/PHASE19_RUNTIME_DECISION.md
+++ b/PHASE19_RUNTIME_DECISION.md
@@ -118,6 +118,10 @@ prepared and accepted:
 6. `RUNTIME_EVIDENCE_PLAN.md`
 7. `RUNTIME_NON_GOALS_AND_DENIALS.md`
 
+The initial RFC set lives under
+`docs/specs/phase19-platform-runtime/`. The existence of that directory does
+not activate Phase-19 and does not authorize implementation.
+
 `MODULE_LOADING_MODEL.md`, `PLUGIN_INSTANTIATION_MODEL.md`, package
 execution, real workspace mounts, capability issuance, trust assignment,
 Semantic CLI authority, AI Runtime authority, and agent behavior are not part

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **CURRENT_PHASE:** `18` (`Phase-18 ACTIVE: Platform Constitution`; runtime implementation yetkisi değildir)
 **Freeze Zinciri:** `make ci-freeze` = 40 kapılı strict suite (normative spec-purity dahil) | `make ci-freeze-local` = local performance authority
 **Authority Durumu:** Issue #145 tek-maintainer authority kararıyla giderildi; PR #142, PR #144, PR #148, PR #149, PR #151, PR #150, PR #152 ve Phase-17 closure decision package birleşti. Closure exact-SHA kanıtı `main` SHA `416a5392` üzerinde yenilendi, gerekli uzak acceptance kontrolleri PASS verdi ve `phase17-official-closure` tag'i aynı SHA'ya doğrulandı
-**Yakın Hedef:** Phase-18 Platform Constitution kapsamını korumak; mevcut somut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`, `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md`, `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`, `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`, `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`, `PHASE18_ACTIVATION_DECISION.md`, `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`, `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md` ve `PHASE19_RUNTIME_DECISION.md`; Phase-19 decision `CURRENT_PHASE=19` veya runtime implementation yetkisi vermez
+**Yakın Hedef:** Phase-18 Platform Constitution kapsamını korumak; mevcut somut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`, `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md`, `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`, `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`, `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`, `PHASE18_ACTIVATION_DECISION.md`, `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`, `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`, `PHASE19_RUNTIME_DECISION.md` ve `docs/specs/phase19-platform-runtime/README.md`; Phase-19 decision/RFC set `CURRENT_PHASE=19` veya runtime implementation yetkisi vermez
 **Ring0 Export Ceiling:** `193 symbols` (current enforced ceiling)
 **Performance Baseline Candidate:** `gha-ubuntu24-20260518.149.1-X64` (authorized run `26370359958` artifact'i PR'a import edildi; SHA `f129d4aa` locked acceptance PASS verdi, ancak tek basina closure authority değildir)
 **Development Status:** Phase-16 OFFICIALLY CLOSED ✅ | Phase-17 OFFICIALLY CLOSED ✅ | SINGLE-MAINTAINER AUTHORITY ALIGNED (#145 RESOLVED) ✅ | PR #142/#144/#148/#149/#151/#150/#152 + closure decision package MERGED ✅ | EXACT-SHA REMOTE EVIDENCE PASS ✅ | Phase-18 PLATFORM CONSTITUTION ACTIVE ✅
@@ -41,7 +41,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **Phase 16 Status:** OFFICIALLY CLOSED ✅ | Verification Layer MVP COMPLETE | Evidence chain integrity verified | Trust anchor established | `make verify-system` → 3 gates → PASS | Constitutional rule enforcement active | Fail-closed behavior confirmed
 **Phase 17 Status:** OFFICIALLY CLOSED ✅ | tag `phase17-official-closure` at `416a5392` | full `ci-freeze` (`26712333892`), locked performance (`26715068398`, `26712374737`) ve Phase-17 QEMU evidence lanes (`26712374742`, `26712374736`, `26712374727`, `26712374744`, `26712374728`) PASS | `reports/phase17_official_closure_candidate/`
 **Phase 18 Status:** ACTIVE AS PLATFORM CONSTITUTION | Authority drift guard and terminology audit active | Runtime implementation, kernel expansion, new syscalls, Ring0 policy and AI authority remain forbidden unless a separate phase RFC and closure authority exists
-**Phase 19 Status:** DECISION PACKAGE ONLY | `PHASE19_RUNTIME_DECISION.md` defines Platform Runtime MVP boundaries; `CURRENT_PHASE=19` and runtime implementation are not authorized
+**Phase 19 Status:** DECISION PACKAGE + PRE-IMPLEMENTATION RFC SET ONLY | `PHASE19_RUNTIME_DECISION.md` and `docs/specs/phase19-platform-runtime/README.md` define Platform Runtime MVP boundaries; `CURRENT_PHASE=19` and runtime implementation are not authorized
 **Architecture Quick Map:** `docs/specs/phase12-trust-layer/AYKENOS_GATE_ARCHITECTURE.md`
 **Active Execution Roadmap:** `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution RFC set | accepted `main` SHA `416a5392` uzerinde bounded uzak evidence PASS; official closure tag doğrulandı; Phase-18 Platform Constitution pointer'i aktiftir
 **Canonical Technical Definition:** AykenOS is a deterministic verification architecture that separates kernel execution, verification semantics, evidence artifacts, and distributed diagnostics into explicit layers. The kernel provides mechanism, userspace verification services produce artifact-bound verdicts and receipts, and parity/topology surfaces expose cross-node observability without elevating diagnostics into authority or consensus.
@@ -69,7 +69,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 - **Evidence:** A, B, C karakterleri başarıyla syscall üzerinden basıldı
 - **Result:** Ring3 infrastructure PROVEN, syscall path WORKING, instruction retirement VALIDATED
 
-**Next Focus:** Phase-18 Platform Constitution kapsamını korumak ve `PHASE19_RUNTIME_DECISION.md` ile tanimlanan Runtime MVP sinirini runtime koduna donusturmeden Phase-19 RFC hazirligina ayirmak. Phase-19 active pointer, implementation RFC seti, evidence plan ve closure boundary ayri karar gerektirir.
+**Next Focus:** Phase-18 Platform Constitution kapsamını korumak ve `PHASE19_RUNTIME_DECISION.md` ile `docs/specs/phase19-platform-runtime/README.md` altinda tanimlanan Runtime MVP sinirini runtime koduna donusturmeden cross-review/pointer-transition hazirligina ayirmak. Phase-19 active pointer, implementation karari ve closure boundary ayri karar gerektirir.
 
 ## Authority Model
 
@@ -323,6 +323,7 @@ Phase 12 trust layer kapsamında tamamlananlar:
 - **Phase-18 Authority Drift Guard:** `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`
 - **Phase-18 Terminology Audit:** `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`
 - **Phase-19 Runtime Decision Package:** `PHASE19_RUNTIME_DECISION.md`
+- **Phase-19 Runtime RFC Set:** `docs/specs/phase19-platform-runtime/README.md`
 - **Documentation Index:** `docs/development/DOCUMENTATION_INDEX.md`
 - **Ring3 User-Leaf Rule:** `docs/governance/RING3_USER_LEAF_ALLOCATION_RULE.md`
 - **Ring3 Runtime Closure Note:** `docs/governance/RING3_RUNTIME_CLOSURE_NOTE.md`
@@ -364,6 +365,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 - Phase-18 authority drift guard: `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`; active review guard'dir, runtime veya Phase-19 authority grant degildir.
 - Phase-18 terminology audit: `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`; high-risk vocabulary icin accepted audit kaydidir, runtime authority degildir.
 - Phase-19 runtime decision package: `PHASE19_RUNTIME_DECISION.md`; Platform Runtime MVP sinirini tanimlar, `CURRENT_PHASE=19` veya runtime implementation yetkisi vermez.
+- Phase-19 runtime RFC set: `docs/specs/phase19-platform-runtime/README.md`; lifecycle, input bundle, validation integration, workspace admission record, receipt, evidence plan ve denial sinirlarini tanimlar; implementation yetkisi vermez.
 - Phase-19 runtime MVP icin ayri implementation RFC/evidence plan/closure boundary hazirlanmadikca package installer, workspace runtime, plugin loader, capability issuer veya trust issuer yazilmaz.
 
 **Orta Vadeli:**
@@ -379,7 +381,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 
 ---
 
-**Son Güncelleme:** 05 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=18; Module Manifest, Capability Contract, Workspace Lifecycle, Package Metadata, Trust Classification, Plugin Boundary, Platform ABI Validation Gate, Cross-Consistency Review, `PHASE18_ACTIVATION_DECISION.md`, `AUTHORITY_DRIFT_GUARD.md` ve `TERMINOLOGY_AUDIT.md` Phase-18 Platform Constitution authority seti olarak aktiftir; `PHASE19_RUNTIME_DECISION.md` Runtime MVP karar sinirini tanimlar, ancak Phase-19 aktif degildir ve runtime implementation yetkisi yoktur.
+**Son Güncelleme:** 05 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=18; Module Manifest, Capability Contract, Workspace Lifecycle, Package Metadata, Trust Classification, Plugin Boundary, Platform ABI Validation Gate, Cross-Consistency Review, `PHASE18_ACTIVATION_DECISION.md`, `AUTHORITY_DRIFT_GUARD.md` ve `TERMINOLOGY_AUDIT.md` Phase-18 Platform Constitution authority seti olarak aktiftir; `PHASE19_RUNTIME_DECISION.md` ve `docs/specs/phase19-platform-runtime/README.md` Runtime MVP karar/RFC sinirini tanimlar, ancak Phase-19 aktif degildir ve runtime implementation yetkisi yoktur.
 **Düzenleyen / Geliştiren / Oluşturan / Mimari Sorumlu:** Kenan AY *(metadata only; runtime/karar yetkisi değildir).*
 
 **© 2026 Kenan AY — AykenOS Project**

--- a/docs/development/DOCUMENTATION_INDEX.md
+++ b/docs/development/DOCUMENTATION_INDEX.md
@@ -18,7 +18,7 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict
 - **Formal Governance Pointer:** `CURRENT_PHASE=18`
 - **Active Phase:** Phase-18 ACTIVE / Platform Constitution only
 - **Active Execution Priority:** Maintain Phase-18 Platform Constitution authority without runtime implementation
-- **Candidate Next Decision:** Phase-19 Runtime MVP decision package; not active phase or implementation authority
+- **Candidate Next Decision:** Phase-19 Runtime MVP decision/RFC set; not active phase or implementation authority
 - **Scope Boundary:** Phase-18 activation does not authorize runtime implementation; kernel expansion, new syscalls, Ring0 policy and AI Runtime authority remain forbidden for Phase-18
 
 ## Primary Truth Sources
@@ -47,14 +47,15 @@ Current repo truth icin once su dosyalari referans alin:
 21. `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md` — **active Phase-18 authority drift review guard; runtime not authorized**
 22. `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md` — **accepted Phase-18 terminology audit; runtime not authorized**
 23. `PHASE19_RUNTIME_DECISION.md` — **Phase-19 Runtime MVP decision package; Phase-19 not active**
-24. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
-25. `reports/phase15_official_closure/closure_index.json`
-26. `reports/phase13_official_closure_candidate/closure_index.json`
-27. `reports/phase12_official_closure_candidate/closure_manifest.json`
-28. `reports/phase10_phase11_official_closure_index.json`
-29. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
-30. `Makefile`
-31. `.github/workflows/ci-freeze.yml`
+24. `docs/specs/phase19-platform-runtime/README.md` — **Phase-19 Runtime MVP pre-implementation RFC set; runtime not authorized**
+25. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
+26. `reports/phase15_official_closure/closure_index.json`
+27. `reports/phase13_official_closure_candidate/closure_index.json`
+28. `reports/phase12_official_closure_candidate/closure_manifest.json`
+29. `reports/phase10_phase11_official_closure_index.json`
+30. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
+31. `Makefile`
+32. `.github/workflows/ci-freeze.yml`
 
 Phase-14 workstream numbering ve aktif durum yorumu icin canonical truth source:
 
@@ -100,13 +101,14 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 17. `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md` — active authority drift review guard
 18. `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md` — accepted terminology audit
 19. `PHASE19_RUNTIME_DECISION.md` — Phase-19 Runtime MVP decision package; not active implementation authority
-20. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
-21. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
-22. `docs/specs/phase16-ayken-orchestration/README.md`
-23. `docs/specs/authority-lineage-v1/README.md`
-24. `docs/specs/phase14-distributed-observability/README.md`
-25. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
-26. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
+20. `docs/specs/phase19-platform-runtime/README.md` — Phase-19 Runtime MVP pre-implementation RFC set; not active implementation authority
+21. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
+22. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
+23. `docs/specs/phase16-ayken-orchestration/README.md`
+24. `docs/specs/authority-lineage-v1/README.md`
+25. `docs/specs/phase14-distributed-observability/README.md`
+26. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
+27. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
 
 ## Phase-18 Reference Set
 1. `PHASE18_TRANSITION_DECISION.md`
@@ -123,10 +125,19 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 12. `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`
 13. `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`
 
-## Phase-19 Decision Set
+## Phase-19 Decision And RFC Set
 1. `PHASE19_RUNTIME_DECISION.md` — Platform Runtime MVP decision boundary;
    does not activate `CURRENT_PHASE=19` and does not authorize
    implementation.
+2. `docs/specs/phase19-platform-runtime/README.md` — Phase-19 Runtime MVP
+   pre-implementation RFC set index; does not authorize implementation.
+3. `docs/specs/phase19-platform-runtime/RUNTIME_LIFECYCLE_SPECIFICATION.md`
+4. `docs/specs/phase19-platform-runtime/RUNTIME_INPUT_BUNDLE_SPECIFICATION.md`
+5. `docs/specs/phase19-platform-runtime/PLATFORM_VALIDATION_INTEGRATION_SPECIFICATION.md`
+6. `docs/specs/phase19-platform-runtime/WORKSPACE_ADMISSION_RUNTIME_SPECIFICATION.md`
+7. `docs/specs/phase19-platform-runtime/RUNTIME_RECEIPT_SPECIFICATION.md`
+8. `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_PLAN.md`
+9. `docs/specs/phase19-platform-runtime/RUNTIME_NON_GOALS_AND_DENIALS.md`
 
 ## Phase-14 Reference Set
 ### Architecture and Observability Surfaces

--- a/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
+++ b/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
@@ -68,8 +68,10 @@ Aktif urun cekirdegi su dort parcadir:
 Phase-18 aktif pointer'i Platform Constitution ile sinirlidir.
 `PHASE19_RUNTIME_DECISION.md` Phase-19 Runtime MVP karar sinirini tanimlar,
 ancak Phase-19'i aktif etmez ve implementation yetkisi vermez. Ayri Phase-19
-pointer transition'i, runtime RFC seti ve implementation karari olmadan
-asagidakiler aktif implementation backlog'u degildir:
+pointer transition'i ve implementation karari olmadan asagidakiler aktif
+implementation backlog'u degildir. `docs/specs/phase19-platform-runtime/`
+pre-implementation RFC seti bu siniri detaylandirir; runtime code veya phase
+activation yetkisi vermez:
 
 - Yeni syscall veya ABI surface genisletmesi.
 - ARM64/RISC-V/real-hardware feature genisletmesi.
@@ -95,7 +97,7 @@ Phase-18 Platform Constitution sinirini asamaz.
 | Review enforcement | `@kenanay` CODEOWNERS accountability metadata'si ve canli `main` required `freeze` protection'i tek-maintainer ADR'iyle hizalandi | Issue #145 RESOLVED; bagimsiz self-review iddiasi veya closure yetkisi kurulmaz |
 | Performance stability | PR-4 local readiness FAIL tarihsel kayit; PR-4A/PR-4B diagnostic; governed renewal ve workflow authority repair accepted | Accepted `main` SHA `416a5392`: Performance Gate `26715068398` ve scoped Phase-17 acceptance `26712374737` PASS; official tag dogrulandi |
 | Phase-18 | Active as Platform Constitution only | Runtime implementation, loader, installer, workspace runtime, plugin loading, capability issuance ve trust assignment yetkisi yoktur |
-| Phase-19 | Decision package only | `PHASE19_RUNTIME_DECISION.md` Runtime MVP sinirini tanimlar; `CURRENT_PHASE=19` veya implementation authority degildir |
+| Phase-19 | Decision/RFC package only | `PHASE19_RUNTIME_DECISION.md` ve `docs/specs/phase19-platform-runtime/` Runtime MVP sinirini tanimlar; `CURRENT_PHASE=19` veya implementation authority degildir |
 
 ## 4. Stratejik Karar: Stabilization-First
 
@@ -378,15 +380,22 @@ donusemez:
     `compatible`, `binding`, `receipt`, `loader` ve `runtime` terimleri
     runtime authority olarak okunamaz.
 
-### S6 - Phase-19 Runtime Decision Package
+### S6 - Phase-19 Runtime Decision and RFC Package
 
-**Status:** DECISION PACKAGE / PHASE-19 NOT ACTIVE / IMPLEMENTATION NOT AUTHORIZED
+**Status:** DECISION + PRE-IMPLEMENTATION RFC SET / PHASE-19 NOT ACTIVE / IMPLEMENTATION NOT AUTHORIZED
 
 Phase-19 icin authority adayi `PHASE19_RUNTIME_DECISION.md` olarak
 kaydedilir. Bu belge Platform Runtime MVP'nin ne oldugunu ve ne olmadigini
 tanimlar; `CURRENT_PHASE=19` pointer transition'i, runtime source code,
 package installer, module loader, workspace runtime, plugin host, capability
 issuer, trust issuer, Semantic CLI authority veya AI Runtime authority
+kurmaz.
+
+Pre-implementation RFC seti `docs/specs/phase19-platform-runtime/` altinda
+acilir. Bu set runtime lifecycle, static input bundle, Platform ABI validation
+integration, workspace admission record, runtime receipt, evidence plan ve
+non-goal/denial sinirlarini tanimlar; parser, loader, installer, workspace
+runtime, plugin host, issuer, trust assignment veya execution authority
 kurmaz.
 
 Phase-19 karar siniri su kurallari korur:
@@ -397,12 +406,15 @@ Phase-19 karar siniri su kurallari korur:
 3. Static input bundle -> manifest/package shape validation -> Platform ABI
    validation decision -> workspace admission record -> runtime receipt
    akisi install/load/mount/execute/issue/trust yapmaz.
-4. Phase-19 runtime RFC seti kabul edilmeden implementation PR acilmaz.
+4. Phase-19 runtime RFC seti implementation authority degildir; ayri
+   implementation karari olmadan PR acilmaz.
 5. `CURRENT_PHASE=19` ancak ayri exact-SHA pointer transition karariyla
    degerlendirilebilir.
 6. Kernel ABI `1000-1011` / 12 syscall / `0x00010001` olarak frozen kalir.
 7. Phase-20 registry/capability ecosystem, Phase-21 Semantic CLI, Phase-22 AI
    Runtime ve Phase-23+ agent sistemleri Phase-19 MVP'ye cekilemez.
+8. Phase-19 cross-review ve pointer transition ayridir; RFC seti tek basina
+   `CURRENT_PHASE=19` yapmaz.
 
 ## 7. PR Sequence and Coordination Matrix
 
@@ -437,6 +449,7 @@ Phase-19 karar siniri su kurallari korur:
 | Phase-18 Authority Drift Guard | ACTIVE REVIEW GUARD / DOCS-ONLY | Phase-18 aktifken constitutional text'in runtime, loader, issuer, workspace, plugin, trust, capability veya AI/Semantic authority'ye kaymasini fail-closed review etmek | `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md` | Guard runtime implementation, CI gate, merge authority, Phase-19 activation veya authority grant degildir |
 | Phase-18 Terminology Audit | ACCEPTED AUDIT / DOCS-ONLY | High-risk Phase-18 vocabulary'nin safe meaning, required qualifier ve forbidden reading sinirlarini kaydetmek | `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md` | Audit PASS runtime implementation, loader, issuer, token, mount, execution veya Phase-19 authority grant degildir |
 | Phase-19 Runtime Decision Package | DECISION PACKAGE / PHASE-19 NOT ACTIVE | Platform Runtime MVP'nin decision boundary, non-goal, RFC precondition ve fail-closed denial kosullarini kaydetmek | `PHASE19_RUNTIME_DECISION.md` | Package `CURRENT_PHASE=19`, runtime implementation, loader, installer, workspace runtime, capability issuer, trust issuer, Semantic CLI authority veya AI Runtime authority grant degildir |
+| Phase-19 Runtime RFC Set | PRE-IMPLEMENTATION RFC SET / PHASE-19 NOT ACTIVE | Runtime lifecycle, input bundle, validation integration, workspace admission record, receipt, evidence plan ve denial sinirlarini docs-only tanimlamak | `docs/specs/phase19-platform-runtime/README.md` | RFC set parser, runtime implementation, loader, installer, workspace runtime, capability issuer, trust issuer, Semantic CLI authority, AI Runtime authority veya `CURRENT_PHASE=19` grant degildir |
 
 PR koordinasyon kurallari:
 
@@ -1128,7 +1141,8 @@ Bu roadmap su olaylarda guncellenir:
 28. Phase-18 Authority Drift Guard review/merge sonucu.
 29. Phase-18 Terminology Audit review/merge sonucu.
 30. Phase-19 Runtime Decision Package review/merge sonucu.
-31. Yeni feature/ABI/authority surface onerisinin incelenmesi.
+31. Phase-19 Runtime RFC Set review/merge sonucu.
+32. Yeni feature/ABI/authority surface onerisinin incelenmesi.
 
 ## References
 
@@ -1160,6 +1174,14 @@ Bu roadmap su olaylarda guncellenir:
 - `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`
 - `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`
 - `PHASE19_RUNTIME_DECISION.md`
+- `docs/specs/phase19-platform-runtime/README.md`
+- `docs/specs/phase19-platform-runtime/RUNTIME_LIFECYCLE_SPECIFICATION.md`
+- `docs/specs/phase19-platform-runtime/RUNTIME_INPUT_BUNDLE_SPECIFICATION.md`
+- `docs/specs/phase19-platform-runtime/PLATFORM_VALIDATION_INTEGRATION_SPECIFICATION.md`
+- `docs/specs/phase19-platform-runtime/WORKSPACE_ADMISSION_RUNTIME_SPECIFICATION.md`
+- `docs/specs/phase19-platform-runtime/RUNTIME_RECEIPT_SPECIFICATION.md`
+- `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_PLAN.md`
+- `docs/specs/phase19-platform-runtime/RUNTIME_NON_GOALS_AND_DENIALS.md`
 - `PHASE18_ROADMAP.md`
 - `shared/abi/syscall_v2.h`
 - `shared/abi/ayken_abi.h`

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -2,7 +2,7 @@
 This document is subordinate to `ARCHITECTURE_FREEZE.md`. In case of conflict,
 the freeze contract prevails.
 
-**Last authority sync:** 2026-06-05 (Phase-19 Runtime Decision Package)
+**Last authority sync:** 2026-06-05 (Phase-19 Runtime RFC Set)
 **Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu:** Kenan AY
 **Attribution boundary:** Documentation metadata only; not runtime or merge authority.
 
@@ -56,7 +56,9 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 18. `../../PHASE19_RUNTIME_DECISION.md`: Phase-19 Platform Runtime MVP
    decision package; phase pointer transition veya implementation authority
    degildir.
-19. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
+19. `../specs/phase19-platform-runtime/README.md`: Phase-19 Runtime MVP
+   pre-implementation RFC set; runtime implementation authority degildir.
+20. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
    planlamasi; aktif Phase-18 otoritesi degildir.
 
 ## Current Status
@@ -66,7 +68,7 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 | Son resmi kapanis | Phase-17 OFFICIALLY CLOSED (`phase17-official-closure` at `416a5392`) |
 | Aktif faz | Phase-18 ACTIVE / Platform Constitution only |
 | Aktif odak | Phase-18 Platform Constitution authority maintenance; runtime implementation remains out of scope |
-| Aday sonraki karar | Phase-19 Platform Runtime MVP decision package; `CURRENT_PHASE=19` veya implementation authority degildir |
+| Aday sonraki karar | Phase-19 Platform Runtime MVP decision/RFC set; `CURRENT_PHASE=19` veya implementation authority degildir |
 | ABI | Canonical `1000-1011` / 12 syscall, ABI version `0x00010001` |
 | Phase-18 | ACTIVE AS PLATFORM CONSTITUTION; kernel expansion, runtime implementation and new syscalls forbidden unless a separate phase RFC/closure authority exists |
 
@@ -97,8 +99,9 @@ current execution priority otoritesi degildir:
 
 ---
 
-**Next action:** `PHASE19_RUNTIME_DECISION.md` Phase-19 Runtime MVP sinirini
+**Next action:** `PHASE19_RUNTIME_DECISION.md` ve
+`../specs/phase19-platform-runtime/README.md` Phase-19 Runtime MVP sinirini
 belgeler; `CURRENT_PHASE=19` veya runtime implementation yetkisi vermez.
-Siradaki is ancak ayri Phase-19 runtime RFC seti, evidence plan ve pointer
-transition karari olabilir. High-risk vocabulary `TERMINOLOGY_AUDIT.md`
+Siradaki is ancak ayri Phase-19 cross-review, pointer transition ve
+implementation karari olabilir. High-risk vocabulary `TERMINOLOGY_AUDIT.md`
 kaydina gore denetlenir.

--- a/docs/specs/phase18-platform-constitution/README.md
+++ b/docs/specs/phase18-platform-constitution/README.md
@@ -64,6 +64,10 @@ not implementation authority.
 MVP decision boundary. It is outside the Phase-18 Constitution spec set and
 does not authorize runtime implementation.
 
+`../phase19-platform-runtime/README.md` may define the pre-implementation
+Phase-19 Runtime RFC set. It is also outside the Phase-18 Constitution spec set
+and does not authorize runtime implementation.
+
 ## Activation Boundary
 
 `../../../PHASE18_ACTIVATION_DECISION.md` is the accepted activation decision

--- a/docs/specs/phase19-platform-runtime/PLATFORM_VALIDATION_INTEGRATION_SPECIFICATION.md
+++ b/docs/specs/phase19-platform-runtime/PLATFORM_VALIDATION_INTEGRATION_SPECIFICATION.md
@@ -1,0 +1,103 @@
+# Phase-19 Platform Validation Integration Specification
+
+This document is subordinate to `PHASE19_RUNTIME_DECISION.md`,
+`RUNTIME_INPUT_BUNDLE_SPECIFICATION.md`, and
+`../phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`. In case
+of conflict, those documents prevail.
+
+**Status:** PRE-IMPLEMENTATION RFC / PHASE-19 NOT ACTIVE / RUNTIME NOT AUTHORIZED
+**Contract id:** `ayken.phase19.platform_validation.integration.v1`
+**Authority boundary:** Documentation/specification only; not a validator
+implementation, runtime implementation, installer, loader, issuer, trust
+assignment, workspace creation, plugin loading, Semantic CLI authority, AI
+Runtime authority, syscall, or kernel ABI expansion.
+
+## Purpose
+
+This RFC defines how a future Phase-19 Runtime MVP may consume the Phase-18
+Platform ABI Validation Gate result.
+
+It does not implement validation. It does not turn validation into runtime
+authority.
+
+## Core Rule
+
+```text
+Validation integration != authority grant
+```
+
+The runtime may later record that a validation decision exists and is bound to
+the same input bundle. That record must not install, load, execute, mount,
+issue, trust, or enable anything.
+
+## Integration Inputs
+
+The integration boundary may consume:
+
+1. Runtime input bundle digest.
+2. Platform ABI validation receipt digest.
+3. Platform ABI validation stage summary.
+4. Validation policy reference.
+5. Denial reason if validation failed.
+
+No Semantic CLI output, AI output, diagnostics dashboard, or ambient runtime
+state may be consumed as authority.
+
+## Required Checks
+
+A later implementation must check:
+
+1. Validation receipt contract id is known.
+2. Validation receipt schema version is known.
+3. Validation receipt subject matches the input bundle subject.
+4. Validation receipt digest matches the referenced content.
+5. Validation stage order matches Phase-18 Platform ABI Validation Gate order.
+6. Validation PASS does not include authority-granting effects.
+7. Validation FAIL stops the runtime lifecycle.
+8. Validation receipt does not declare token, mount, loader, execution, trust,
+   or capability authority.
+
+Unknown fields, unknown stages, stale digests, missing policy references, or
+authority-granting effects fail closed.
+
+## Positive Integration Result
+
+A positive integration result may record:
+
+1. Input bundle digest.
+2. Validation receipt digest.
+3. Stage count.
+4. Stage result digests.
+5. Decision status `recordable`.
+
+It must not record active handles, tokens, loaded modules, mounted paths,
+plugin instances, trust levels, or runtime execution results.
+
+## Negative Integration Result
+
+A negative integration result must record:
+
+1. Input bundle digest when available.
+2. Failed or missing validation reference.
+3. Denial reason.
+4. Terminal lifecycle state.
+
+After a negative result, workspace admission record and runtime receipt
+emission must be blocked unless the receipt is an explicit denial receipt.
+
+## Evidence Requirements
+
+Future evidence must prove:
+
+1. Valid validation receipt can be bound to the input bundle.
+2. Mismatched subject fails closed.
+3. Stale digest fails closed.
+4. Unknown stage fails closed.
+5. Validation FAIL prevents admission.
+6. Validation PASS does not grant runtime authority.
+
+## Acceptance Boundary
+
+This RFC only defines integration rules. It does not create a validation gate,
+runtime validator, loader, package manager, workspace engine, or authority
+surface.

--- a/docs/specs/phase19-platform-runtime/README.md
+++ b/docs/specs/phase19-platform-runtime/README.md
@@ -1,0 +1,91 @@
+# Phase-19 Platform Runtime RFC Set
+
+This directory is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, `PHASE18_TRANSITION_DECISION.md`,
+`PHASE18_ACTIVATION_DECISION.md`, the Phase-18 Platform Constitution
+reference set, `AUTHORITY_DRIFT_GUARD.md`, `TERMINOLOGY_AUDIT.md`, and
+`PHASE19_RUNTIME_DECISION.md`. In case of conflict, those documents prevail.
+
+**Status:** PRE-IMPLEMENTATION RFC SET / PHASE-19 NOT ACTIVE / RUNTIME NOT AUTHORIZED
+**Authority basis:** `PHASE19_RUNTIME_DECISION.md`
+**Attribution:** Documentation metadata only; not runtime, merge, or execution
+authority.
+
+## Purpose
+
+This directory defines the first Phase-19 Platform Runtime MVP RFC set.
+
+The set narrows the future runtime implementation question before any runtime
+source code exists. It defines lifecycle, static input bundle, validation
+integration, workspace admission record, runtime receipt, evidence plan, and
+non-goal boundaries.
+
+It does not activate Phase-19. It does not update `CURRENT_PHASE`. It does not
+authorize package installation, module loading, workspace creation, real
+filesystem mounts, plugin loading, capability issuance, trust assignment,
+Semantic CLI authority, AI Runtime authority, new syscalls, or kernel ABI
+expansion.
+
+## Current RFCs
+
+1. `RUNTIME_LIFECYCLE_SPECIFICATION.md` - deterministic runtime MVP lifecycle
+   states and transitions.
+2. `RUNTIME_INPUT_BUNDLE_SPECIFICATION.md` - static test-owned input bundle
+   boundary.
+3. `PLATFORM_VALIDATION_INTEGRATION_SPECIFICATION.md` - integration with the
+   Phase-18 Platform ABI Validation Gate.
+4. `WORKSPACE_ADMISSION_RUNTIME_SPECIFICATION.md` - workspace admission record
+   boundary without workspace creation or mount authority.
+5. `RUNTIME_RECEIPT_SPECIFICATION.md` - deterministic runtime receipt schema
+   and digest binding.
+6. `RUNTIME_EVIDENCE_PLAN.md` - required local/remote evidence surfaces for a
+   later implementation.
+7. `RUNTIME_NON_GOALS_AND_DENIALS.md` - explicit denial list for installer,
+   loader, issuer, trust, Semantic CLI, AI Runtime, registry, and agent drift.
+
+## Core Rule
+
+```text
+Runtime RFC set != runtime implementation
+```
+
+The existence of these RFCs means only that the Phase-19 Runtime MVP boundary
+is documented for later review. A separate exact-SHA pointer transition,
+implementation RFC acceptance, runtime evidence implementation, and remote CI
+authority remain required before any runtime code can be accepted.
+
+## MVP Boundary
+
+The only future MVP shape allowed by this set is:
+
+```text
+static input bundle
+  -> Phase-18 Platform ABI validation integration
+  -> workspace admission record
+  -> deterministic runtime receipt
+```
+
+This flow must not install, load, mount, execute, issue, trust, publish, or
+schedule anything.
+
+## Non-Authority Rule
+
+No file in this directory may grant:
+
+1. `CURRENT_PHASE=19`.
+2. Runtime source code authority.
+3. Package installation or execution.
+4. Module loading.
+5. Plugin loading or instantiation.
+6. Workspace creation or real mounts.
+7. Capability token minting or issuance.
+8. Trust assignment.
+9. Registry publication.
+10. Semantic CLI execution authority.
+11. AI Runtime authority.
+12. Agent authority.
+13. New syscalls.
+14. Kernel ABI expansion.
+15. Ring0 policy.
+
+Unknown authority readings fail closed.

--- a/docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_PLAN.md
+++ b/docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_PLAN.md
@@ -1,0 +1,117 @@
+# Phase-19 Runtime Evidence Plan
+
+This document is subordinate to `PHASE19_RUNTIME_DECISION.md` and the Phase-19
+Runtime RFC set. In case of conflict, those documents prevail.
+
+**Status:** PRE-IMPLEMENTATION RFC / PHASE-19 NOT ACTIVE / RUNTIME NOT AUTHORIZED
+**Contract id:** `ayken.phase19.runtime.evidence_plan.v1`
+**Authority boundary:** Documentation/specification only; not a CI gate
+implementation, runtime implementation, loader, installer, workspace runtime,
+issuer, trust assignment, Semantic CLI authority, AI Runtime authority,
+syscall, kernel ABI expansion, or closure authority.
+
+## Purpose
+
+This plan defines the evidence that a later Phase-19 Runtime MVP
+implementation must produce before activation or acceptance can be considered.
+
+It does not implement any evidence gate.
+
+## Core Rule
+
+```text
+Evidence plan != evidence PASS
+```
+
+Planning an evidence path does not prove runtime behavior. Only exact-SHA
+local and remote evidence can support a later implementation review.
+
+## Required Evidence Surfaces
+
+A later implementation must provide evidence for:
+
+1. Runtime lifecycle positive path.
+2. Runtime lifecycle fail-closed negative paths.
+3. Static input bundle canonical binding.
+4. Platform validation integration.
+5. Workspace admission record emission.
+6. Runtime receipt emission.
+7. Deterministic repeat.
+8. Authority drift denial.
+9. Kernel ABI freeze preservation.
+10. Production default behavior.
+
+## Positive Evidence
+
+Positive evidence must prove only this bounded flow:
+
+```text
+static input bundle
+  -> validation integration record
+  -> workspace admission record
+  -> runtime receipt
+```
+
+Positive evidence must explicitly state that it does not prove install, load,
+mount, execute, issue, trust, plugin loading, Semantic CLI authority, AI
+Runtime authority, registry publication, or agent behavior.
+
+## Negative Evidence
+
+Negative evidence must include at least:
+
+1. Unknown input bundle field.
+2. Duplicate input bundle key.
+3. Missing manifest reference.
+4. Stale manifest digest.
+5. Mismatched package and manifest subject.
+6. Missing Platform ABI validation receipt.
+7. Validation FAIL.
+8. Workspace declaration requesting real mount.
+9. Receipt declaring token authority.
+10. Trust classification treated as capability grant.
+11. Plugin compatibility treated as loading.
+12. Semantic CLI output treated as runtime authority.
+13. AI output treated as runtime authority.
+14. New syscall or kernel ABI expansion request.
+
+Each negative case must fail closed before receipt success emission.
+
+## Determinism Evidence
+
+Determinism evidence must show:
+
+1. Same input bundle produces same lifecycle transcript digest.
+2. Same input bundle produces same admission record digest.
+3. Same input bundle produces same receipt digest.
+4. Denial cases produce stable denial reasons.
+5. Wall-clock values do not affect authoritative verdicts.
+
+## Remote Evidence
+
+Before a future implementation can be considered, remote CI must prove:
+
+1. Strict `ci-freeze` PASS on the candidate SHA.
+2. Dev Loop PASS on the candidate SHA.
+3. Any new runtime-specific gate PASS on the candidate SHA.
+4. Kernel ABI gate PASS with `1000-1011`, count `12`, version `0x00010001`.
+5. Phase-18 authority drift guard remains effective.
+
+## Performance Evidence
+
+If a future implementation touches runtime hot paths, it must define measured
+surface, baseline authority, threshold policy, and local/remote acceptance
+rules before claiming performance acceptance.
+
+Docs-only RFC changes do not create runtime performance claims.
+
+## Evidence Output Rule
+
+Evidence is output only. It must not become control input for scheduling,
+loading, admission, trust, capability, Semantic CLI, AI Runtime, registry, or
+agent decisions.
+
+## Acceptance Boundary
+
+This plan is not a CI implementation. It is a required checklist for a later
+implementation PR and pointer-transition review.

--- a/docs/specs/phase19-platform-runtime/RUNTIME_INPUT_BUNDLE_SPECIFICATION.md
+++ b/docs/specs/phase19-platform-runtime/RUNTIME_INPUT_BUNDLE_SPECIFICATION.md
@@ -1,0 +1,114 @@
+# Phase-19 Runtime Input Bundle Specification
+
+This document is subordinate to `PHASE19_RUNTIME_DECISION.md`,
+`RUNTIME_LIFECYCLE_SPECIFICATION.md`, and the Phase-18 Platform Constitution
+reference set. In case of conflict, those documents prevail.
+
+**Status:** PRE-IMPLEMENTATION RFC / PHASE-19 NOT ACTIVE / RUNTIME NOT AUTHORIZED
+**Contract id:** `ayken.phase19.runtime.input_bundle.v1`
+**Authority boundary:** Documentation/specification only; not a parser,
+installer, loader, workspace creator, mount engine, plugin host, issuer,
+trust assignment, Semantic CLI authority, AI Runtime authority, syscall, or
+kernel ABI expansion.
+
+## Purpose
+
+This RFC defines the static input bundle shape for the first possible
+Phase-19 Runtime MVP.
+
+The bundle is a deterministic collection of references to Phase-18
+constitutional inputs. It is not a runtime request and does not authorize any
+action by itself.
+
+## Core Rule
+
+```text
+Input bundle != execution request
+```
+
+An input bundle may be validated and recorded. It must not install, load,
+mount, execute, issue, trust, publish, or schedule anything.
+
+## Bundle Shape
+
+Version 1 bundles are declarative records with these required fields:
+
+| Field | Required | Meaning | Authority boundary |
+|---|---|---|---|
+| `schema_id` | yes | Must be `ayken.phase19.runtime.input_bundle.v1` | Not runtime authority |
+| `bundle_id` | yes | Stable bundle identifier | Not package id authority |
+| `bundle_version` | yes | Bundle schema version | Not module version authority |
+| `subject` | yes | Exact subject being evaluated | Not install target |
+| `manifest_ref` | yes | Digest-bound manifest reference | Not parser authority |
+| `package_ref` | optional | Digest-bound package metadata reference | Not installer authority |
+| `platform_validation_policy_ref` | yes | Validation policy reference | Not policy execution |
+| `workspace_admission_request` | yes | Declarative workspace admission request | Not workspace creation |
+| `expected_receipt_profile` | yes | Receipt profile name and version | Not token request |
+| `evidence_refs` | optional | Immutable input evidence references | Not authority inheritance |
+
+Unknown fields fail closed.
+
+## Subject Binding
+
+The `subject` field must bind:
+
+1. Subject kind.
+2. Subject id.
+3. Subject version.
+4. Subject digest.
+5. Optional publisher reference.
+6. Optional package reference.
+
+The subject must match all referenced Phase-18 documents. If manifest,
+package, validation, workspace, or evidence references disagree, the bundle
+must be rejected.
+
+## Reference Rules
+
+All references must be immutable or digest-bound.
+
+Required reference properties:
+
+1. Stable path or URI.
+2. Digest algorithm.
+3. Digest value.
+4. Declared contract id.
+5. Expected schema version.
+
+Mutable references, branch names, unpinned URLs, ambient local paths, or
+implicit latest values fail closed.
+
+## Canonicalization Rules
+
+A later implementation must define a canonical serialization before computing
+bundle digests.
+
+Until then, this RFC requires only these constraints:
+
+1. Duplicate keys are invalid.
+2. Unknown top-level fields are invalid.
+3. Unknown enum values are invalid.
+4. Missing required references are invalid.
+5. Non-deterministic ordering is invalid unless canonicalized before use.
+6. Wall-clock timestamps are not authoritative.
+
+## Negative Cases
+
+The bundle must be denied if it:
+
+1. Requests installation.
+2. Requests execution.
+3. Requests module loading.
+4. Requests plugin loading.
+5. Requests real filesystem mounts.
+6. Requests capability issuance.
+7. Requests trust assignment.
+8. Treats validation PASS as authority.
+9. Treats a receipt as a bearer token.
+10. Requires new syscalls or kernel ABI expansion.
+
+## Acceptance Boundary
+
+This RFC does not implement bundle parsing. A later implementation must prove
+deterministic positive and negative bundle handling before Phase-19 runtime
+activation can be considered.

--- a/docs/specs/phase19-platform-runtime/RUNTIME_LIFECYCLE_SPECIFICATION.md
+++ b/docs/specs/phase19-platform-runtime/RUNTIME_LIFECYCLE_SPECIFICATION.md
@@ -1,0 +1,129 @@
+# Phase-19 Runtime Lifecycle Specification
+
+This document is subordinate to `PHASE19_RUNTIME_DECISION.md` and the
+Phase-18 Platform Constitution reference set. In case of conflict, those
+documents prevail.
+
+**Status:** PRE-IMPLEMENTATION RFC / PHASE-19 NOT ACTIVE / RUNTIME NOT AUTHORIZED
+**Contract id:** `ayken.phase19.runtime.lifecycle.v1`
+**Authority boundary:** Documentation/specification only; not runtime source
+code, scheduler policy, package installer, module loader, workspace runtime,
+plugin host, capability issuer, trust issuer, Semantic CLI authority, AI
+Runtime authority, syscall, kernel ABI expansion, or closure authority.
+
+## Purpose
+
+This RFC defines the deterministic lifecycle for the first possible
+Phase-19 Platform Runtime MVP.
+
+The lifecycle exists to bound future implementation. It does not implement a
+runtime and does not activate Phase-19.
+
+## Core Rule
+
+```text
+Lifecycle state != runtime authority
+```
+
+A lifecycle state may describe where a future MVP is in an admission/receipt
+flow. It must never grant install, load, mount, execute, issue, trust, plugin,
+Semantic CLI, AI, registry, or agent authority.
+
+## Positive Scope
+
+Version 1 lifecycle scope is limited to:
+
+1. Static input bundle intake.
+2. Input bundle binding.
+3. Platform validation integration.
+4. Workspace admission record preparation.
+5. Runtime receipt emission.
+6. Fail-closed denial.
+7. Evidence output.
+
+## Non-Goals
+
+This lifecycle does not define:
+
+1. A runtime binary.
+2. A package manager.
+3. A module loader.
+4. A plugin loader.
+5. A workspace mount engine.
+6. A capability issuer.
+7. A trust issuer.
+8. Semantic CLI execution.
+9. AI Runtime.
+10. Agent behavior.
+11. Kernel behavior.
+
+## Lifecycle States
+
+| State | Meaning | Authority boundary |
+|---|---|---|
+| `UNINITIALIZED` | No input bundle is bound | No work authorized |
+| `INPUT_BOUND` | Static input bundle has been selected and digest-bound | Not validated or admitted |
+| `VALIDATING` | Platform validation integration is evaluating input references | Not authority grant |
+| `VALIDATION_REJECTED` | Validation failed or was blocked | Terminal denial |
+| `VALIDATED_RECORDABLE` | Validation evidence is sufficient to prepare records | Not execution or trust |
+| `ADMISSION_RECORDED` | Workspace admission record has been emitted | Not workspace creation or mount |
+| `RECEIPT_EMITTED` | Runtime receipt has been emitted | Not token or handle |
+| `ABORTED` | Flow stopped due to ambiguity, missing evidence, drift, or internal failure | Terminal denial |
+
+Unknown states fail closed.
+
+## Required Transition Order
+
+The only valid positive transition order is:
+
+```text
+UNINITIALIZED
+  -> INPUT_BOUND
+  -> VALIDATING
+  -> VALIDATED_RECORDABLE
+  -> ADMISSION_RECORDED
+  -> RECEIPT_EMITTED
+```
+
+The only valid denial transitions are:
+
+```text
+INPUT_BOUND -> ABORTED
+VALIDATING -> VALIDATION_REJECTED
+VALIDATING -> ABORTED
+VALIDATED_RECORDABLE -> ABORTED
+ADMISSION_RECORDED -> ABORTED
+```
+
+After `VALIDATION_REJECTED`, `RECEIPT_EMITTED`, or `ABORTED`, no further
+authoritative transition is allowed.
+
+## Determinism Requirements
+
+A later implementation must prove:
+
+1. Same input bundle digest produces the same lifecycle transcript.
+2. Unknown fields produce the same denial state.
+3. Missing references produce the same denial state.
+4. Stale validation receipts produce the same denial state.
+5. Authority-granting words produce the same denial state.
+6. No wall-clock value is part of an authoritative lifecycle verdict.
+
+## Evidence Requirements
+
+Each lifecycle run must emit:
+
+1. Input bundle digest.
+2. Validation integration result digest.
+3. Workspace admission record digest when emitted.
+4. Runtime receipt digest when emitted.
+5. Ordered lifecycle states.
+6. Denial reason for rejected or aborted flows.
+
+Evidence is output only. It must not become runtime control input.
+
+## Acceptance Boundary
+
+This RFC can support a future implementation only if that implementation
+proves the positive path and negative denial paths through local and remote
+evidence. Until then, this file is documentation only.

--- a/docs/specs/phase19-platform-runtime/RUNTIME_NON_GOALS_AND_DENIALS.md
+++ b/docs/specs/phase19-platform-runtime/RUNTIME_NON_GOALS_AND_DENIALS.md
@@ -1,0 +1,103 @@
+# Phase-19 Runtime Non-Goals And Denials
+
+This document is subordinate to `PHASE19_RUNTIME_DECISION.md`,
+`../phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`../phase18-platform-constitution/TERMINOLOGY_AUDIT.md`, and the Phase-19
+Runtime RFC set. In case of conflict, those documents prevail.
+
+**Status:** PRE-IMPLEMENTATION RFC / PHASE-19 NOT ACTIVE / RUNTIME NOT AUTHORIZED
+**Contract id:** `ayken.phase19.runtime.non_goals.denials.v1`
+**Authority boundary:** Documentation/specification only; not runtime source
+code, installer, loader, workspace runtime, plugin host, capability issuer,
+trust issuer, Semantic CLI authority, AI Runtime authority, registry, agent,
+syscall, kernel ABI expansion, merge authority, or closure authority.
+
+## Purpose
+
+This RFC records what Phase-19 Runtime MVP planning must not do.
+
+The denial list exists to prevent Phase-19 from absorbing Phase-20, Phase-21,
+Phase-22, or Phase-23+ work by terminology or convenience.
+
+## Core Rule
+
+```text
+MVP boundary denial is mandatory
+```
+
+If a future Phase-19 proposal conflicts with this file, the proposal must fail
+closed or move to a later reviewed phase decision.
+
+## Denied In Phase-19 MVP
+
+The Phase-19 Runtime MVP must not include:
+
+1. Package installation.
+2. Package execution.
+3. Module loading.
+4. Loader handles.
+5. Plugin loading.
+6. Plugin instantiation.
+7. Workspace creation.
+8. Real filesystem mounts.
+9. Capability token minting.
+10. Capability issuance.
+11. Trust assignment.
+12. Registry publication.
+13. Marketplace behavior.
+14. Semantic CLI execution authority.
+15. AI Runtime authority.
+16. Agent systems.
+17. Kernel loader behavior.
+18. New syscalls.
+19. Kernel ABI expansion.
+20. Ring0 policy.
+21. Observability-as-authority.
+
+## High-Risk Term Denials
+
+| Term | Safe Phase-19 meaning | Forbidden reading |
+|---|---|---|
+| `runtime` | Future userspace admission/receipt MVP boundary | Full platform executor |
+| `admission` | Evidence record | Workspace creation or mount |
+| `receipt` | Digest-bound evidence output | Token, handle, or capability |
+| `validated` | Consistent with Platform ABI inputs | Install, load, execute, trust, or issue |
+| `enabled` | Not allowed for MVP behavior | Autoload or execution |
+| `binding` | Digest/reference relation | Runtime link or loader binding |
+| `workspace` | Declarative admission subject | Real filesystem namespace |
+| `loader` | Forbidden in Phase-19 MVP | Module or plugin loading |
+| `trusted` | Phase-18 classification input only | Capability grant |
+
+Unknown high-risk terms fail closed until audited.
+
+## Later-Phase Ownership
+
+The following work remains outside Phase-19:
+
+1. Phase-20: Capability Ecosystem / Module Registry.
+2. Phase-21: Semantic CLI Integration.
+3. Phase-22: AI Runtime Foundation.
+4. Phase-23+: Agent Systems.
+
+These later phases require their own decision packages, RFC sets, evidence
+plans, pointer transitions, and acceptance boundaries.
+
+## Rejection Conditions
+
+A future Phase-19 proposal must be rejected if it:
+
+1. Updates `CURRENT_PHASE` without separate pointer transition.
+2. Adds runtime source code before RFC/evidence acceptance.
+3. Adds loader, installer, registry, workspace runtime, plugin host, issuer,
+   trust, Semantic CLI, AI Runtime, or agent code.
+4. Adds new syscalls or changes the frozen kernel ABI.
+5. Treats a receipt as a bearer token.
+6. Treats validation as authority.
+7. Treats trust as capability.
+8. Treats admission as mount.
+9. Treats plugin compatibility as loading.
+10. Omits negative evidence for authority drift.
+
+## Acceptance Boundary
+
+This file is a denial contract. It authorizes no runtime behavior.

--- a/docs/specs/phase19-platform-runtime/RUNTIME_RECEIPT_SPECIFICATION.md
+++ b/docs/specs/phase19-platform-runtime/RUNTIME_RECEIPT_SPECIFICATION.md
@@ -1,0 +1,102 @@
+# Phase-19 Runtime Receipt Specification
+
+This document is subordinate to `PHASE19_RUNTIME_DECISION.md`,
+`RUNTIME_LIFECYCLE_SPECIFICATION.md`,
+`WORKSPACE_ADMISSION_RUNTIME_SPECIFICATION.md`, and
+`../phase18-platform-constitution/TERMINOLOGY_AUDIT.md`. In case of conflict,
+those documents prevail.
+
+**Status:** PRE-IMPLEMENTATION RFC / PHASE-19 NOT ACTIVE / RUNTIME NOT AUTHORIZED
+**Contract id:** `ayken.phase19.runtime.receipt.v1`
+**Authority boundary:** Documentation/specification only; not a token,
+capability, runtime handle, loader handle, workspace handle, plugin instance,
+trust assignment, Semantic CLI authority, AI Runtime authority, syscall,
+kernel ABI expansion, or closure authority.
+
+## Purpose
+
+This RFC defines the deterministic runtime receipt for the first possible
+Phase-19 Runtime MVP.
+
+The receipt records the outcome of the static input bundle admission flow. It
+does not grant access or execution.
+
+## Core Rule
+
+```text
+Receipt != token
+```
+
+A receipt is evidence. It must not be accepted as a bearer credential,
+capability token, workspace handle, plugin binding, execution right, trust
+assignment, or loader result.
+
+## Receipt Fields
+
+Version 1 receipts require:
+
+| Field | Required | Meaning | Authority boundary |
+|---|---|---|---|
+| `schema_id` | yes | Must be `ayken.phase19.runtime.receipt.v1` | Not authority |
+| `receipt_id` | yes | Stable deterministic id | Not token id |
+| `subject` | yes | Bound subject | Not execution target |
+| `input_bundle_digest` | yes | Bound input bundle | Not replay permission |
+| `lifecycle_digest` | yes | Ordered lifecycle digest | Not lifecycle authority |
+| `validation_result_digest` | yes | Bound validation integration digest | Not validation grant |
+| `admission_record_digest` | conditional | Required for admitted records | Not workspace handle |
+| `receipt_status` | yes | `admitted_recorded`, `denied`, or `aborted` | Not runtime state |
+| `denial_reason` | conditional | Required for denied or aborted receipts | Not override authority |
+
+Unknown fields fail closed.
+
+## Receipt Status Values
+
+| Status | Meaning | Boundary |
+|---|---|---|
+| `admitted_recorded` | Admission record and receipt were emitted | No execution or workspace |
+| `denied` | Input failed deterministic checks | Terminal denial |
+| `aborted` | Flow stopped due to ambiguity or internal failure | Terminal denial |
+
+Unknown statuses fail closed.
+
+## Digest Binding
+
+The receipt digest must bind:
+
+1. Receipt schema id.
+2. Subject.
+3. Input bundle digest.
+4. Lifecycle digest.
+5. Validation result digest.
+6. Admission record digest when present.
+7. Receipt status.
+8. Denial reason when present.
+
+The receipt must not bind wall-clock time as an authoritative verdict input.
+
+## Denial Requirements
+
+A receipt must be denied or aborted if:
+
+1. Input bundle is missing.
+2. Validation integration is missing.
+3. Workspace admission record is stale or mismatched.
+4. Any digest is stale or inconsistent.
+5. Receipt content declares capability, token, loader, execution, trust,
+   plugin, workspace mount, Semantic CLI, AI, registry, or agent authority.
+6. Kernel ABI expansion is required.
+
+## Evidence Requirements
+
+Future implementation evidence must prove:
+
+1. Same accepted input emits identical receipt digest.
+2. Changed input digest changes or denies the receipt.
+3. Missing validation denies the receipt.
+4. Authority-granting receipt fields deny the receipt.
+5. Denial receipts cannot be reused as success receipts.
+
+## Acceptance Boundary
+
+This RFC defines receipt semantics only. It does not implement receipt
+generation and does not grant runtime authority.

--- a/docs/specs/phase19-platform-runtime/WORKSPACE_ADMISSION_RUNTIME_SPECIFICATION.md
+++ b/docs/specs/phase19-platform-runtime/WORKSPACE_ADMISSION_RUNTIME_SPECIFICATION.md
@@ -1,0 +1,102 @@
+# Phase-19 Workspace Admission Runtime Specification
+
+This document is subordinate to `PHASE19_RUNTIME_DECISION.md`,
+`PLATFORM_VALIDATION_INTEGRATION_SPECIFICATION.md`, and
+`../phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`. In
+case of conflict, those documents prevail.
+
+**Status:** PRE-IMPLEMENTATION RFC / PHASE-19 NOT ACTIVE / RUNTIME NOT AUTHORIZED
+**Contract id:** `ayken.phase19.workspace_admission.runtime.v1`
+**Authority boundary:** Documentation/specification only; not workspace
+creation, real mount authority, filesystem implementation, package
+installation, module loading, plugin loading, capability issuance, trust
+assignment, Semantic CLI authority, AI Runtime authority, syscall, or kernel
+ABI expansion.
+
+## Purpose
+
+This RFC defines the workspace admission record boundary for the first
+possible Phase-19 Runtime MVP.
+
+The record may later show that a static input bundle passed enough validation
+to be admitted as a record. It does not create a workspace and does not mount
+anything.
+
+## Core Rule
+
+```text
+Workspace admission record != workspace creation
+```
+
+Admission is an evidence record. It is not a real workspace, mount namespace,
+filesystem handle, permission grant, or execution context.
+
+## Admission Inputs
+
+Admission may depend only on:
+
+1. Runtime input bundle digest.
+2. Platform validation integration result digest.
+3. Phase-18 workspace declaration reference.
+4. Requested logical workspace profile.
+5. Denial policy reference.
+
+No ambient filesystem state, user shell state, Semantic CLI output, AI output,
+or diagnostics surface may become admission authority.
+
+## Admission Record Fields
+
+Version 1 admission records require:
+
+| Field | Required | Meaning | Authority boundary |
+|---|---|---|---|
+| `schema_id` | yes | Must be `ayken.phase19.workspace_admission.runtime.v1` | Not runtime authority |
+| `admission_id` | yes | Stable record id | Not workspace id grant |
+| `subject` | yes | Bound subject from input bundle | Not execution target |
+| `input_bundle_digest` | yes | Bound input bundle digest | Not request replay authority |
+| `validation_result_digest` | yes | Bound validation result digest | Not capability |
+| `workspace_profile` | yes | Declarative logical profile | Not mount profile |
+| `admission_status` | yes | `admitted_record`, `denied`, or `blocked` | Not active workspace |
+| `denial_reason` | conditional | Required for denied or blocked records | Not remediation authority |
+
+Unknown fields fail closed.
+
+## Allowed Status Values
+
+| Status | Meaning | Boundary |
+|---|---|---|
+| `admitted_record` | Evidence record may be emitted | No workspace exists |
+| `denied` | Input is rejected | Terminal denial |
+| `blocked` | Prior validation or binding failed | Terminal denial |
+
+Unknown statuses fail closed.
+
+## Denial Conditions
+
+Admission must be denied if:
+
+1. Platform validation integration failed.
+2. Workspace declaration is missing or stale.
+3. Workspace declaration asks for real mount authority.
+4. Workspace declaration asks for capability issuance.
+5. Workspace declaration asks for trust assignment.
+6. Workspace declaration asks for package install or execution.
+7. Workspace declaration asks for plugin loading.
+8. Subject binding does not match the input bundle.
+9. Admission record would become a bearer token.
+10. Kernel ABI expansion is required.
+
+## Evidence Requirements
+
+Future implementation evidence must prove:
+
+1. Positive admission record emission for a valid static bundle.
+2. Denial when validation is missing.
+3. Denial when workspace declaration requests real mount.
+4. Denial when subject digest changes.
+5. Denial when authority-granting fields appear.
+
+## Acceptance Boundary
+
+This RFC does not create workspace runtime behavior. A later implementation
+must still prove that admission records are inert evidence outputs.


### PR DESCRIPTION
## Summary
- Add `docs/specs/phase19-platform-runtime/` as the Phase-19 pre-implementation Runtime MVP RFC set.
- Define lifecycle, static input bundle, Platform ABI validation integration, workspace admission record, runtime receipt, evidence plan, and non-goal/denial boundaries.
- Sync README, current status, roadmap, roadmap index, documentation index, Phase-18 spec README, and `PHASE19_RUNTIME_DECISION.md` references.

## Authority Boundary
This PR does not activate Phase-19, does not update `CURRENT_PHASE=19`, and does not authorize runtime implementation, parser implementation, package installation, module loading, workspace runtime, real mounts, plugin loading, capability issuance, trust assignment, Semantic CLI authority, AI Runtime authority, new syscalls, or kernel ABI expansion.

## Local Validation
- `make ci-gate-spec-purity`
- `make ci-gate-naming-compliance`
- `make ci-gate-governance`
- `make ci-gate-drift-activation`
- `make ci-gate-abi`
- `make ci-gate-constitutional`
- `python3 tools/ci/validate_phase17_closure_candidate.py --expected-subject-sha 416a5392afbe217e16d26a59e2e1716fdfa9c8f6`
- `git diff --cached --check`