### PR TITLE
docs: add phase19 runtime cross review

### DIFF
--- a/AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md
+++ b/AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md
@@ -18,6 +18,9 @@
 > the pre-implementation RFC set under
 > `docs/specs/phase19-platform-runtime/`, which do not activate Phase-19 or
 > authorize implementation.
+> The Phase-19 RFC set cross-review is recorded in
+> `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`; review
+> PASS is not activation or implementation authority.
 > Phase-18 is active only as Platform Constitution and does not authorize
 > runtime implementation.
 
@@ -31,7 +34,7 @@
 | Phase-17 kapanisi | `reports/phase17_official_closure_candidate/` official closure package ve verified tag mevcut | Closure authority exact-SHA subject ile sinirlidir; Phase-18'i aktive etmez |
 | Phase-17.5 | PR #142, PR #144, PR #148, PR #149/#151/#150, PR #152 ve closure decision package `main`e kabul edildi | Accepted subject SHA `416a5392` icin bounded evidence resmi closure'a baglandi |
 | Phase-18 | `PHASE18_TRANSITION_DECISION.md` + `PHASE18_ACTIVATION_DECISION.md` + `AUTHORITY_DRIFT_GUARD.md` + `TERMINOLOGY_AUDIT.md` | Platform Constitution active; runtime implementation yetkisi degildir |
-| Phase-19 | `PHASE19_RUNTIME_DECISION.md` + `docs/specs/phase19-platform-runtime/README.md` | Runtime MVP decision/RFC boundary only; `CURRENT_PHASE=19` veya implementation yetkisi yoktur |
+| Phase-19 | `PHASE19_RUNTIME_DECISION.md` + `docs/specs/phase19-platform-runtime/README.md` + `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` | Runtime MVP decision/RFC/review boundary only; `CURRENT_PHASE=19` veya implementation yetkisi yoktur |
 | Aktif execution roadmap | `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution reference set + Phase-19 pre-implementation RFC set | Phase-19 pointer transition ve ayri implementation karari olmadan runtime baslatilmaz; authority drift review guard ve terminology audit korunur |
 | Canonical performance baseline | `scripts/ci/perf-baseline.lock.json` | Accepted `main` SHA `416a5392`: standalone Performance Gate `26715068398` ve scoped Phase-17 acceptance `26712374737` PASS; closure tag dogrulandi |
 | Review enforcement | Issue #145 tek-maintainer ADR'i, `@kenanay` CODEOWNERS accountability metadata'si ve canli `main` `freeze` protection paritesi ile kapatildi | Bagimsiz self-review iddiasi yoktur; remote CI ve kayitli maintainer karari merge siniridir |

--- a/PHASE19_RUNTIME_DECISION.md
+++ b/PHASE19_RUNTIME_DECISION.md
@@ -122,6 +122,11 @@ The initial RFC set lives under
 `docs/specs/phase19-platform-runtime/`. The existence of that directory does
 not activate Phase-19 and does not authorize implementation.
 
+After the RFC set is accepted, a Phase-19 runtime cross-consistency review
+must be accepted before a pointer-transition discussion can use the RFC set as
+planning input. That review is still not activation and still not
+implementation authority.
+
 `MODULE_LOADING_MODEL.md`, `PLUGIN_INSTANTIATION_MODEL.md`, package
 execution, real workspace mounts, capability issuance, trust assignment,
 Semantic CLI authority, AI Runtime authority, and agent behavior are not part
@@ -175,6 +180,7 @@ are true:
 | P19-A8 | Exact-SHA CI passes | strict `ci-freeze` and Dev Loop pass on the candidate SHA |
 | P19-A9 | Implementation is separated | pointer transition does not include runtime source code |
 | P19-A10 | Evidence plan is accepted | runtime evidence paths, receipts, negative cases, and fail-closed behavior are defined |
+| P19-A11 | Runtime RFC cross-review is accepted | Phase-19 runtime RFC set has a reviewed cross-consistency record |
 
 Missing, stale, ambiguous, or partially satisfied preconditions fail closed.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **CURRENT_PHASE:** `18` (`Phase-18 ACTIVE: Platform Constitution`; runtime implementation yetkisi değildir)
 **Freeze Zinciri:** `make ci-freeze` = 40 kapılı strict suite (normative spec-purity dahil) | `make ci-freeze-local` = local performance authority
 **Authority Durumu:** Issue #145 tek-maintainer authority kararıyla giderildi; PR #142, PR #144, PR #148, PR #149, PR #151, PR #150, PR #152 ve Phase-17 closure decision package birleşti. Closure exact-SHA kanıtı `main` SHA `416a5392` üzerinde yenilendi, gerekli uzak acceptance kontrolleri PASS verdi ve `phase17-official-closure` tag'i aynı SHA'ya doğrulandı
-**Yakın Hedef:** Phase-18 Platform Constitution kapsamını korumak; mevcut somut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`, `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md`, `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`, `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`, `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`, `PHASE18_ACTIVATION_DECISION.md`, `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`, `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`, `PHASE19_RUNTIME_DECISION.md` ve `docs/specs/phase19-platform-runtime/README.md`; Phase-19 decision/RFC set `CURRENT_PHASE=19` veya runtime implementation yetkisi vermez
+**Yakın Hedef:** Phase-18 Platform Constitution kapsamını korumak; mevcut somut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`, `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md`, `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`, `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`, `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`, `PHASE18_ACTIVATION_DECISION.md`, `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`, `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`, `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md` ve `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`; Phase-19 decision/RFC/review set `CURRENT_PHASE=19` veya runtime implementation yetkisi vermez
 **Ring0 Export Ceiling:** `193 symbols` (current enforced ceiling)
 **Performance Baseline Candidate:** `gha-ubuntu24-20260518.149.1-X64` (authorized run `26370359958` artifact'i PR'a import edildi; SHA `f129d4aa` locked acceptance PASS verdi, ancak tek basina closure authority değildir)
 **Development Status:** Phase-16 OFFICIALLY CLOSED ✅ | Phase-17 OFFICIALLY CLOSED ✅ | SINGLE-MAINTAINER AUTHORITY ALIGNED (#145 RESOLVED) ✅ | PR #142/#144/#148/#149/#151/#150/#152 + closure decision package MERGED ✅ | EXACT-SHA REMOTE EVIDENCE PASS ✅ | Phase-18 PLATFORM CONSTITUTION ACTIVE ✅
@@ -41,7 +41,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **Phase 16 Status:** OFFICIALLY CLOSED ✅ | Verification Layer MVP COMPLETE | Evidence chain integrity verified | Trust anchor established | `make verify-system` → 3 gates → PASS | Constitutional rule enforcement active | Fail-closed behavior confirmed
 **Phase 17 Status:** OFFICIALLY CLOSED ✅ | tag `phase17-official-closure` at `416a5392` | full `ci-freeze` (`26712333892`), locked performance (`26715068398`, `26712374737`) ve Phase-17 QEMU evidence lanes (`26712374742`, `26712374736`, `26712374727`, `26712374744`, `26712374728`) PASS | `reports/phase17_official_closure_candidate/`
 **Phase 18 Status:** ACTIVE AS PLATFORM CONSTITUTION | Authority drift guard and terminology audit active | Runtime implementation, kernel expansion, new syscalls, Ring0 policy and AI authority remain forbidden unless a separate phase RFC and closure authority exists
-**Phase 19 Status:** DECISION PACKAGE + PRE-IMPLEMENTATION RFC SET ONLY | `PHASE19_RUNTIME_DECISION.md` and `docs/specs/phase19-platform-runtime/README.md` define Platform Runtime MVP boundaries; `CURRENT_PHASE=19` and runtime implementation are not authorized
+**Phase 19 Status:** DECISION PACKAGE + PRE-IMPLEMENTATION RFC SET + CROSS-REVIEW ONLY | `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, and `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` define and review Platform Runtime MVP boundaries; `CURRENT_PHASE=19` and runtime implementation are not authorized
 **Architecture Quick Map:** `docs/specs/phase12-trust-layer/AYKENOS_GATE_ARCHITECTURE.md`
 **Active Execution Roadmap:** `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution RFC set | accepted `main` SHA `416a5392` uzerinde bounded uzak evidence PASS; official closure tag doğrulandı; Phase-18 Platform Constitution pointer'i aktiftir
 **Canonical Technical Definition:** AykenOS is a deterministic verification architecture that separates kernel execution, verification semantics, evidence artifacts, and distributed diagnostics into explicit layers. The kernel provides mechanism, userspace verification services produce artifact-bound verdicts and receipts, and parity/topology surfaces expose cross-node observability without elevating diagnostics into authority or consensus.
@@ -69,7 +69,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 - **Evidence:** A, B, C karakterleri başarıyla syscall üzerinden basıldı
 - **Result:** Ring3 infrastructure PROVEN, syscall path WORKING, instruction retirement VALIDATED
 
-**Next Focus:** Phase-18 Platform Constitution kapsamını korumak ve `PHASE19_RUNTIME_DECISION.md` ile `docs/specs/phase19-platform-runtime/README.md` altinda tanimlanan Runtime MVP sinirini runtime koduna donusturmeden cross-review/pointer-transition hazirligina ayirmak. Phase-19 active pointer, implementation karari ve closure boundary ayri karar gerektirir.
+**Next Focus:** Phase-18 Platform Constitution kapsamını korumak ve `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md` ve `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` altinda tanimlanan Runtime MVP sinirini runtime koduna donusturmeden pointer-transition hazirligina ayirmak. Phase-19 active pointer, implementation karari ve closure boundary ayri karar gerektirir.
 
 ## Authority Model
 
@@ -324,6 +324,7 @@ Phase 12 trust layer kapsamında tamamlananlar:
 - **Phase-18 Terminology Audit:** `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`
 - **Phase-19 Runtime Decision Package:** `PHASE19_RUNTIME_DECISION.md`
 - **Phase-19 Runtime RFC Set:** `docs/specs/phase19-platform-runtime/README.md`
+- **Phase-19 Runtime Cross-Consistency Review:** `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`
 - **Documentation Index:** `docs/development/DOCUMENTATION_INDEX.md`
 - **Ring3 User-Leaf Rule:** `docs/governance/RING3_USER_LEAF_ALLOCATION_RULE.md`
 - **Ring3 Runtime Closure Note:** `docs/governance/RING3_RUNTIME_CLOSURE_NOTE.md`
@@ -366,6 +367,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 - Phase-18 terminology audit: `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`; high-risk vocabulary icin accepted audit kaydidir, runtime authority degildir.
 - Phase-19 runtime decision package: `PHASE19_RUNTIME_DECISION.md`; Platform Runtime MVP sinirini tanimlar, `CURRENT_PHASE=19` veya runtime implementation yetkisi vermez.
 - Phase-19 runtime RFC set: `docs/specs/phase19-platform-runtime/README.md`; lifecycle, input bundle, validation integration, workspace admission record, receipt, evidence plan ve denial sinirlarini tanimlar; implementation yetkisi vermez.
+- Phase-19 runtime cross-consistency review: `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`; RFC set PASS review kaydidir, `CURRENT_PHASE=19` veya implementation yetkisi vermez.
 - Phase-19 runtime MVP icin ayri implementation RFC/evidence plan/closure boundary hazirlanmadikca package installer, workspace runtime, plugin loader, capability issuer veya trust issuer yazilmaz.
 
 **Orta Vadeli:**
@@ -381,7 +383,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 
 ---
 
-**Son Güncelleme:** 05 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=18; Module Manifest, Capability Contract, Workspace Lifecycle, Package Metadata, Trust Classification, Plugin Boundary, Platform ABI Validation Gate, Cross-Consistency Review, `PHASE18_ACTIVATION_DECISION.md`, `AUTHORITY_DRIFT_GUARD.md` ve `TERMINOLOGY_AUDIT.md` Phase-18 Platform Constitution authority seti olarak aktiftir; `PHASE19_RUNTIME_DECISION.md` ve `docs/specs/phase19-platform-runtime/README.md` Runtime MVP karar/RFC sinirini tanimlar, ancak Phase-19 aktif degildir ve runtime implementation yetkisi yoktur.
+**Son Güncelleme:** 05 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=18; Module Manifest, Capability Contract, Workspace Lifecycle, Package Metadata, Trust Classification, Plugin Boundary, Platform ABI Validation Gate, Cross-Consistency Review, `PHASE18_ACTIVATION_DECISION.md`, `AUTHORITY_DRIFT_GUARD.md` ve `TERMINOLOGY_AUDIT.md` Phase-18 Platform Constitution authority seti olarak aktiftir; `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md` ve `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` Runtime MVP karar/RFC/review sinirini tanimlar, ancak Phase-19 aktif degildir ve runtime implementation yetkisi yoktur.
 **Düzenleyen / Geliştiren / Oluşturan / Mimari Sorumlu:** Kenan AY *(metadata only; runtime/karar yetkisi değildir).*
 
 **© 2026 Kenan AY — AykenOS Project**

--- a/docs/development/DOCUMENTATION_INDEX.md
+++ b/docs/development/DOCUMENTATION_INDEX.md
@@ -18,7 +18,7 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict
 - **Formal Governance Pointer:** `CURRENT_PHASE=18`
 - **Active Phase:** Phase-18 ACTIVE / Platform Constitution only
 - **Active Execution Priority:** Maintain Phase-18 Platform Constitution authority without runtime implementation
-- **Candidate Next Decision:** Phase-19 Runtime MVP decision/RFC set; not active phase or implementation authority
+- **Candidate Next Decision:** Phase-19 Runtime MVP decision/RFC/review set; not active phase or implementation authority
 - **Scope Boundary:** Phase-18 activation does not authorize runtime implementation; kernel expansion, new syscalls, Ring0 policy and AI Runtime authority remain forbidden for Phase-18
 
 ## Primary Truth Sources
@@ -48,14 +48,15 @@ Current repo truth icin once su dosyalari referans alin:
 22. `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md` — **accepted Phase-18 terminology audit; runtime not authorized**
 23. `PHASE19_RUNTIME_DECISION.md` — **Phase-19 Runtime MVP decision package; Phase-19 not active**
 24. `docs/specs/phase19-platform-runtime/README.md` — **Phase-19 Runtime MVP pre-implementation RFC set; runtime not authorized**
-25. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
-26. `reports/phase15_official_closure/closure_index.json`
-27. `reports/phase13_official_closure_candidate/closure_index.json`
-28. `reports/phase12_official_closure_candidate/closure_manifest.json`
-29. `reports/phase10_phase11_official_closure_index.json`
-30. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
-31. `Makefile`
-32. `.github/workflows/ci-freeze.yml`
+25. `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` — **Phase-19 Runtime RFC set cross-consistency review; runtime not authorized**
+26. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
+27. `reports/phase15_official_closure/closure_index.json`
+28. `reports/phase13_official_closure_candidate/closure_index.json`
+29. `reports/phase12_official_closure_candidate/closure_manifest.json`
+30. `reports/phase10_phase11_official_closure_index.json`
+31. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
+32. `Makefile`
+33. `.github/workflows/ci-freeze.yml`
 
 Phase-14 workstream numbering ve aktif durum yorumu icin canonical truth source:
 
@@ -102,13 +103,14 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 18. `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md` — accepted terminology audit
 19. `PHASE19_RUNTIME_DECISION.md` — Phase-19 Runtime MVP decision package; not active implementation authority
 20. `docs/specs/phase19-platform-runtime/README.md` — Phase-19 Runtime MVP pre-implementation RFC set; not active implementation authority
-21. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
-22. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
-23. `docs/specs/phase16-ayken-orchestration/README.md`
-24. `docs/specs/authority-lineage-v1/README.md`
-25. `docs/specs/phase14-distributed-observability/README.md`
-26. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
-27. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
+21. `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` — Phase-19 Runtime RFC set cross-consistency review; not active implementation authority
+22. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
+23. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
+24. `docs/specs/phase16-ayken-orchestration/README.md`
+25. `docs/specs/authority-lineage-v1/README.md`
+26. `docs/specs/phase14-distributed-observability/README.md`
+27. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
+28. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
 
 ## Phase-18 Reference Set
 1. `PHASE18_TRANSITION_DECISION.md`
@@ -138,6 +140,9 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 7. `docs/specs/phase19-platform-runtime/RUNTIME_RECEIPT_SPECIFICATION.md`
 8. `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_PLAN.md`
 9. `docs/specs/phase19-platform-runtime/RUNTIME_NON_GOALS_AND_DENIALS.md`
+10. `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` —
+    accepted cross-consistency review; does not activate Phase-19 and does
+    not authorize implementation.
 
 ## Phase-14 Reference Set
 ### Architecture and Observability Surfaces

--- a/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
+++ b/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
@@ -71,7 +71,9 @@ ancak Phase-19'i aktif etmez ve implementation yetkisi vermez. Ayri Phase-19
 pointer transition'i ve implementation karari olmadan asagidakiler aktif
 implementation backlog'u degildir. `docs/specs/phase19-platform-runtime/`
 pre-implementation RFC seti bu siniri detaylandirir; runtime code veya phase
-activation yetkisi vermez:
+activation yetkisi vermez. `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`
+bu RFC setini review eder; PASS sonucu yine activation veya implementation
+authority degildir:
 
 - Yeni syscall veya ABI surface genisletmesi.
 - ARM64/RISC-V/real-hardware feature genisletmesi.
@@ -97,7 +99,7 @@ Phase-18 Platform Constitution sinirini asamaz.
 | Review enforcement | `@kenanay` CODEOWNERS accountability metadata'si ve canli `main` required `freeze` protection'i tek-maintainer ADR'iyle hizalandi | Issue #145 RESOLVED; bagimsiz self-review iddiasi veya closure yetkisi kurulmaz |
 | Performance stability | PR-4 local readiness FAIL tarihsel kayit; PR-4A/PR-4B diagnostic; governed renewal ve workflow authority repair accepted | Accepted `main` SHA `416a5392`: Performance Gate `26715068398` ve scoped Phase-17 acceptance `26712374737` PASS; official tag dogrulandi |
 | Phase-18 | Active as Platform Constitution only | Runtime implementation, loader, installer, workspace runtime, plugin loading, capability issuance ve trust assignment yetkisi yoktur |
-| Phase-19 | Decision/RFC package only | `PHASE19_RUNTIME_DECISION.md` ve `docs/specs/phase19-platform-runtime/` Runtime MVP sinirini tanimlar; `CURRENT_PHASE=19` veya implementation authority degildir |
+| Phase-19 | Decision/RFC/review package only | `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/` ve Phase-19 cross-review Runtime MVP sinirini tanimlar/review eder; `CURRENT_PHASE=19` veya implementation authority degildir |
 
 ## 4. Stratejik Karar: Stabilization-First
 
@@ -382,7 +384,7 @@ donusemez:
 
 ### S6 - Phase-19 Runtime Decision and RFC Package
 
-**Status:** DECISION + PRE-IMPLEMENTATION RFC SET / PHASE-19 NOT ACTIVE / IMPLEMENTATION NOT AUTHORIZED
+**Status:** DECISION + PRE-IMPLEMENTATION RFC SET + CROSS-REVIEW / PHASE-19 NOT ACTIVE / IMPLEMENTATION NOT AUTHORIZED
 
 Phase-19 icin authority adayi `PHASE19_RUNTIME_DECISION.md` olarak
 kaydedilir. Bu belge Platform Runtime MVP'nin ne oldugunu ve ne olmadigini
@@ -397,6 +399,11 @@ integration, workspace admission record, runtime receipt, evidence plan ve
 non-goal/denial sinirlarini tanimlar; parser, loader, installer, workspace
 runtime, plugin host, issuer, trust assignment veya execution authority
 kurmaz.
+
+`docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, RFC setinin
+state, validation, admission, receipt, evidence ve denial sinirlarini capraz
+review eder. Bu review PASS sonucu Phase-19 pointer transition, runtime
+implementation veya closure authority kurmaz.
 
 Phase-19 karar siniri su kurallari korur:
 
@@ -413,8 +420,8 @@ Phase-19 karar siniri su kurallari korur:
 6. Kernel ABI `1000-1011` / 12 syscall / `0x00010001` olarak frozen kalir.
 7. Phase-20 registry/capability ecosystem, Phase-21 Semantic CLI, Phase-22 AI
    Runtime ve Phase-23+ agent sistemleri Phase-19 MVP'ye cekilemez.
-8. Phase-19 cross-review ve pointer transition ayridir; RFC seti tek basina
-   `CURRENT_PHASE=19` yapmaz.
+8. Phase-19 cross-review, pointer transition ve implementation karari
+   ayridir; review PASS tek basina `CURRENT_PHASE=19` yapmaz.
 
 ## 7. PR Sequence and Coordination Matrix
 
@@ -450,6 +457,7 @@ Phase-19 karar siniri su kurallari korur:
 | Phase-18 Terminology Audit | ACCEPTED AUDIT / DOCS-ONLY | High-risk Phase-18 vocabulary'nin safe meaning, required qualifier ve forbidden reading sinirlarini kaydetmek | `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md` | Audit PASS runtime implementation, loader, issuer, token, mount, execution veya Phase-19 authority grant degildir |
 | Phase-19 Runtime Decision Package | DECISION PACKAGE / PHASE-19 NOT ACTIVE | Platform Runtime MVP'nin decision boundary, non-goal, RFC precondition ve fail-closed denial kosullarini kaydetmek | `PHASE19_RUNTIME_DECISION.md` | Package `CURRENT_PHASE=19`, runtime implementation, loader, installer, workspace runtime, capability issuer, trust issuer, Semantic CLI authority veya AI Runtime authority grant degildir |
 | Phase-19 Runtime RFC Set | PRE-IMPLEMENTATION RFC SET / PHASE-19 NOT ACTIVE | Runtime lifecycle, input bundle, validation integration, workspace admission record, receipt, evidence plan ve denial sinirlarini docs-only tanimlamak | `docs/specs/phase19-platform-runtime/README.md` | RFC set parser, runtime implementation, loader, installer, workspace runtime, capability issuer, trust issuer, Semantic CLI authority, AI Runtime authority veya `CURRENT_PHASE=19` grant degildir |
+| Phase-19 Runtime Cross-Consistency Review | ACCEPTED REVIEW / PHASE-19 NOT ACTIVE | Runtime RFC setinin lifecycle, input bundle, validation integration, workspace admission, receipt, evidence ve denial sinirlarinin celismedigini kaydetmek | `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` | Review PASS `CURRENT_PHASE=19`, runtime implementation, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
 
 PR koordinasyon kurallari:
 
@@ -1142,7 +1150,8 @@ Bu roadmap su olaylarda guncellenir:
 29. Phase-18 Terminology Audit review/merge sonucu.
 30. Phase-19 Runtime Decision Package review/merge sonucu.
 31. Phase-19 Runtime RFC Set review/merge sonucu.
-32. Yeni feature/ABI/authority surface onerisinin incelenmesi.
+32. Phase-19 Runtime Cross-Consistency Review sonucu.
+33. Yeni feature/ABI/authority surface onerisinin incelenmesi.
 
 ## References
 
@@ -1182,6 +1191,7 @@ Bu roadmap su olaylarda guncellenir:
 - `docs/specs/phase19-platform-runtime/RUNTIME_RECEIPT_SPECIFICATION.md`
 - `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_PLAN.md`
 - `docs/specs/phase19-platform-runtime/RUNTIME_NON_GOALS_AND_DENIALS.md`
+- `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`
 - `PHASE18_ROADMAP.md`
 - `shared/abi/syscall_v2.h`
 - `shared/abi/ayken_abi.h`

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -2,7 +2,7 @@
 This document is subordinate to `ARCHITECTURE_FREEZE.md`. In case of conflict,
 the freeze contract prevails.
 
-**Last authority sync:** 2026-06-05 (Phase-19 Runtime RFC Set)
+**Last authority sync:** 2026-06-05 (Phase-19 Runtime Cross-Consistency Review)
 **Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu:** Kenan AY
 **Attribution boundary:** Documentation metadata only; not runtime or merge authority.
 
@@ -58,7 +58,10 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
    degildir.
 19. `../specs/phase19-platform-runtime/README.md`: Phase-19 Runtime MVP
    pre-implementation RFC set; runtime implementation authority degildir.
-20. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
+20. `../specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`:
+   Phase-19 Runtime RFC set capraz tutarlilik review kaydi; phase pointer
+   transition veya runtime implementation yetkisi degildir.
+21. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
    planlamasi; aktif Phase-18 otoritesi degildir.
 
 ## Current Status
@@ -68,7 +71,7 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 | Son resmi kapanis | Phase-17 OFFICIALLY CLOSED (`phase17-official-closure` at `416a5392`) |
 | Aktif faz | Phase-18 ACTIVE / Platform Constitution only |
 | Aktif odak | Phase-18 Platform Constitution authority maintenance; runtime implementation remains out of scope |
-| Aday sonraki karar | Phase-19 Platform Runtime MVP decision/RFC set; `CURRENT_PHASE=19` veya implementation authority degildir |
+| Aday sonraki karar | Phase-19 Platform Runtime MVP decision/RFC/review set; `CURRENT_PHASE=19` veya implementation authority degildir |
 | ABI | Canonical `1000-1011` / 12 syscall, ABI version `0x00010001` |
 | Phase-18 | ACTIVE AS PLATFORM CONSTITUTION; kernel expansion, runtime implementation and new syscalls forbidden unless a separate phase RFC/closure authority exists |
 
@@ -99,9 +102,10 @@ current execution priority otoritesi degildir:
 
 ---
 
-**Next action:** `PHASE19_RUNTIME_DECISION.md` ve
-`../specs/phase19-platform-runtime/README.md` Phase-19 Runtime MVP sinirini
-belgeler; `CURRENT_PHASE=19` veya runtime implementation yetkisi vermez.
-Siradaki is ancak ayri Phase-19 cross-review, pointer transition ve
-implementation karari olabilir. High-risk vocabulary `TERMINOLOGY_AUDIT.md`
-kaydina gore denetlenir.
+**Next action:** `PHASE19_RUNTIME_DECISION.md`,
+`../specs/phase19-platform-runtime/README.md` ve
+`../specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` Phase-19
+Runtime MVP sinirini belgeler ve review eder; `CURRENT_PHASE=19` veya runtime
+implementation yetkisi vermez. Siradaki is ancak ayri Phase-19 pointer
+transition ve implementation karari olabilir. High-risk vocabulary
+`TERMINOLOGY_AUDIT.md` kaydina gore denetlenir.

--- a/docs/specs/phase18-platform-constitution/README.md
+++ b/docs/specs/phase18-platform-constitution/README.md
@@ -68,6 +68,10 @@ does not authorize runtime implementation.
 Phase-19 Runtime RFC set. It is also outside the Phase-18 Constitution spec set
 and does not authorize runtime implementation.
 
+`../phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` may review that RFC
+set for cross-document coherence. It is outside the Phase-18 Constitution spec
+set and does not authorize Phase-19 activation or runtime implementation.
+
 ## Activation Boundary
 
 `../../../PHASE18_ACTIVATION_DECISION.md` is the accepted activation decision

--- a/docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md
+++ b/docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md
@@ -1,0 +1,271 @@
+# Phase-19 Platform Runtime Cross-Consistency Review
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, `PHASE18_TRANSITION_DECISION.md`,
+`PHASE18_ACTIVATION_DECISION.md`, the Phase-18 Platform Constitution
+reference set, `AUTHORITY_DRIFT_GUARD.md`, `TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, and the Phase-19 Runtime RFC set. In case of
+conflict, those documents prevail.
+
+**Status:** ACCEPTED REVIEW / PHASE-19 NOT ACTIVE / RUNTIME NOT AUTHORIZED
+**Review date:** 2026-06-05
+**Review id:** `ayken.phase19.runtime.cross_consistency.review.v1`
+**Authority boundary:** Documentation/review record only; not
+`CURRENT_PHASE=19`, not runtime implementation, not a parser, not a package
+installer, not a module loader, not workspace runtime, not real mount
+authority, not plugin loading, not capability issuance, not trust assignment,
+not Semantic CLI authority, not AI Runtime authority, not a syscall, not
+kernel ABI expansion, not merge authority, and not closure authority.
+
+## Purpose
+
+This review answers the pre-activation planning question:
+
+Do the Phase-19 Platform Runtime RFCs define a coherent deterministic
+admission/receipt MVP boundary without contradicting the active Phase-18
+Platform Constitution or widening the frozen kernel execution substrate?
+
+This document does not activate Phase-19. It records cross-document
+consistency findings that may be used by a later pointer-transition or
+implementation decision package.
+
+## Reviewed Inputs
+
+The reviewed Phase-19 planning set is:
+
+1. `PHASE19_RUNTIME_DECISION.md`
+2. `docs/specs/phase19-platform-runtime/README.md`
+3. `docs/specs/phase19-platform-runtime/RUNTIME_LIFECYCLE_SPECIFICATION.md`
+4. `docs/specs/phase19-platform-runtime/RUNTIME_INPUT_BUNDLE_SPECIFICATION.md`
+5. `docs/specs/phase19-platform-runtime/PLATFORM_VALIDATION_INTEGRATION_SPECIFICATION.md`
+6. `docs/specs/phase19-platform-runtime/WORKSPACE_ADMISSION_RUNTIME_SPECIFICATION.md`
+7. `docs/specs/phase19-platform-runtime/RUNTIME_RECEIPT_SPECIFICATION.md`
+8. `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_PLAN.md`
+9. `docs/specs/phase19-platform-runtime/RUNTIME_NON_GOALS_AND_DENIALS.md`
+
+## Review Verdict
+
+**Verdict:** PASS
+
+No pointer-transition-blocking contradiction is identified across the reviewed
+RFC set. The documents consistently preserve `CURRENT_PHASE=18`, keep
+Phase-19 as planning only, and constrain the future MVP to an inert
+userspace admission/receipt pipeline.
+
+This PASS is a review finding only. It does not authorize implementation and
+does not make Phase-19 active.
+
+## Core Consistency Finding
+
+The reviewed set consistently preserves these rules:
+
+```text
+runtime decision != runtime implementation
+runtime RFC set != runtime implementation
+lifecycle state != runtime authority
+input bundle != execution request
+validation integration != authority grant
+workspace admission record != workspace creation
+receipt != token
+evidence plan != evidence PASS
+MVP boundary denial is mandatory
+```
+
+The rules are repeated across the RFCs in compatible language and are
+consistent with the Phase-18 Platform Constitution terminology audit.
+
+## Kernel And Phase Boundary Review
+
+| Check | Finding | Result |
+|---|---|---|
+| Current phase pointer | Reviewed files preserve `CURRENT_PHASE=18` until a separate exact-SHA pointer transition exists | PASS |
+| Frozen syscall surface | Reviewed files preserve `1000-1011` / 12 syscall / ABI version `0x00010001` | PASS |
+| Kernel expansion | No reviewed RFC authorizes a new syscall, Ring0 policy, kernel loader, or kernel ABI expansion | PASS |
+| Runtime authority | No reviewed RFC authorizes runtime source code, package installation, module loading, workspace runtime, plugin loading, capability issuance, trust assignment, Semantic CLI authority, AI Runtime authority, registry, or agents | PASS |
+| Phase-18 boundary | Reviewed files consume Phase-18 Platform Constitution outputs as declarative inputs only | PASS |
+| Later phases | Phase-20 registry/capability ecosystem, Phase-21 Semantic CLI, Phase-22 AI Runtime, and Phase-23+ agent systems remain outside Phase-19 | PASS |
+
+## Runtime Chain Review
+
+The reviewed RFCs consistently define the only allowed future MVP shape as:
+
+```text
+static input bundle
+  -> Phase-18 Platform ABI validation integration
+  -> workspace admission record
+  -> deterministic runtime receipt
+```
+
+This chain is internally coherent:
+
+1. `RUNTIME_INPUT_BUNDLE_SPECIFICATION.md` defines digest-bound static input.
+2. `PLATFORM_VALIDATION_INTEGRATION_SPECIFICATION.md` binds Phase-18
+   validation receipt evidence to the same input subject.
+3. `WORKSPACE_ADMISSION_RUNTIME_SPECIFICATION.md` emits an inert admission
+   record only after validation integration succeeds.
+4. `RUNTIME_RECEIPT_SPECIFICATION.md` binds lifecycle, input, validation, and
+   admission digests into an evidence receipt.
+5. `RUNTIME_LIFECYCLE_SPECIFICATION.md` orders these states without using
+   `RUNNING`, `LOADED`, `ACTIVE`, `EXECUTING`, or `MOUNTED`.
+6. `RUNTIME_EVIDENCE_PLAN.md` requires positive, negative, deterministic, and
+   remote evidence for any later implementation.
+7. `RUNTIME_NON_GOALS_AND_DENIALS.md` rejects any expansion beyond this
+   bounded chain.
+
+**Result:** PASS
+
+## Contract Boundary Matrix
+
+| Contract | Positive scope | Explicit non-authority boundary | Review result |
+|---|---|---|---|
+| Runtime Decision | Defines the safe Platform Runtime MVP planning boundary | Does not activate Phase-19 or authorize implementation | PASS |
+| Runtime RFC Set README | Indexes lifecycle, input, validation, admission, receipt, evidence, and denial RFCs | Does not grant runtime source code or `CURRENT_PHASE=19` | PASS |
+| Runtime Lifecycle | Defines deterministic admission/receipt states and transitions | Lifecycle states do not install, load, mount, execute, issue, trust, or grant authority | PASS |
+| Runtime Input Bundle | Defines static digest-bound input references | Bundle is not a parser, installer, loader, execution request, token request, or workspace creation request | PASS |
+| Platform Validation Integration | Defines how validation receipt evidence may be bound to the input bundle | Validation PASS remains evidence only and grants no runtime authority | PASS |
+| Workspace Admission Runtime | Defines an inert workspace admission record | Admission record does not create a workspace, mount, handle, context, or permission | PASS |
+| Runtime Receipt | Defines deterministic digest-bound receipt output | Receipt is not a bearer token, capability token, handle, workspace handle, plugin binding, or execution right | PASS |
+| Runtime Evidence Plan | Defines future proof surfaces and negative cases | Evidence plan is not a CI gate implementation or evidence PASS | PASS |
+| Runtime Non-Goals And Denials | Defines mandatory denial boundaries | Denial list grants no runtime behavior and blocks later-phase work from entering Phase-19 | PASS |
+
+## Lifecycle And Record Dependency Review
+
+The reviewed set defines this dependency direction:
+
+```text
+Phase-17 closure verified
+  -> Phase-18 Platform Constitution active
+  -> Phase-19 runtime decision boundary
+  -> static input bundle binding
+  -> Phase-18 validation integration
+  -> workspace admission record
+  -> deterministic runtime receipt
+  -> evidence output
+```
+
+No reviewed document reverses this dependency into runtime authority.
+
+The positive lifecycle order is compatible with the record dependency order:
+
+```text
+UNINITIALIZED
+  -> INPUT_BOUND
+  -> VALIDATING
+  -> VALIDATED_RECORDABLE
+  -> ADMISSION_RECORDED
+  -> RECEIPT_EMITTED
+```
+
+Terminal denial states are consistently inert:
+
+1. `VALIDATION_REJECTED`
+2. `ABORTED`
+3. `denied`
+4. `blocked`
+5. `aborted`
+
+**Result:** PASS
+
+## Vocabulary Review
+
+The following terms are high-risk because they can be misread as authority.
+The reviewed RFCs keep each term bounded as evidence, record, or planning
+language.
+
+| Term | Safe Phase-19 meaning | Forbidden interpretation | Result |
+|---|---|---|---|
+| `runtime` | Future userspace admission/receipt MVP boundary | Full platform executor, loader, scheduler, or authority source | PASS |
+| `admission` | Evidence record after validation binding | Workspace creation, real mount, permission grant, or execution context | PASS |
+| `receipt` | Digest-bound evidence output | Token, bearer credential, handle, capability, or execution right | PASS |
+| `validated` | Bound Phase-18 validation evidence exists | Install, load, execute, trust, capability, workspace, plugin, Semantic CLI, or AI authority | PASS |
+| `binding` | Digest/reference relation | Runtime link, loader binding, token binding, or active mount | PASS |
+| `workspace` | Declarative admission subject | Filesystem namespace, mount, workspace runtime, or access grant | PASS |
+| `loader` | Explicitly denied in Phase-19 MVP | Module loading, plugin loading, or autoload | PASS |
+| `trusted` | Phase-18 classification input only | Capability grant, execution permission, workspace access, or issuer authority | PASS |
+| `evidence` | Output-only proof artifact | Runtime control input or scheduler/policy input | PASS |
+
+## Cross-RFC Denial Review
+
+The reviewed RFCs consistently require fail-closed rejection for these leaks:
+
+| Leak | Required result | Review result |
+|---|---|---|
+| Decision package used to update `CURRENT_PHASE` directly | Reject | PASS |
+| RFC set used as implementation authority | Reject | PASS |
+| Manifest schema treated as active parser | Reject | PASS |
+| Input bundle treated as execution request | Reject | PASS |
+| Package metadata treated as install or execute authority | Reject | PASS |
+| Platform validation PASS treated as runtime authority | Deny | PASS |
+| Workspace admission treated as real mount | Deny | PASS |
+| Admission record treated as workspace handle | Deny | PASS |
+| Receipt treated as bearer token | Deny | PASS |
+| Trust classification treated as capability grant | Deny | PASS |
+| Plugin compatibility treated as loading | Deny | PASS |
+| Semantic CLI output treated as runtime authority | Deny | PASS |
+| AI output treated as runtime authority | Deny | PASS |
+| Evidence output used as control input | Deny | PASS |
+| New syscall or kernel ABI expansion requested | Reject | PASS |
+| Later-phase registry, Semantic CLI, AI Runtime, or agents pulled into Phase-19 | Reject | PASS |
+
+## Evidence Plan Review
+
+`RUNTIME_EVIDENCE_PLAN.md` is consistent with the RFC set because it requires
+future evidence for both the positive inert pipeline and negative authority
+drift cases before any implementation can be considered.
+
+The evidence plan correctly preserves:
+
+1. Exact-SHA local and remote evidence requirement.
+2. Strict `ci-freeze` and Dev Loop requirement on a candidate SHA.
+3. Kernel ABI gate preservation.
+4. Deterministic repeat for lifecycle, admission, and receipt digests.
+5. Negative cases for trust-to-capability, plugin-to-loading, Semantic CLI,
+   AI, receipt-to-token, and kernel ABI drift.
+6. Performance measurement only if runtime hot paths are touched.
+
+**Result:** PASS
+
+## Non-Blocking Wording Risks
+
+The following terms remain acceptable, but future pointer-transition or
+implementation documents must keep them qualified:
+
+1. `runtime` can sound like a full executor. Current RFC text limits it to an
+   admission/receipt MVP boundary.
+2. `admitted` can sound like workspace creation. Current RFC text limits it
+   to an inert record.
+3. `receipt` can sound like a token. Current RFC text states that it is not a
+   bearer credential or handle.
+4. `validated` can sound like authorization. Current RFC text states that
+   validation PASS is not authority.
+5. `binding` can sound like loader behavior. Current RFC text limits binding
+   to digest/reference relationships.
+
+These are not contradictions. They are ongoing Phase-19 vocabulary risks.
+
+## Pointer-Transition Preconditions Checked
+
+This review finds that the Phase-19 RFC set satisfies the documentation
+cross-consistency precondition for a later pointer-transition discussion.
+
+That finding is not enough to transition phases. A future pointer-transition
+candidate still needs:
+
+1. Separate exact-SHA `CURRENT_PHASE=19` decision package.
+2. No runtime source code bundled with the pointer transition.
+3. Strict `ci-freeze` PASS on the candidate SHA.
+4. Dev Loop PASS on the candidate SHA.
+5. Kernel ABI still frozen at `1000-1011` / 12 syscall / `0x00010001`.
+6. Phase-18 authority drift guard and terminology audit still effective.
+7. Explicit confirmation that implementation remains separate.
+
+## Review Conclusion
+
+The Phase-19 Runtime RFC set is internally coherent enough to serve as the
+pre-implementation planning reference for a later pointer-transition
+decision.
+
+The safe next step after this review is still not runtime implementation.
+Phase-19 remains inactive until a separate pointer transition is reviewed and
+accepted, and runtime code remains unauthorized until a later implementation
+decision and evidence package exists.

--- a/docs/specs/phase19-platform-runtime/README.md
+++ b/docs/specs/phase19-platform-runtime/README.md
@@ -43,6 +43,13 @@ expansion.
 7. `RUNTIME_NON_GOALS_AND_DENIALS.md` - explicit denial list for installer,
    loader, issuer, trust, Semantic CLI, AI Runtime, registry, and agent drift.
 
+## Current Review Record
+
+`CROSS_CONSISTENCY_REVIEW.md` records the accepted cross-document review for
+the Phase-19 Runtime RFC set. The review PASS is documentation evidence only.
+It does not activate Phase-19, update `CURRENT_PHASE`, or authorize runtime
+implementation.
+
 ## Core Rule
 
 ```text


### PR DESCRIPTION
## Summary
- add Phase-19 Runtime RFC Set cross-consistency review
- record PASS as review-only: no CURRENT_PHASE=19, no runtime implementation authority
- sync roadmap, README, status report, and documentation index references

## Authority Boundary
- docs-only review package
- no syscall or ABI change
- no parser, loader, installer, workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI authority, or AI Runtime authority

## Local Validation
- git diff --check
- new cross-review ASCII scan
- branch/name leakage scan
- make ci-gate-spec-purity
- make ci-gate-naming-compliance
- make ci-gate-governance
- make ci-gate-drift-activation
- make ci-gate-abi
- make ci-gate-constitutional
- python3 tools/ci/validate_phase17_closure_candidate.py --expected-subject-sha 416a5392afbe217e16d26a59e2e1716fdfa9c8f6