### PR TITLE
docs: transition CURRENT_PHASE to 19

### DIFF
--- a/AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md
+++ b/AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md
@@ -2,7 +2,7 @@
 
 **Durum tarihi:** 2026-05-23
 **Uygulama ek kaydi:** 2026-05-24/26 (Phase-17 S1.E2E, PR-2B fixture worker completion, PR-3 IRQ timeout-race, PR-4 local performance readiness, PR-4A/PR-4B variance isolation, full-freeze timer witness integration repair, validation flag matrix, issue #145 tek-maintainer authority giderimi, PR #142/#144 merge, PR #148 performance authority onarimi, accepted-main exact-SHA remote evidence PASS ve Phase-17 closure-candidate kaydi)
-**Authority sync:** 2026-06-05 (`CURRENT_PHASE=18`; Phase-18 active as Platform Constitution only)
+**Authority sync:** 2026-06-06 (`CURRENT_PHASE=19`; Phase-19 active as Platform Runtime MVP planning/admission/receipt boundary only)
 **Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu:** Kenan AY
 **Dijital imza siniri:** Bu atif yalnizca insan-okunur dokumantasyon ve metadata icindir; runtime log, karar veya yetki kaynagi degildir.
 
@@ -15,8 +15,7 @@
 > High-risk wording is audited in
 > `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`.
 > Phase-19 runtime planning is bounded by `PHASE19_RUNTIME_DECISION.md` and
-> the pre-implementation RFC set under
-> `docs/specs/phase19-platform-runtime/`, which do not activate Phase-19 or
+> the RFC set under `docs/specs/phase19-platform-runtime/`, which do not
 > authorize implementation.
 > The Phase-19 RFC set cross-review is recorded in
 > `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`; review
@@ -27,21 +26,24 @@
 > `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` reviews activation
 > preconditions; it is not activation, pointer transition, or implementation
 > authority.
-> Phase-18 is active only as Platform Constitution and does not authorize
-> runtime implementation.
+> `PHASE19_POINTER_TRANSITION_DECISION.md` records the exact phase pointer
+> transition to `CURRENT_PHASE=19`; it activates only Runtime MVP planning,
+> validation-integration, admission-record and receipt-boundary authority.
+> Phase-18 remains the accepted Platform Constitution reference set.
+> Runtime implementation remains unauthorized.
 
 ## Yetkili Durum
 
 | Konu | Repo gercegi | Sonuc |
 |---|---|---|
 | Son resmi kapanis | `phase17-official-closure` etiketi `416a5392` uzerinde dogrulandi | Phase-17 OFFICIALLY CLOSED |
-| Aktif faz | `CURRENT_PHASE=18` | Phase-18 ACTIVE / Platform Constitution only |
+| Aktif faz | `CURRENT_PHASE=19` | Phase-19 ACTIVE / Platform Runtime MVP planning, admission and receipt boundary only |
 | Step 5 | PR #134, merge `71d10691` | Marker-validation dilimi mainline'a birlesti |
 | Phase-17 kapanisi | `reports/phase17_official_closure_candidate/` official closure package ve verified tag mevcut | Closure authority exact-SHA subject ile sinirlidir; Phase-18'i aktive etmez |
 | Phase-17.5 | PR #142, PR #144, PR #148, PR #149/#151/#150, PR #152 ve closure decision package `main`e kabul edildi | Accepted subject SHA `416a5392` icin bounded evidence resmi closure'a baglandi |
-| Phase-18 | `PHASE18_TRANSITION_DECISION.md` + `PHASE18_ACTIVATION_DECISION.md` + `AUTHORITY_DRIFT_GUARD.md` + `TERMINOLOGY_AUDIT.md` | Platform Constitution active; runtime implementation yetkisi degildir |
-| Phase-19 | `PHASE19_RUNTIME_DECISION.md` + `docs/specs/phase19-platform-runtime/README.md` + `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` + `PHASE19_POINTER_TRANSITION_CANDIDATE.md` + `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` | Runtime MVP decision/RFC/review/candidate/precondition boundary only; `CURRENT_PHASE=19` veya implementation yetkisi yoktur |
-| Aktif execution roadmap | `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution reference set + Phase-19 pre-implementation RFC set | Phase-19 pointer transition ve ayri implementation karari olmadan runtime baslatilmaz; authority drift review guard ve terminology audit korunur |
+| Phase-18 | `PHASE18_TRANSITION_DECISION.md` + `PHASE18_ACTIVATION_DECISION.md` + `AUTHORITY_DRIFT_GUARD.md` + `TERMINOLOGY_AUDIT.md` | Accepted Platform Constitution reference set; runtime implementation yetkisi degildir |
+| Phase-19 | `PHASE19_RUNTIME_DECISION.md` + `docs/specs/phase19-platform-runtime/README.md` + `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` + `PHASE19_POINTER_TRANSITION_CANDIDATE.md` + `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` + `PHASE19_POINTER_TRANSITION_DECISION.md` | Runtime MVP planning/admission/receipt boundary active; implementation yetkisi yoktur |
+| Aktif execution roadmap | `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution reference set + Phase-19 Runtime MVP planning boundary | Ayri implementation karari olmadan runtime baslatilmaz; authority drift review guard ve terminology audit korunur |
 | Canonical performance baseline | `scripts/ci/perf-baseline.lock.json` | Accepted `main` SHA `416a5392`: standalone Performance Gate `26715068398` ve scoped Phase-17 acceptance `26712374737` PASS; closure tag dogrulandi |
 | Review enforcement | Issue #145 tek-maintainer ADR'i, `@kenanay` CODEOWNERS accountability metadata'si ve canli `main` `freeze` protection paritesi ile kapatildi | Bagimsiz self-review iddiasi yoktur; remote CI ve kayitli maintainer karari merge siniridir |
 
@@ -233,9 +235,17 @@ baseline kabul otoritesi de clean-tree PR CI incelemesidir.
 
 ## Oncelik Sirasi
 
-**En oncelikli adim:** PR #142/#144/#148 kabul edilmis ve `main` SHA `e0286c7b` icin bounded exact-SHA uzak evidence PASS uretilmistir. Siradaki authority adimi, `reports/phase17_official_closure_candidate/` kaydinin reviewed kabulü ve ancak bundan sonra resmi closure karar/tag degerlendirmesidir. Yeni ozellik veya Phase-18 aktivasyonu closure otoritesi kurulmadan baslatilmamalidir.
+**En oncelikli adim:** `CURRENT_PHASE=19` pointer transition sonrasi
+Platform Runtime MVP planning/admission/receipt sinirini korumak ve runtime
+implementation'i ayri karar/evidence paketine kadar kapali tutmaktir.
+Runtime source code, loader, installer, workspace runtime, plugin host,
+capability issuer, trust issuer, Semantic CLI authority ve AI Runtime
+authority bu pointer ile baslatilmaz.
 
-**Aktif plan:** `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` - #145 authority parity giderildi; PR #142/#144/#148 merged; accepted-main exact-SHA remote evidence PASS; closure-candidate review ve resmi closure/tag authority pending.
+**Aktif plan:** `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`
+- Phase-17 official closure dogrulandi; Phase-18 Platform Constitution
+reference set olarak korunur; Phase-19 pointer transition yalnız
+planning/admission/receipt boundary kurar; implementation authority pending.
 
 ---
 

--- a/PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md
+++ b/PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md
@@ -5,20 +5,21 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
 `PHASE18_ACTIVATION_DECISION.md`, the Phase-18 Platform Constitution
 reference set, `AUTHORITY_DRIFT_GUARD.md`, `TERMINOLOGY_AUDIT.md`,
 `PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
-`docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, and
-`PHASE19_POINTER_TRANSITION_CANDIDATE.md`. In case of conflict, those
+`docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`,
+`PHASE19_POINTER_TRANSITION_CANDIDATE.md`, and
+`PHASE19_POINTER_TRANSITION_DECISION.md`. In case of conflict, those
 documents prevail.
 
-**Status:** PRECONDITION REVIEW / PHASE-19 NOT ACTIVE / POINTER NOT EXECUTED / IMPLEMENTATION NOT AUTHORIZED
+**Status:** ACCEPTED PRECONDITION REVIEW / SUPERSEDED BY POINTER TRANSITION DECISION / IMPLEMENTATION NOT AUTHORIZED
 **Review date:** 2026-06-05
 **Review id:** `ayken.phase19.activation_preconditions.review.v1`
 **Authority boundary:** Documentation review only; not
-`PHASE19_ACTIVATION_DECISION.md`, not `CURRENT_PHASE=19`, not a phase pointer
-transition, not runtime implementation, not a parser, not a package installer,
-not a module loader, not workspace runtime, not real mount authority, not
-plugin loading, not capability issuance, not trust assignment, not Semantic
-CLI authority, not AI Runtime authority, not a syscall, not kernel ABI
-expansion, not merge authority, and not closure authority.
+`PHASE19_ACTIVATION_DECISION.md`, not runtime implementation, not a parser,
+not a package installer, not a module loader, not workspace runtime, not real
+mount authority, not plugin loading, not capability issuance, not trust
+assignment, not Semantic CLI authority, not AI Runtime authority, not a
+syscall, not kernel ABI expansion, not merge authority, and not closure
+authority.
 
 ## Purpose
 
@@ -29,12 +30,13 @@ Are the documented preconditions for a later Phase-19 pointer transition
 complete enough to be reviewed without starting implementation?
 ```
 
-The answer is a documentation review finding only. This file does not update
-`docs/roadmap/CURRENT_PHASE`; the current pointer remains `CURRENT_PHASE=18`.
+The answer is a documentation review finding only. This file did not update
+`docs/roadmap/CURRENT_PHASE`; the later pointer transition is recorded in
+`PHASE19_POINTER_TRANSITION_DECISION.md`.
 
 This file is intentionally not named `PHASE19_ACTIVATION_DECISION.md`. A
-future activation or pointer transition must be a separate exact-SHA PR that
-changes the phase pointer and records fresh remote evidence on that subject.
+separate exact-SHA pointer transition changes the phase pointer and must
+record fresh remote evidence on that subject.
 
 ## Core Rule
 
@@ -45,7 +47,7 @@ runtime RFC set != runtime implementation
 runtime artifact != behavior source
 ```
 
-The safe default remains no Phase-19 activation.
+The safe default remains no runtime implementation.
 
 ## Reviewed Inputs
 
@@ -69,33 +71,32 @@ The reviewed precondition set is:
 
 **Verdict:** PASS FOR PRECONDITION DOCUMENTATION
 
-The reviewed set is sufficient to define the preconditions for a later
-Phase-19 pointer transition discussion. No reviewed input activates Phase-19,
-updates `CURRENT_PHASE`, or authorizes runtime implementation.
+The reviewed set is sufficient to define the preconditions for the Phase-19
+pointer transition discussion. No reviewed input by itself activated Phase-19,
+updated `CURRENT_PHASE`, or authorized runtime implementation.
 
-This PASS is not activation. Actual Phase-19 activation remains blocked until
-a later exact-SHA pointer transition PR updates `docs/roadmap/CURRENT_PHASE`
-and passes the required remote authority checks.
+This PASS is not runtime implementation authority. The exact-SHA pointer
+transition is separate and must pass the required remote authority checks.
 
 ## Current Pointer Confirmation
 
 | Check | Finding | Result |
 |---|---|---|
-| Current phase value | `docs/roadmap/CURRENT_PHASE` remains `CURRENT_PHASE=18` | PASS |
-| Phase-19 active status | Phase-19 remains not active | PASS |
+| Current phase value | `docs/roadmap/CURRENT_PHASE` remained `CURRENT_PHASE=18` during this review | PASS |
+| Phase-19 active status | Phase-19 remained not active during this review | PASS |
 | Pointer update in this review | No pointer update is present | PASS |
 | Runtime code in this review | No runtime implementation is present | PASS |
 | Kernel ABI status | `1000-1011` / 12 syscall / `0x00010001` remains the frozen boundary | PASS |
 
-## Preconditions For A Later Pointer Transition
+## Preconditions For Pointer Transition
 
-A future `CURRENT_PHASE=19` pointer transition PR must fail closed unless all
-of the following are true on that future exact subject SHA:
+A `CURRENT_PHASE=19` pointer transition PR must fail closed unless all of the
+following are true on that exact subject SHA:
 
 | ID | Precondition | Required result |
 |---|---|---|
 | P19-R1 | Phase-17 official closure remains verified | `phase17-official-closure` resolves to `416a5392afbe217e16d26a59e2e1716fdfa9c8f6` |
-| P19-R2 | Phase-18 remains Platform Constitution only before transition | `CURRENT_PHASE=18` remains true before the future pointer PR changes it |
+| P19-R2 | Phase-18 remains Platform Constitution only before transition | `CURRENT_PHASE=18` remains true before the pointer PR changes it |
 | P19-R3 | Authority Drift Guard remains active | Runtime, loader, issuer, workspace, plugin, trust, capability, Semantic CLI, AI, and agent authority drift is rejected |
 | P19-R4 | Terminology Audit remains active | High-risk vocabulary remains non-authoritative |
 | P19-R5 | Runtime Decision Package is accepted | `PHASE19_RUNTIME_DECISION.md` remains decision boundary only |
@@ -104,9 +105,9 @@ of the following are true on that future exact subject SHA:
 | P19-R8 | Pointer Transition Candidate is accepted | Candidate remains a pre-transition record only |
 | P19-R9 | This Preconditions Review is accepted | Preconditions are reviewed before any pointer update |
 | P19-R10 | Kernel ABI remains frozen | Syscall IDs remain `1000-1011`, count remains `12`, ABI version remains `0x00010001` |
-| P19-R11 | Future pointer PR is docs-only | No runtime source, parser, loader, installer, workspace runtime, issuer, plugin, registry, Semantic CLI, AI Runtime, or agent code is included |
+| P19-R11 | Pointer PR is docs-only | No runtime source, parser, loader, installer, workspace runtime, issuer, plugin, registry, Semantic CLI, AI Runtime, or agent code is included |
 | P19-R12 | Inert artifact invariant remains explicit | Bundle, validation receipt, admission record, and runtime receipt remain records only |
-| P19-R13 | Exact-SHA remote authority is fresh | Strict `ci-freeze` and Dev Loop PASS on the future pointer transition subject SHA |
+| P19-R13 | Exact-SHA remote authority is fresh | Strict `ci-freeze` and Dev Loop PASS on the pointer transition subject SHA |
 | P19-R14 | Implementation remains separate | Runtime MVP implementation still requires a later implementation decision and evidence package |
 
 Missing, stale, ambiguous, inherited, or partially satisfied preconditions
@@ -155,29 +156,27 @@ a later reviewed phase.
 
 This review must not be read to permit:
 
-1. `CURRENT_PHASE=19`.
-2. Runtime source code.
-3. Manifest parser implementation.
-4. Package installation or execution.
-5. Module loading.
-6. Workspace creation, workspace runtime, or real mounts.
-7. Plugin host, plugin loading, or plugin instantiation.
-8. Capability token minting or capability issuance.
-9. Trust assignment or trust issuer behavior.
-10. Registry publication or marketplace behavior.
-11. Semantic CLI execution authority.
-12. AI Runtime authority.
-13. Agent systems.
-14. New syscalls.
-15. Kernel ABI expansion.
-16. Ring0 policy.
+1. Runtime source code.
+2. Manifest parser implementation.
+3. Package installation or execution.
+4. Module loading.
+5. Workspace creation, workspace runtime, or real mounts.
+6. Plugin host, plugin loading, or plugin instantiation.
+7. Capability token minting or capability issuance.
+8. Trust assignment or trust issuer behavior.
+9. Registry publication or marketplace behavior.
+10. Semantic CLI execution authority.
+11. AI Runtime authority.
+12. Agent systems.
+13. New syscalls.
+14. Kernel ABI expansion.
+15. Ring0 policy.
 
 Unknown authority readings fail closed.
 
-## Required Evidence Before Pointer Transition
+## Required Evidence For Pointer Transition
 
-Before any future pointer transition can be accepted, the future pointer PR
-must record fresh exact-SHA evidence for:
+A pointer PR must record fresh exact-SHA evidence for:
 
 1. Strict `ci-freeze` PASS.
 2. Dev Loop PASS.
@@ -190,16 +189,14 @@ must record fresh exact-SHA evidence for:
 Historical PASS results may be cited as context only. They cannot be inherited
 as authority for a new subject SHA.
 
-## Open Blockers For Actual Activation
+## Open Blockers For Runtime Implementation
 
-The following blockers remain for actual Phase-19 activation:
+The following blockers remain for runtime implementation:
 
-1. No exact-SHA `CURRENT_PHASE=19` pointer transition PR exists.
-2. No activation decision package exists.
-3. No runtime implementation authority exists.
-4. No runtime MVP implementation evidence exists.
-5. No runtime-specific CI gate exists.
-6. No loader, installer, workspace runtime, capability issuer, trust issuer,
+1. No runtime implementation authority exists.
+2. No runtime MVP implementation evidence exists.
+3. No runtime-specific CI gate exists.
+4. No loader, installer, workspace runtime, capability issuer, trust issuer,
    Semantic CLI authority, AI Runtime, registry, or agent authority exists.
 
 These are intentional blockers. They preserve the separation between
@@ -208,9 +205,8 @@ precondition review, pointer transition, and implementation.
 ## Final Review Conclusion
 
 Phase-19 activation preconditions are documented, bounded, and internally
-consistent enough for a later pointer transition PR to be reviewed.
+consistent enough for the pointer transition PR to be reviewed.
 
-Phase-19 is still not active. `CURRENT_PHASE` remains `18`. Runtime
-implementation is still not authorized. The next authority-changing action
-would have to be a separate exact-SHA pointer transition PR; until then, the
-safe default remains no Phase-19 activation and no runtime implementation.
+Runtime implementation is still not authorized. The next authority-changing
+action after pointer transition would have to be a separate implementation
+decision; until then, the safe default remains no runtime implementation.

--- a/PHASE19_POINTER_TRANSITION_CANDIDATE.md
+++ b/PHASE19_POINTER_TRANSITION_CANDIDATE.md
@@ -4,14 +4,15 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
 `ARCHITECTURE_FREEZE.md`, `PHASE18_TRANSITION_DECISION.md`,
 `PHASE18_ACTIVATION_DECISION.md`, the Phase-18 Platform Constitution
 reference set, `AUTHORITY_DRIFT_GUARD.md`, `TERMINOLOGY_AUDIT.md`,
-`PHASE19_RUNTIME_DECISION.md`, and the Phase-19 Runtime RFC set. In case of
-conflict, those documents prevail.
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set, and
+`PHASE19_POINTER_TRANSITION_DECISION.md`. In case of conflict, those documents
+prevail.
 
-**Status:** POINTER TRANSITION CANDIDATE / PHASE-19 NOT ACTIVE / POINTER NOT EXECUTED / IMPLEMENTATION NOT AUTHORIZED
+**Status:** ACCEPTED POINTER TRANSITION CANDIDATE / SUPERSEDED BY POINTER TRANSITION DECISION / IMPLEMENTATION NOT AUTHORIZED
 **Candidate date:** 2026-06-05
 **Candidate id:** `ayken.phase19.pointer_transition.candidate.v1`
 **Authority boundary:** Documentation candidate only; not `CURRENT_PHASE=19`,
-not a phase activation decision, not runtime implementation, not a package
+not the pointer transition decision, not runtime implementation, not a package
 installer, not a module loader, not workspace runtime, not real mount
 authority, not plugin loading, not capability issuance, not trust assignment,
 not Semantic CLI authority, not AI Runtime authority, not a syscall, not
@@ -25,12 +26,12 @@ This candidate answers only one question:
 If Phase-19 is later transitioned, which authority conditions must be true?
 ```
 
-It does not perform that transition. `docs/roadmap/CURRENT_PHASE` remains
-`CURRENT_PHASE=18`.
+It did not perform that transition. The later transition is recorded in
+`PHASE19_POINTER_TRANSITION_DECISION.md`.
 
 This document is intentionally not named `PHASE19_ACTIVATION_DECISION.md`.
-It is a pre-transition candidate record. A later exact-SHA pointer transition
-must be reviewed separately before Phase-19 can become active.
+It is a pre-transition candidate record. The later exact-SHA pointer
+transition remains separate from runtime implementation authority.
 
 ## Core Rule
 
@@ -77,22 +78,22 @@ Phase-17 official closure verified
   -> Phase-19 Runtime Cross-Consistency Review accepted
   -> Phase-19 Pointer Transition Candidate accepted
   -> Phase-19 Activation Preconditions Review accepted
-  -> later exact-SHA pointer transition PR
+  -> exact-SHA pointer transition PR
   -> CURRENT_PHASE=19 only after separate review and remote PASS
 ```
 
-This candidate occupies only the candidate step. It does not update the
+This candidate occupies only the candidate step. It did not update the
 pointer.
 
-## Required Preconditions For Later Pointer Transition
+## Required Preconditions For Pointer Transition
 
-A later `CURRENT_PHASE=19` pointer transition must fail closed unless all of
-the following are true on the exact candidate SHA for that future transition:
+The `CURRENT_PHASE=19` pointer transition must fail closed unless all of the
+following are true on the exact candidate SHA for that transition:
 
 | ID | Requirement | Required result |
 |---|---|---|
 | P19-P1 | Phase-17 closure remains verified | `phase17-official-closure` resolves to `416a5392afbe217e16d26a59e2e1716fdfa9c8f6` |
-| P19-P2 | Current phase remains 18 before transition | `docs/roadmap/CURRENT_PHASE` still contains `CURRENT_PHASE=18` before the future pointer PR changes it |
+| P19-P2 | Current phase remains 18 before transition | `docs/roadmap/CURRENT_PHASE` contained `CURRENT_PHASE=18` before the pointer PR changed it |
 | P19-P3 | Phase-18 remains Platform Constitution only | no runtime interpretation of Phase-18 activation exists |
 | P19-P4 | Authority Drift Guard remains active | runtime, loader, issuer, workspace, plugin, trust, capability, AI, and Semantic authority drift is rejected |
 | P19-P5 | Terminology Audit remains active | high-risk vocabulary remains non-authoritative |
@@ -101,17 +102,17 @@ the following are true on the exact candidate SHA for that future transition:
 | P19-P8 | Phase-19 Runtime Cross-Consistency Review is accepted | `CROSS_CONSISTENCY_REVIEW.md` remains PASS and non-authoritative |
 | P19-P9 | This pointer transition candidate is accepted | this file remains docs-only and does not update `CURRENT_PHASE` |
 | P19-P10 | Kernel ABI remains frozen | syscall IDs remain `1000-1011`, count remains `12`, ABI version remains `0x00010001` |
-| P19-P11 | Future pointer PR is docs-only | no kernel, userspace runtime, parser, loader, installer, issuer, plugin, Semantic CLI, AI Runtime, or registry code is included |
+| P19-P11 | Pointer PR is docs-only | no kernel, userspace runtime, parser, loader, installer, issuer, plugin, Semantic CLI, AI Runtime, or registry code is included |
 | P19-P12 | Inert artifact invariant is preserved | input bundle, validation receipt, admission record, and runtime receipt remain records only |
-| P19-P13 | Exact-SHA CI passes | strict `ci-freeze` and Dev Loop pass on the future pointer transition SHA |
+| P19-P13 | Exact-SHA CI passes | strict `ci-freeze` and Dev Loop pass on the pointer transition SHA |
 | P19-P14 | Implementation remains separated | runtime implementation still requires a later implementation decision and evidence package |
 | P19-P15 | Activation Preconditions Review is accepted | `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` reviews preconditions without changing `CURRENT_PHASE` |
 
 Missing, stale, ambiguous, or partially satisfied preconditions fail closed.
 
-## Future Pointer PR Scope
+## Pointer PR Scope
 
-A later pointer transition PR may only propose:
+A pointer transition PR may only propose:
 
 1. Updating `docs/roadmap/CURRENT_PHASE` from `CURRENT_PHASE=18` to
    `CURRENT_PHASE=19`.
@@ -142,11 +143,11 @@ It must not include:
 
 ## Exact-SHA Rule
 
-This candidate does not contain a final transition SHA because it does not
+This candidate does not contain the final transition SHA because it did not
 execute the transition.
 
-The exact-SHA authority for a future pointer transition can only be the
-reviewed subject SHA of the future PR that actually changes
+The exact-SHA authority for the pointer transition can only be the reviewed
+subject SHA of the PR that actually changes
 `docs/roadmap/CURRENT_PHASE`. If that subject changes after evidence is
 recorded, the pointer transition evidence must be regenerated on the new
 subject SHA.
@@ -173,9 +174,8 @@ Pointer transition planning must be denied if any of the following are true:
 
 ## Candidate Conclusion
 
-This candidate makes Phase-19 pointer transition reviewable later.
+This candidate made Phase-19 pointer transition reviewable.
 
-It does not activate Phase-19. It does not authorize implementation. It does
-not change `CURRENT_PHASE`. It preserves the Phase-18 rule that Constitution
-is not Runtime and adds the Phase-19 rule that Runtime MVP artifacts must
-remain inert until a separate implementation authority exists.
+It did not authorize implementation. It preserves the Phase-18 rule that
+Constitution is not Runtime and adds the Phase-19 rule that Runtime MVP
+artifacts must remain inert until a separate implementation authority exists.

--- a/PHASE19_POINTER_TRANSITION_DECISION.md
+++ b/PHASE19_POINTER_TRANSITION_DECISION.md
@@ -1,0 +1,192 @@
+# Phase-19 Pointer Transition Decision
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, `PHASE18_TRANSITION_DECISION.md`,
+`PHASE18_ACTIVATION_DECISION.md`, the Phase-18 Platform Constitution
+reference set, `AUTHORITY_DRIFT_GUARD.md`, `TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`,
+`PHASE19_POINTER_TRANSITION_CANDIDATE.md`, and
+`PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`. In case of conflict, those
+documents prevail unless this decision is the narrower pointer authority for
+`docs/roadmap/CURRENT_PHASE`.
+
+**Status:** POINTER TRANSITION DECISION / CURRENT_PHASE=19 / RUNTIME IMPLEMENTATION NOT AUTHORIZED
+**Decision date:** 2026-06-06
+**Decision id:** `ayken.phase19.pointer_transition.decision.v1`
+**Authority boundary:** Phase pointer decision only; not runtime
+implementation, not a manifest parser, not a package installer, not a package
+executor, not a module loader, not workspace runtime, not workspace creation,
+not real mount authority, not plugin host, not plugin loading, not capability
+token minting, not capability issuance, not trust assignment, not registry
+publication, not Semantic CLI authority, not AI Runtime authority, not agent
+authority, not a syscall, not kernel ABI expansion, not Ring0 policy, not
+merge authority, and not closure authority.
+
+## Decision
+
+`docs/roadmap/CURRENT_PHASE` is transitioned from `CURRENT_PHASE=18` to
+`CURRENT_PHASE=19`.
+
+Phase-19 is active only as the documented **Platform Runtime MVP planning,
+validation-integration, admission-record, and receipt-boundary phase**.
+
+CURRENT_PHASE=19 does not authorize runtime implementation.
+
+Implementation authority remains denied.
+
+## Core Rule
+
+```text
+pointer transition != runtime implementation
+CURRENT_PHASE=19 != runtime source code authority
+runtime artifact != behavior source
+```
+
+The safe default remains no runtime behavior unless a later reviewed
+implementation decision grants a specific bounded behavior and supplies its
+own evidence package.
+
+## Transition Basis
+
+The pointer transition is based on the accepted pre-transition chain:
+
+1. Phase-17 official closure remains verified by `phase17-official-closure`
+   at `416a5392afbe217e16d26a59e2e1716fdfa9c8f6`.
+2. Phase-18 was active as Platform Constitution only before this transition
+   and remains the accepted Platform Constitution reference set.
+3. Phase-18 Authority Drift Guard remains the review guard for runtime,
+   loader, issuer, workspace, plugin, trust, capability, Semantic CLI, AI, and
+   agent drift.
+4. Phase-18 Terminology Audit remains the vocabulary guard for high-risk
+   terms.
+5. `PHASE19_RUNTIME_DECISION.md` defines the Platform Runtime MVP planning
+   boundary.
+6. The Phase-19 Runtime RFC set under
+   `docs/specs/phase19-platform-runtime/` defines lifecycle, static input
+   bundle, validation integration, workspace admission record, runtime
+   receipt, evidence, and denial boundaries.
+7. `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`
+   records PASS for the RFC set without granting implementation authority.
+8. `PHASE19_POINTER_TRANSITION_CANDIDATE.md` defines the pre-transition
+   exact-SHA and inert artifact conditions.
+9. `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` records PASS for the
+   precondition documentation without activating Phase-19.
+
+## Active Phase-19 Scope
+
+Phase-19 active scope is limited to:
+
+1. Maintaining the accepted Runtime MVP decision boundary.
+2. Maintaining the accepted Runtime RFC set.
+3. Maintaining cross-document consistency for the Runtime MVP boundary.
+4. Planning validation integration with the Phase-18 Platform ABI Validation
+   Gate.
+5. Planning inert workspace admission records.
+6. Planning deterministic runtime receipts.
+7. Preparing a later implementation decision package and evidence plan.
+
+The only allowed MVP shape remains:
+
+```text
+static input bundle
+  -> Phase-18 Platform ABI validation integration
+  -> workspace admission record
+  -> deterministic runtime receipt
+```
+
+This flow must not install, load, mount, execute, issue, trust, publish,
+schedule, or grant anything.
+
+## Inert Artifact Rule
+
+Every Phase-19 Runtime MVP artifact remains inert.
+
+| Artifact | Safe meaning | Forbidden reading |
+|---|---|---|
+| Static input bundle | Digest-bound declarative input set | Parser, installer request, loader request, execution request, token request, workspace creation request |
+| Validation receipt | Evidence that validation inputs were checked | Authorization, install permission, load permission, trust grant, capability grant, workspace grant |
+| Workspace admission record | Deterministic record for later review | Workspace creation, filesystem mount, namespace creation, handle, access grant |
+| Runtime receipt | Digest-bound evidence output | Bearer token, capability token, workspace handle, plugin binding, execution right |
+
+If a later proposal makes one of these artifacts active, executable, loadable,
+mountable, transferable, or authority-bearing, the proposal must fail closed
+or move to a later reviewed phase.
+
+## Implementation Remains Denied
+
+This pointer transition must not authorize:
+
+1. Runtime source code.
+2. Manifest parser implementation.
+3. Package installation.
+4. Package execution.
+5. Module loading.
+6. Plugin host, plugin loading, or plugin instantiation.
+7. Workspace creation, workspace runtime, or real mounts.
+8. Capability token minting.
+9. Capability issuance.
+10. Trust assignment or trust issuer behavior.
+11. Registry publication or marketplace behavior.
+12. Semantic CLI execution authority.
+13. AI Runtime authority.
+14. Agent behavior.
+15. New syscalls.
+16. Kernel ABI expansion.
+17. Ring0 policy.
+18. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Kernel And ABI Boundary
+
+The kernel ABI remains frozen:
+
+1. Syscall IDs remain `1000-1011`.
+2. Syscall count remains `12`.
+3. ABI version remains `0x00010001`.
+4. Ring0 remains mechanism only.
+5. Ring3 runtime policy remains outside kernel authority.
+
+This pointer transition does not change kernel code, userspace runtime code,
+baseline data, CI workflows, syscall declarations, or ABI layout.
+
+## Evidence Rule
+
+This decision becomes valid only for the exact subject SHA that contains this
+pointer transition after required remote checks pass.
+
+Required evidence for the pointer transition subject:
+
+1. Strict `ci-freeze` PASS.
+2. Dev Loop PASS.
+3. No runtime source code changes.
+4. No kernel ABI change.
+5. No CI gate or workflow authority widening.
+6. Status, roadmap, README, and documentation index synchronization.
+
+Historical PASS results may be cited as context only. They cannot be inherited
+as authority for this pointer transition subject SHA.
+
+If the subject SHA changes after evidence is recorded, the evidence must be
+regenerated for the new subject SHA.
+
+## Relationship To Later Phases
+
+Phase-19 must not pull later phases forward:
+
+1. Phase-20 registry/capability ecosystem remains later work.
+2. Phase-21 Semantic CLI authority remains later work.
+3. Phase-22 AI Runtime remains later work.
+4. Phase-23+ agent systems remain later work.
+
+Those phases require their own reviewed decision packages.
+
+## Decision Conclusion
+
+This package transitions the formal phase pointer to `CURRENT_PHASE=19`.
+
+The transition authorizes only the documented Runtime MVP planning,
+validation-integration, admission-record, and receipt-boundary phase.
+
+Runtime implementation remains unauthorized.

--- a/PHASE19_RUNTIME_DECISION.md
+++ b/PHASE19_RUNTIME_DECISION.md
@@ -3,29 +3,30 @@
 This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
 `ARCHITECTURE_FREEZE.md`, `PHASE18_TRANSITION_DECISION.md`,
 `PHASE18_ACTIVATION_DECISION.md`, the Phase-18 Platform Constitution
-reference set, `AUTHORITY_DRIFT_GUARD.md`, and `TERMINOLOGY_AUDIT.md`. In
-case of conflict, those documents prevail until a separate reviewed Phase-19
-activation and closure authority exists.
+reference set, `AUTHORITY_DRIFT_GUARD.md`, `TERMINOLOGY_AUDIT.md`, and
+`PHASE19_POINTER_TRANSITION_DECISION.md`. In case of conflict, those
+documents prevail.
 
-**Status:** DECISION PACKAGE / PHASE-19 NOT ACTIVE / IMPLEMENTATION NOT AUTHORIZED
+**Status:** DECISION PACKAGE / PHASE-19 ACTIVE AS PLANNING BOUNDARY / IMPLEMENTATION NOT AUTHORIZED
 **Decision package date:** 2026-06-05
 **Decision id:** `ayken.phase19.platform_runtime_decision.v1`
-**Authority boundary:** Documentation decision only; not a phase pointer
-transition, runtime implementation, package installer, module loader,
-workspace runtime, real mount authority, plugin host, capability issuer,
-trust issuer, Semantic CLI authority, AI Runtime authority, syscall, kernel
-ABI expansion, merge authority, or closure authority.
+**Authority boundary:** Runtime MVP decision boundary only; not runtime
+implementation, package installer, module loader, workspace runtime, real
+mount authority, plugin host, capability issuer, trust issuer, Semantic CLI
+authority, AI Runtime authority, syscall, kernel ABI expansion, merge
+authority, or closure authority.
 
 ## Decision
 
 Phase-19 may be proposed only as **Platform Runtime MVP**.
 
-This package does not activate Phase-19. `CURRENT_PHASE` remains `18` until a
-separate exact-SHA pointer transition is reviewed and accepted.
+This package did not activate Phase-19 by itself. Phase-19 is now active only
+through the separate exact-SHA `PHASE19_POINTER_TRANSITION_DECISION.md`
+pointer decision.
 
 This package does not authorize runtime source code. It authorizes only the
-preparation of a future Phase-19 runtime RFC set that preserves the Phase-18
-Platform Constitution boundaries.
+Runtime MVP planning boundary that preserves the Phase-18 Platform
+Constitution boundaries.
 
 ## Core Rule
 
@@ -105,10 +106,10 @@ That harness may only prove the following bounded behavior:
 
 It must not execute the described package or module.
 
-## Future Runtime RFC Set
+## Runtime RFC Set
 
-Before any Phase-19 implementation PR, the following runtime RFC set must be
-prepared and accepted:
+Before any Phase-19 implementation PR, the following runtime RFC set must
+remain accepted:
 
 1. `RUNTIME_LIFECYCLE_SPECIFICATION.md`
 2. `RUNTIME_INPUT_BUNDLE_SPECIFICATION.md`
@@ -118,24 +119,26 @@ prepared and accepted:
 6. `RUNTIME_EVIDENCE_PLAN.md`
 7. `RUNTIME_NON_GOALS_AND_DENIALS.md`
 
-The initial RFC set lives under
-`docs/specs/phase19-platform-runtime/`. The existence of that directory does
-not activate Phase-19 and does not authorize implementation.
+The accepted RFC set lives under `docs/specs/phase19-platform-runtime/`. The
+existence of that directory does not authorize implementation.
 
-After the RFC set is accepted, a Phase-19 runtime cross-consistency review
-must be accepted before a pointer-transition discussion can use the RFC set as
-planning input. That review is still not activation and still not
-implementation authority.
+After the RFC set was accepted, a Phase-19 runtime cross-consistency review
+was accepted before a pointer-transition discussion could use the RFC set as
+planning input. That review is still not implementation authority.
 
 After the cross-consistency review, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`
-may define the conditions for a later exact-SHA pointer transition. That
-candidate still does not update `CURRENT_PHASE` and still does not authorize
-runtime implementation.
+defined the conditions for a later exact-SHA pointer transition. That
+candidate did not update `CURRENT_PHASE` and did not authorize runtime
+implementation.
 
 After the pointer transition candidate,
-`PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` may review whether the documented
-preconditions are complete enough for a later pointer transition discussion.
-That review is still not activation and still not implementation authority.
+`PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` reviewed whether the documented
+preconditions were complete enough for a later pointer transition discussion.
+That review is still not implementation authority.
+
+After that review, `PHASE19_POINTER_TRANSITION_DECISION.md` transitions
+`docs/roadmap/CURRENT_PHASE` to `19` as planning/admission/receipt authority
+only. That pointer transition is still not runtime implementation authority.
 
 `MODULE_LOADING_MODEL.md`, `PLUGIN_INSTANTIATION_MODEL.md`, package
 execution, real workspace mounts, capability issuance, trust assignment,
@@ -149,26 +152,25 @@ non-loader admission model or move to a later phase decision.
 
 This decision package must not authorize:
 
-1. `CURRENT_PHASE=19`.
-2. Runtime implementation.
-3. Package installation.
-4. Package execution.
-5. Module loading.
-6. Plugin loading or plugin instantiation.
-7. Workspace creation.
-8. Real filesystem mounts.
-9. Capability token minting.
-10. Capability issuance.
-11. Trust assignment.
-12. Registry publication.
-13. Semantic CLI execution authority.
-14. AI Runtime authority.
-15. Agent systems.
-16. New syscalls.
-17. Kernel ABI expansion.
-18. Ring0 policy.
-19. Kernel loader behavior.
-20. Observability-as-authority.
+1. Runtime implementation.
+2. Package installation.
+3. Package execution.
+4. Module loading.
+5. Plugin loading or plugin instantiation.
+6. Workspace creation.
+7. Real filesystem mounts.
+8. Capability token minting.
+9. Capability issuance.
+10. Trust assignment.
+11. Registry publication.
+12. Semantic CLI execution authority.
+13. AI Runtime authority.
+14. Agent systems.
+15. New syscalls.
+16. Kernel ABI expansion.
+17. Ring0 policy.
+18. Kernel loader behavior.
+19. Observability-as-authority.
 
 Any such work requires a separate reviewed decision, RFC set, evidence plan,
 and acceptance boundary.
@@ -181,13 +183,13 @@ are true:
 | ID | Precondition | Required result |
 |---|---|---|
 | P19-A1 | Phase-17 closure remains verified | `phase17-official-closure` resolves to `416a5392afbe217e16d26a59e2e1716fdfa9c8f6` |
-| P19-A2 | Phase-18 remains active as Platform Constitution only | `CURRENT_PHASE=18` remains true before the separate pointer transition |
+| P19-A2 | Phase-18 remains accepted as Platform Constitution only | Phase-18 activation is not interpreted as runtime implementation |
 | P19-A3 | Phase-18 Authority Drift Guard remains active | `AUTHORITY_DRIFT_GUARD.md` rejects runtime drift |
 | P19-A4 | Phase-18 Terminology Audit remains active | high-risk words remain non-authoritative |
 | P19-A5 | Runtime RFC set exists | all required Phase-19 runtime RFCs are accepted |
 | P19-A6 | Runtime non-goals are explicit | installer, loader, execution, issuer, trust, AI, Semantic CLI, and agent authority are denied |
 | P19-A7 | Kernel ABI remains frozen | syscall IDs remain `1000-1011`, count remains `12`, ABI version remains `0x00010001` |
-| P19-A8 | Exact-SHA CI passes | strict `ci-freeze` and Dev Loop pass on the candidate SHA |
+| P19-A8 | Exact-SHA CI passes | strict `ci-freeze` and Dev Loop pass on the pointer transition candidate SHA |
 | P19-A9 | Implementation is separated | pointer transition does not include runtime source code |
 | P19-A10 | Evidence plan is accepted | runtime evidence paths, receipts, negative cases, and fail-closed behavior are defined |
 | P19-A11 | Runtime RFC cross-review is accepted | Phase-19 runtime RFC set has a reviewed cross-consistency record |
@@ -233,12 +235,12 @@ Phase-19 planning must be denied if any of the following are true:
 13. Required local or remote checks fail.
 14. Exact-SHA evidence is missing.
 
-The safe default is no Phase-19 activation.
+The safe default is no runtime implementation.
 
 ## Relationship To Later Phases
 
-Phase-19 is limited to Platform Runtime MVP planning and, after a separate
-accepted activation, a bounded runtime MVP.
+Phase-19 is limited to Platform Runtime MVP planning, validation integration,
+admission records, and deterministic receipts.
 
 The following remain later-phase work:
 
@@ -254,6 +256,6 @@ or convenience.
 
 This package defines the safe Phase-19 Runtime MVP decision boundary.
 
-It does not activate Phase-19. It does not authorize implementation. It
-preserves the rule that Phase-18 remains the active Platform Constitution
-until a separate reviewed pointer transition changes `CURRENT_PHASE`.
+It does not authorize implementation. It preserves the rule that Phase-18
+remains the accepted Platform Constitution reference set and that
+`CURRENT_PHASE=19` is only a planning/admission/receipt pointer.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **Oluşturan:** Kenan AY
 **Düzenleyen / Geliştiren / Mimari Sorumlu:** Kenan AY *(bilgilendirme metadata'sı; runtime yetkisi değildir)*
 **Oluşturma Tarihi:** 01.01.2026
-**Son Güncelleme:** 05.06.2026
+**Son Güncelleme:** 06.06.2026
 **Closure Evidence:** `local-freeze-p10p11` + `local-phase11-closure` + `run-local-phase12c-closure-2026-03-11` + `run-local-p13-kill-switch-20260315T000051Z` + `phase15-official-closure` + `phase16-verification-layer-mvp-complete`
 **Evidence Git SHA (Phase-10/11):** `9cb2171b` | **Evidence Git SHA (Phase-12C):** `01d1cb5c` | **Evidence Git SHA (Phase-13):** `40158350` | **Evidence Git SHA (Phase-15):** `48970cd0` | **Evidence Git SHA (Phase-16):** `489868f8`
 **Closure Sync / Remote CI (Phase-10/11):** `fe9031d7` (`ci-freeze#22797401328 = success`)
@@ -22,15 +22,15 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **Remote CI (Phase-13):** `ci-freeze#23706742211 = success` (PR #81)
 **Remote CI (Phase-15):** `ci-freeze#24213727039 = success` (PR #104) | tag `phase15-official-closure`
 **Remote CI (Phase-16):** Verification Layer MVP complete (2026-04-25)
-**CURRENT_PHASE:** `18` (`Phase-18 ACTIVE: Platform Constitution`; runtime implementation yetkisi değildir)
+**CURRENT_PHASE:** `19` (`Phase-19 ACTIVE: Platform Runtime MVP planning/admission/receipt boundary`; runtime implementation yetkisi değildir)
 **Freeze Zinciri:** `make ci-freeze` = 40 kapılı strict suite (normative spec-purity dahil) | `make ci-freeze-local` = local performance authority
 **Authority Durumu:** Issue #145 tek-maintainer authority kararıyla giderildi; PR #142, PR #144, PR #148, PR #149, PR #151, PR #150, PR #152 ve Phase-17 closure decision package birleşti. Closure exact-SHA kanıtı `main` SHA `416a5392` üzerinde yenilendi, gerekli uzak acceptance kontrolleri PASS verdi ve `phase17-official-closure` tag'i aynı SHA'ya doğrulandı
-**Yakın Hedef:** Phase-18 Platform Constitution kapsamını korumak; mevcut somut çıktılar `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`, `docs/specs/phase18-platform-constitution/CAPABILITY_CONTRACT_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`, `docs/specs/phase18-platform-constitution/PACKAGE_METADATA_SCHEMA.md`, `docs/specs/phase18-platform-constitution/TRUST_CLASSIFICATION_MODEL.md`, `docs/specs/phase18-platform-constitution/PLUGIN_BOUNDARY_CONTRACT.md`, `docs/specs/phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`, `docs/specs/phase18-platform-constitution/CROSS_CONSISTENCY_REVIEW.md`, `PHASE18_ACTIVATION_DECISION.md`, `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`, `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`, `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md` ve `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`; Phase-19 decision/RFC/review/candidate/precondition set `CURRENT_PHASE=19` veya runtime implementation yetkisi vermez
+**Yakın Hedef:** Phase-19 Platform Runtime MVP planning/admission/receipt sınırını korumak; mevcut somut girdiler `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` ve `PHASE19_POINTER_TRANSITION_DECISION.md`; `CURRENT_PHASE=19` runtime implementation, loader, installer, workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI authority veya AI Runtime authority vermez
 **Ring0 Export Ceiling:** `193 symbols` (current enforced ceiling)
 **Performance Baseline Candidate:** `gha-ubuntu24-20260518.149.1-X64` (authorized run `26370359958` artifact'i PR'a import edildi; SHA `f129d4aa` locked acceptance PASS verdi, ancak tek basina closure authority değildir)
-**Development Status:** Phase-16 OFFICIALLY CLOSED ✅ | Phase-17 OFFICIALLY CLOSED ✅ | SINGLE-MAINTAINER AUTHORITY ALIGNED (#145 RESOLVED) ✅ | PR #142/#144/#148/#149/#151/#150/#152 + closure decision package MERGED ✅ | EXACT-SHA REMOTE EVIDENCE PASS ✅ | Phase-18 PLATFORM CONSTITUTION ACTIVE ✅
+**Development Status:** Phase-16 OFFICIALLY CLOSED ✅ | Phase-17 OFFICIALLY CLOSED ✅ | SINGLE-MAINTAINER AUTHORITY ALIGNED (#145 RESOLVED) ✅ | PR #142/#144/#148/#149/#151/#150/#152 + closure decision package MERGED ✅ | EXACT-SHA REMOTE EVIDENCE PASS ✅ | Phase-18 PLATFORM CONSTITUTION ACCEPTED ✅ | Phase-19 POINTER TRANSITION ACTIVE AS PLANNING BOUNDARY ✅
 
-**Proje Durumu:** Core OS Phase 4.5 TAMAMLANDI ✅ | Phase 10-17 kapanış kayıtları mevcut ✅ | Phase 17 Execution Pipeline OFFICIALLY CLOSED ✅ (2026-05-31) | CURRENT_PHASE=18 ✅ | Phase-18 Platform Constitution aktif 🔒 | Architecture Freeze ACTIVE ✅
+**Proje Durumu:** Core OS Phase 4.5 TAMAMLANDI ✅ | Phase 10-17 kapanış kayıtları mevcut ✅ | Phase 17 Execution Pipeline OFFICIALLY CLOSED ✅ (2026-05-31) | CURRENT_PHASE=19 ✅ | Phase-19 Platform Runtime MVP planning/admission/receipt boundary aktif 🔒 | Runtime implementation kapalı 🔒 | Architecture Freeze ACTIVE ✅
 **Boot/Kernel Bring-up:** UEFI→kernel handoff doğrulandı ✅ | Ring3 process preparation operasyonel ✅ | ELF64 loader çalışıyor ✅ | User address space creation aktif ✅ | Syscall roundtrip doğrulandı ✅ | IRQ-tail preempt doğrulama hattı mevcut ✅
 **Phase 10 Status:** Runtime determinism officially closed ✅ | remote `ci-freeze` run `22797401328`
 **Phase 11 Status:** Replay + KPL + proof bundle officially closed ✅
@@ -40,10 +40,10 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **Phase 15 Status:** OFFICIALLY CLOSED ✅ | tag `phase15-official-closure` at `48970cd0` | remote `ci-freeze` run `24213727039` (PR #104) | BCIB Execution Engine v3: three-layer architecture, 293 tests PASS, 12 property tests PASS | `ayken-cli` v0.1 (Faz A wrapper) shipped | `tools/ayken-cli/`
 **Phase 16 Status:** OFFICIALLY CLOSED ✅ | Verification Layer MVP COMPLETE | Evidence chain integrity verified | Trust anchor established | `make verify-system` → 3 gates → PASS | Constitutional rule enforcement active | Fail-closed behavior confirmed
 **Phase 17 Status:** OFFICIALLY CLOSED ✅ | tag `phase17-official-closure` at `416a5392` | full `ci-freeze` (`26712333892`), locked performance (`26715068398`, `26712374737`) ve Phase-17 QEMU evidence lanes (`26712374742`, `26712374736`, `26712374727`, `26712374744`, `26712374728`) PASS | `reports/phase17_official_closure_candidate/`
-**Phase 18 Status:** ACTIVE AS PLATFORM CONSTITUTION | Authority drift guard and terminology audit active | Runtime implementation, kernel expansion, new syscalls, Ring0 policy and AI authority remain forbidden unless a separate phase RFC and closure authority exists
-**Phase 19 Status:** DECISION PACKAGE + PRE-IMPLEMENTATION RFC SET + CROSS-REVIEW + POINTER CANDIDATE + PRECONDITION REVIEW ONLY | `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, and `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` define, review, and precondition Platform Runtime MVP boundaries; `CURRENT_PHASE=19` and runtime implementation are not authorized
+**Phase 18 Status:** ACCEPTED PLATFORM CONSTITUTION REFERENCE SET | Authority drift guard and terminology audit active | Runtime implementation, kernel expansion, new syscalls, Ring0 policy and AI authority remain forbidden unless a separate phase RFC and closure authority exists
+**Phase 19 Status:** ACTIVE AS PLATFORM RUNTIME MVP PLANNING / ADMISSION / RECEIPT BOUNDARY | `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, and `PHASE19_POINTER_TRANSITION_DECISION.md` define and activate the planning boundary only; runtime implementation is not authorized
 **Architecture Quick Map:** `docs/specs/phase12-trust-layer/AYKENOS_GATE_ARCHITECTURE.md`
-**Active Execution Roadmap:** `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution RFC set | accepted `main` SHA `416a5392` uzerinde bounded uzak evidence PASS; official closure tag doğrulandı; Phase-18 Platform Constitution pointer'i aktiftir
+**Active Execution Roadmap:** `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution reference set + Phase-19 Runtime MVP planning boundary | accepted `main` SHA `416a5392` uzerinde bounded Phase-17 uzak evidence PASS; official closure tag doğrulandı; `CURRENT_PHASE=19` runtime implementation yetkisi vermez
 **Canonical Technical Definition:** AykenOS is a deterministic verification architecture that separates kernel execution, verification semantics, evidence artifacts, and distributed diagnostics into explicit layers. The kernel provides mechanism, userspace verification services produce artifact-bound verdicts and receipts, and parity/topology surfaces expose cross-node observability without elevating diagnostics into authority or consensus.
 
 ⚠️ **CI Mode:** `ci-freeze` workflow varsayılan olarak **CONSTITUTIONAL** modda çalışır (`PERF_BASELINE_MODE=constitutional`); provisional yol yalnız diagnosis/baseline artifact adayıdır ve acceptance/closure otoritesi değildir. Ayrıntı: [Constitutional CI Mode](docs/operations/CONSTITUTIONAL_CI_MODE.md), [Provisional CI Mode](docs/operations/PROVISIONAL_CI_MODE.md) ve [Performance Baseline Policy](docs/operations/PERF_BASELINE_POLICY.md).
@@ -52,13 +52,13 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 
 ## Phase Status
 
-- **Current Phase:** `18`
-- **Status:** `ACTIVE / PLATFORM CONSTITUTION ONLY`
+- **Current Phase:** `19`
+- **Status:** `ACTIVE / PLATFORM RUNTIME MVP PLANNING, ADMISSION, AND RECEIPT BOUNDARY ONLY`
 - **Last Official Closure:** `17` (Execution Pipeline, 2026-05-31)
-- **Candidate Next Phase:** `19` (Platform Runtime MVP; `PHASE19_RUNTIME_DECISION.md` defines the decision boundary, but Phase-19 is not active)
+- **Candidate Next Authority Action:** Phase-19 runtime implementation decision package; runtime source code remains unauthorized until then
 - **Verification Layer:** `COMPLETE` (MVP delivered 2026-04-25)
 - **Closure Index:** `reports/phase17_official_closure_candidate/closure_index.json`
-- **Phase-18 Authority Note:** `CURRENT_PHASE=18` activates Platform Constitution only; runtime implementation still requires a separate decision.
+- **Phase-19 Authority Note:** `CURRENT_PHASE=19` activates only Runtime MVP planning, validation-integration, admission-record, and receipt-boundary authority; runtime implementation still requires a separate decision.
 
 ## 🎯 Latest Breakthrough (2026-04-24)
 
@@ -69,7 +69,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 - **Evidence:** A, B, C karakterleri başarıyla syscall üzerinden basıldı
 - **Result:** Ring3 infrastructure PROVEN, syscall path WORKING, instruction retirement VALIDATED
 
-**Next Focus:** Phase-18 Platform Constitution kapsamını korumak ve `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md` ve `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` altinda tanimlanan Runtime MVP sinirini runtime koduna donusturmeden pointer-transition hazirligina ayirmak. Phase-19 active pointer, implementation karari ve closure boundary ayri karar gerektirir.
+**Next Focus:** `CURRENT_PHASE=19` altında Runtime MVP planning/admission/receipt sınırını korumak ve runtime implementasyonunu ayrı karar/evidence paketine ayırmak. Runtime source code, loader, installer, workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI authority ve AI Runtime authority hâlâ kapalıdır.
 
 ## Authority Model
 
@@ -327,6 +327,7 @@ Phase 12 trust layer kapsamında tamamlananlar:
 - **Phase-19 Runtime Cross-Consistency Review:** `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`
 - **Phase-19 Pointer Transition Candidate:** `PHASE19_POINTER_TRANSITION_CANDIDATE.md`
 - **Phase-19 Activation Preconditions Review:** `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`
+- **Phase-19 Pointer Transition Decision:** `PHASE19_POINTER_TRANSITION_DECISION.md`
 - **Documentation Index:** `docs/development/DOCUMENTATION_INDEX.md`
 - **Ring3 User-Leaf Rule:** `docs/governance/RING3_USER_LEAF_ALLOCATION_RULE.md`
 - **Ring3 Runtime Closure Note:** `docs/governance/RING3_RUNTIME_CLOSURE_NOTE.md`
@@ -352,8 +353,9 @@ AykenOS iki lisans modeli ile dağıtılır:
 
 ## 🎯 Sonraki Hedefler
 
-**Kısa Vadeli (Phase-18 Platform Constitution):**
-- `CURRENT_PHASE=18`; Phase-18 yalniz Platform Constitution olarak aktiftir.
+**Kısa Vadeli (Phase-19 Platform Runtime MVP Planning):**
+- `CURRENT_PHASE=19`; Phase-19 yalniz Runtime MVP planning, validation-integration, admission-record ve receipt-boundary olarak aktiftir.
+- Runtime implementation, loader, installer, workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI authority ve AI Runtime authority yetkisi yoktur.
 - `PHASE18_TRANSITION_DECISION.md` ve `PHASE18_ACTIVATION_DECISION.md` accepted authority inputs olarak korunur.
 - Platform ABI schema authority maintained; runtime implementation yetkisi yoktur.
 - Module manifest schema active spec: `docs/specs/phase18-platform-constitution/MODULE_MANIFEST_SCHEMA.md`.
@@ -367,11 +369,12 @@ AykenOS iki lisans modeli ile dağıtılır:
 - Phase-18 activation decision package: `PHASE18_ACTIVATION_DECISION.md`; `Constitution != Runtime`, activation runtime implementation yetkisi vermez.
 - Phase-18 authority drift guard: `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`; active review guard'dir, runtime veya Phase-19 authority grant degildir.
 - Phase-18 terminology audit: `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`; high-risk vocabulary icin accepted audit kaydidir, runtime authority degildir.
-- Phase-19 runtime decision package: `PHASE19_RUNTIME_DECISION.md`; Platform Runtime MVP sinirini tanimlar, `CURRENT_PHASE=19` veya runtime implementation yetkisi vermez.
-- Phase-19 runtime RFC set: `docs/specs/phase19-platform-runtime/README.md`; lifecycle, input bundle, validation integration, workspace admission record, receipt, evidence plan ve denial sinirlarini tanimlar; implementation yetkisi vermez.
-- Phase-19 runtime cross-consistency review: `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`; RFC set PASS review kaydidir, `CURRENT_PHASE=19` veya implementation yetkisi vermez.
-- Phase-19 pointer transition candidate: `PHASE19_POINTER_TRANSITION_CANDIDATE.md`; later exact-SHA pointer transition kosullarini tanimlar, `CURRENT_PHASE=19` veya implementation yetkisi vermez.
-- Phase-19 activation preconditions review: `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`; precondition review PASS kaydidir, `CURRENT_PHASE=19`, activation decision veya runtime implementation yetkisi vermez.
+- Phase-19 runtime decision package: `PHASE19_RUNTIME_DECISION.md`; Platform Runtime MVP sinirini tanimlar, runtime implementation yetkisi vermez.
+- Phase-19 runtime RFC set: `docs/specs/phase19-platform-runtime/README.md`; lifecycle, input bundle, validation integration, workspace admission record, receipt, evidence plan ve denial sinirlarini aktif planning boundary olarak tanimlar; implementation yetkisi vermez.
+- Phase-19 runtime cross-consistency review: `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`; RFC set PASS review kaydidir, implementation yetkisi vermez.
+- Phase-19 pointer transition candidate: `PHASE19_POINTER_TRANSITION_CANDIDATE.md`; exact-SHA pointer transition kosullarini tanimlayan accepted candidate kaydidir, implementation yetkisi vermez.
+- Phase-19 activation preconditions review: `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`; precondition review PASS kaydidir, runtime implementation yetkisi vermez.
+- Phase-19 pointer transition decision: `PHASE19_POINTER_TRANSITION_DECISION.md`; `CURRENT_PHASE=19` pointer'ini planning/admission/receipt sinirinda aktive eder, runtime implementation yetkisi vermez.
 - Phase-19 runtime MVP icin ayri implementation RFC/evidence plan/closure boundary hazirlanmadikca package installer, workspace runtime, plugin loader, capability issuer veya trust issuer yazilmaz.
 
 **Orta Vadeli:**
@@ -387,7 +390,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 
 ---
 
-**Son Güncelleme:** 05 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=18; Module Manifest, Capability Contract, Workspace Lifecycle, Package Metadata, Trust Classification, Plugin Boundary, Platform ABI Validation Gate, Cross-Consistency Review, `PHASE18_ACTIVATION_DECISION.md`, `AUTHORITY_DRIFT_GUARD.md` ve `TERMINOLOGY_AUDIT.md` Phase-18 Platform Constitution authority seti olarak aktiftir; `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md` ve `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` Runtime MVP karar/RFC/review/candidate/precondition sinirini tanimlar, ancak Phase-19 aktif degildir ve runtime implementation yetkisi yoktur.
+**Son Güncelleme:** 06 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=19; Phase-18 Platform Constitution reference set korunur; `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` ve `PHASE19_POINTER_TRANSITION_DECISION.md` Runtime MVP planning/admission/receipt sinirini aktive eder, ancak runtime implementation yetkisi yoktur.
 **Düzenleyen / Geliştiren / Oluşturan / Mimari Sorumlu:** Kenan AY *(metadata only; runtime/karar yetkisi değildir).*
 
 **© 2026 Kenan AY — AykenOS Project**

--- a/docs/development/DOCUMENTATION_INDEX.md
+++ b/docs/development/DOCUMENTATION_INDEX.md
@@ -1,10 +1,10 @@
 # AykenOS Documentation Index
 This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict, Phase 0 prevails.
 
-**Last Updated:** 2026-06-05
+**Last Updated:** 2026-06-06
 **Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu:** Kenan AY
 **Attribution Boundary:** Human-readable documentation metadata only; not runtime authority or execution evidence.
-**Current Authority Basis:** `phase17-official-closure` + `CURRENT_PHASE=18` + `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`
+**Current Authority Basis:** `phase17-official-closure` + `CURRENT_PHASE=19` + `PHASE19_POINTER_TRANSITION_DECISION.md` + `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`
 
 ## Current Status
 - **Runtime:** `Phase-10` officially closed — `ci-freeze` run `22797401328`
@@ -15,17 +15,17 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict
 - **BCIB Execution Engine v3:** `Phase-15` officially closed — `ci-freeze` run `24213727039` (PR #104)
 - **Verification Layer MVP:** `Phase-16` officially closed — `ci-freeze` run `25214669681`, tag `phase16-official-closure`
 - **Execution Pipeline:** `Phase-17` officially closed — tag `phase17-official-closure` at `416a5392`
-- **Formal Governance Pointer:** `CURRENT_PHASE=18`
-- **Active Phase:** Phase-18 ACTIVE / Platform Constitution only
-- **Active Execution Priority:** Maintain Phase-18 Platform Constitution authority without runtime implementation
-- **Candidate Next Decision:** Phase-19 Runtime MVP decision/RFC/review/candidate/precondition set; not active phase or implementation authority
-- **Scope Boundary:** Phase-18 activation does not authorize runtime implementation; kernel expansion, new syscalls, Ring0 policy and AI Runtime authority remain forbidden for Phase-18
+- **Formal Governance Pointer:** `CURRENT_PHASE=19`
+- **Active Phase:** Phase-19 ACTIVE / Platform Runtime MVP planning, admission, and receipt boundary only
+- **Active Execution Priority:** Maintain Phase-19 planning/admission/receipt authority without runtime implementation
+- **Candidate Next Decision:** Phase-19 runtime implementation decision package; source code remains unauthorized until a separate exact-SHA decision
+- **Scope Boundary:** `CURRENT_PHASE=19` does not authorize runtime implementation; kernel expansion, new syscalls, Ring0 policy and AI Runtime authority remain forbidden
 
 ## Primary Truth Sources
 Current repo truth icin once su dosyalari referans alin:
 
 1. `ARCHITECTURE_FREEZE.md`
-2. `docs/roadmap/CURRENT_PHASE` — `CURRENT_PHASE=18`
+2. `docs/roadmap/CURRENT_PHASE` — `CURRENT_PHASE=19`
 3. `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` — **active execution roadmap**
 4. `AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md` — **current status report**
 5. `README.md`
@@ -46,19 +46,20 @@ Current repo truth icin once su dosyalari referans alin:
 20. `PHASE18_ACTIVATION_DECISION.md` — **accepted Phase-18 activation decision package; runtime not authorized**
 21. `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md` — **active Phase-18 authority drift review guard; runtime not authorized**
 22. `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md` — **accepted Phase-18 terminology audit; runtime not authorized**
-23. `PHASE19_RUNTIME_DECISION.md` — **Phase-19 Runtime MVP decision package; Phase-19 not active**
-24. `docs/specs/phase19-platform-runtime/README.md` — **Phase-19 Runtime MVP pre-implementation RFC set; runtime not authorized**
+23. `PHASE19_RUNTIME_DECISION.md` — **Phase-19 Runtime MVP decision package; implementation not authorized**
+24. `docs/specs/phase19-platform-runtime/README.md` — **Phase-19 Runtime MVP active planning/admission/receipt RFC set; runtime not authorized**
 25. `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` — **Phase-19 Runtime RFC set cross-consistency review; runtime not authorized**
-26. `PHASE19_POINTER_TRANSITION_CANDIDATE.md` — **Phase-19 pointer transition candidate; phase pointer not updated**
-27. `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` — **Phase-19 activation preconditions review; Phase-19 not active**
-28. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
-29. `reports/phase15_official_closure/closure_index.json`
-30. `reports/phase13_official_closure_candidate/closure_index.json`
-31. `reports/phase12_official_closure_candidate/closure_manifest.json`
-32. `reports/phase10_phase11_official_closure_index.json`
-33. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
-34. `Makefile`
-35. `.github/workflows/ci-freeze.yml`
+26. `PHASE19_POINTER_TRANSITION_CANDIDATE.md` — **Phase-19 pointer transition candidate; implementation not authorized**
+27. `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` — **Phase-19 activation preconditions review; implementation not authorized**
+28. `PHASE19_POINTER_TRANSITION_DECISION.md` — **Phase-19 pointer transition decision; `CURRENT_PHASE=19`, runtime implementation not authorized**
+29. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
+30. `reports/phase15_official_closure/closure_index.json`
+31. `reports/phase13_official_closure_candidate/closure_index.json`
+32. `reports/phase12_official_closure_candidate/closure_manifest.json`
+33. `reports/phase10_phase11_official_closure_index.json`
+34. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
+35. `Makefile`
+36. `.github/workflows/ci-freeze.yml`
 
 Phase-14 workstream numbering ve aktif durum yorumu icin canonical truth source:
 
@@ -86,7 +87,7 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 
 ## Roadmap and Status Surfaces
 1. `docs/roadmap/README.md`
-2. `docs/roadmap/CURRENT_PHASE` — `CURRENT_PHASE=18`
+2. `docs/roadmap/CURRENT_PHASE` — `CURRENT_PHASE=19`
 3. `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`
 4. `docs/roadmap/freeze-enforcement-workflow.md`
 5. `AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md`
@@ -103,18 +104,19 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 16. `PHASE18_ACTIVATION_DECISION.md` — accepted activation decision package
 17. `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md` — active authority drift review guard
 18. `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md` — accepted terminology audit
-19. `PHASE19_RUNTIME_DECISION.md` — Phase-19 Runtime MVP decision package; not active implementation authority
-20. `docs/specs/phase19-platform-runtime/README.md` — Phase-19 Runtime MVP pre-implementation RFC set; not active implementation authority
+19. `PHASE19_RUNTIME_DECISION.md` — Phase-19 Runtime MVP decision package; not implementation authority
+20. `docs/specs/phase19-platform-runtime/README.md` — Phase-19 Runtime MVP active planning/admission/receipt RFC set; not implementation authority
 21. `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` — Phase-19 Runtime RFC set cross-consistency review; not active implementation authority
-22. `PHASE19_POINTER_TRANSITION_CANDIDATE.md` — Phase-19 pointer transition candidate; not active implementation authority
-23. `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` — Phase-19 activation preconditions review; not active implementation authority
-24. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
-25. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
-26. `docs/specs/phase16-ayken-orchestration/README.md`
-27. `docs/specs/authority-lineage-v1/README.md`
-28. `docs/specs/phase14-distributed-observability/README.md`
-29. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
-30. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
+22. `PHASE19_POINTER_TRANSITION_CANDIDATE.md` — Phase-19 pointer transition candidate; not implementation authority
+23. `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` — Phase-19 activation preconditions review; not implementation authority
+24. `PHASE19_POINTER_TRANSITION_DECISION.md` — Phase-19 pointer transition decision; not implementation authority
+25. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
+26. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
+27. `docs/specs/phase16-ayken-orchestration/README.md`
+28. `docs/specs/authority-lineage-v1/README.md`
+29. `docs/specs/phase14-distributed-observability/README.md`
+30. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
+31. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
 
 ## Phase-18 Reference Set
 1. `PHASE18_TRANSITION_DECISION.md`
@@ -133,10 +135,10 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 
 ## Phase-19 Decision And RFC Set
 1. `PHASE19_RUNTIME_DECISION.md` — Platform Runtime MVP decision boundary;
-   does not activate `CURRENT_PHASE=19` and does not authorize
-   implementation.
+   does not authorize implementation.
 2. `docs/specs/phase19-platform-runtime/README.md` — Phase-19 Runtime MVP
-   pre-implementation RFC set index; does not authorize implementation.
+   active planning/admission/receipt RFC set index; does not authorize
+   implementation.
 3. `docs/specs/phase19-platform-runtime/RUNTIME_LIFECYCLE_SPECIFICATION.md`
 4. `docs/specs/phase19-platform-runtime/RUNTIME_INPUT_BUNDLE_SPECIFICATION.md`
 5. `docs/specs/phase19-platform-runtime/PLATFORM_VALIDATION_INTEGRATION_SPECIFICATION.md`
@@ -145,14 +147,14 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 8. `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_PLAN.md`
 9. `docs/specs/phase19-platform-runtime/RUNTIME_NON_GOALS_AND_DENIALS.md`
 10. `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` —
-    accepted cross-consistency review; does not activate Phase-19 and does
-    not authorize implementation.
+    accepted cross-consistency review; does not authorize implementation.
 11. `PHASE19_POINTER_TRANSITION_CANDIDATE.md` — pointer transition
-    precondition candidate; does not update `CURRENT_PHASE` and does not
-    authorize implementation.
+    precondition candidate; does not authorize implementation.
 12. `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` — activation
-    preconditions review; does not activate Phase-19, update
-    `CURRENT_PHASE`, or authorize implementation.
+    preconditions review; does not authorize implementation.
+13. `PHASE19_POINTER_TRANSITION_DECISION.md` — pointer transition decision;
+    activates `CURRENT_PHASE=19` only as planning/admission/receipt boundary
+    and does not authorize implementation.
 
 ## Phase-14 Reference Set
 ### Architecture and Observability Surfaces
@@ -262,10 +264,11 @@ Asagidaki dosyalar tarihsel snapshot niteligindedir; current truth yerine dogrud
 ## Note
 Eski raporlarda gecen blocker veya progress ifadeleri tarihsel baglam icindir.
 Current status yorumlari icin Phase-17 official closure otoritesi,
-`docs/roadmap/CURRENT_PHASE` ve aktif stabilization roadmap birlikte
-kullanilmalidir. Yeni ozellik veya Phase-18 aktivasyonu,
-`PHASE18_TRANSITION_DECISION.md` ve `PHASE18_ACTIVATION_DECISION.md` review
-edilip explicit `CURRENT_PHASE` transition yapilmadan current execution plani
+`docs/roadmap/CURRENT_PHASE`, `PHASE19_POINTER_TRANSITION_DECISION.md` ve
+aktif stabilization roadmap birlikte kullanilmalidir. Yeni runtime
+implementation, loader, installer, workspace runtime, plugin host, capability
+issuer, trust issuer, Semantic CLI authority veya AI Runtime authority ayri
+implementation decision ve evidence package olmadan current execution plani
 olarak sunulamaz.
 
-**Son Guncelleme:** 2026-06-05
+**Son Guncelleme:** 2026-06-06

--- a/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
+++ b/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
@@ -5,7 +5,7 @@ the freeze contract prevails.
 
 **Status:** ACTIVE EXECUTION ROADMAP
 **Effective date:** 2026-05-23
-**Current phase authority:** `CURRENT_PHASE=18` (Phase-18 active as Platform Constitution only)
+**Current phase authority:** `CURRENT_PHASE=19` (Phase-19 active as Platform Runtime MVP planning/admission/receipt boundary only)
 **Last official closure:** Phase-17 (`phase17-official-closure` at `416a5392`)
 **Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu:** Kenan AY
 **Dijital imza siniri:** Bu atif dokumantasyon metadata'sidir; runtime
@@ -65,19 +65,14 @@ Aktif urun cekirdegi su dort parcadir:
 
 ### 2.3 Urun Olmayan veya Ertelenen Alanlar
 
-Phase-18 aktif pointer'i Platform Constitution ile sinirlidir.
-`PHASE19_RUNTIME_DECISION.md` Phase-19 Runtime MVP karar sinirini tanimlar,
-ancak Phase-19'i aktif etmez ve implementation yetkisi vermez. Ayri Phase-19
-pointer transition'i ve implementation karari olmadan asagidakiler aktif
-implementation backlog'u degildir. `docs/specs/phase19-platform-runtime/`
-pre-implementation RFC seti bu siniri detaylandirir; runtime code veya phase
-activation yetkisi vermez. `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`
-bu RFC setini review eder; PASS sonucu yine activation veya implementation
-authority degildir. `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, daha sonraki
-exact-SHA pointer transition kosullarini tanimlar; `CURRENT_PHASE=19` veya
-implementation authority kurmaz. `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`,
-activation precondition setini review eder; `CURRENT_PHASE=19`, activation
-decision veya implementation authority kurmaz:
+Phase-18 accepted pointer'i Platform Constitution ile sinirlidir.
+`PHASE19_POINTER_TRANSITION_DECISION.md`, `CURRENT_PHASE=19` pointer'ini
+yalniz Platform Runtime MVP planning/admission/receipt boundary olarak
+aktive eder. `PHASE19_RUNTIME_DECISION.md`, Phase-19 Runtime MVP karar
+sinirini tanimlar; `docs/specs/phase19-platform-runtime/` RFC seti bu siniri
+detaylandirir. Phase-19 pointer transition runtime code veya implementation
+authority vermez. Ayri implementation karari olmadan asagidakiler aktif
+implementation backlog'u degildir:
 
 - Yeni syscall veya ABI surface genisletmesi.
 - ARM64/RISC-V/real-hardware feature genisletmesi.
@@ -85,11 +80,12 @@ decision veya implementation authority kurmaz:
   donusturulmesi.
 - Yeni AI orchestration ozellikleri veya model sonucunun authoritative
   execution verdict'i olarak kullanilmasi.
-- Phase-18'in runtime implementation fazi olarak yorumlanmasi.
+- Phase-18'in veya Phase-19 pointer transition'in runtime implementation
+  fazi olarak yorumlanmasi.
 - Trust classification'in capability grant gibi kullanilmasi.
 
 Bu alanlarda belge veya izole arastirma tutulabilir; production merge icin
-Phase-18 Platform Constitution sinirini asamaz.
+Phase-19 planning/admission/receipt sinirini asamaz.
 
 ## 3. Bugunku Repo Gercegi
 
@@ -102,8 +98,8 @@ Phase-18 Platform Constitution sinirini asamaz.
 | Governance | Spec-purity, fail-closed marker isolation, validation matrix ve S2 inventory kabul edildi | #145 tek-maintainer authority paritesiyle giderildi; closure yine ayrik reviewed karardir |
 | Review enforcement | `@kenanay` CODEOWNERS accountability metadata'si ve canli `main` required `freeze` protection'i tek-maintainer ADR'iyle hizalandi | Issue #145 RESOLVED; bagimsiz self-review iddiasi veya closure yetkisi kurulmaz |
 | Performance stability | PR-4 local readiness FAIL tarihsel kayit; PR-4A/PR-4B diagnostic; governed renewal ve workflow authority repair accepted | Accepted `main` SHA `416a5392`: Performance Gate `26715068398` ve scoped Phase-17 acceptance `26712374737` PASS; official tag dogrulandi |
-| Phase-18 | Active as Platform Constitution only | Runtime implementation, loader, installer, workspace runtime, plugin loading, capability issuance ve trust assignment yetkisi yoktur |
-| Phase-19 | Decision/RFC/review/candidate/precondition package only | `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/`, Phase-19 cross-review, `PHASE19_POINTER_TRANSITION_CANDIDATE.md` ve `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` Runtime MVP sinirini tanimlar/review eder; `CURRENT_PHASE=19` veya implementation authority degildir |
+| Phase-18 | Accepted Platform Constitution reference set | Runtime implementation, loader, installer, workspace runtime, plugin loading, capability issuance ve trust assignment yetkisi yoktur |
+| Phase-19 | Active as Platform Runtime MVP planning/admission/receipt boundary only | `PHASE19_POINTER_TRANSITION_DECISION.md`, `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/`, Phase-19 cross-review, `PHASE19_POINTER_TRANSITION_CANDIDATE.md` ve `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` Runtime MVP sinirini kurar; implementation authority degildir |
 
 ## 4. Stratejik Karar: Stabilization-First
 
@@ -118,8 +114,8 @@ Oncelik sirasi:
 4. Module/package/workspace/capability/trust/plugin kontratlarini fail-closed
    tanimlamak.
 5. BCIB/SMP/race validation backlog'unu gorunur tutmak ama ana yon yapmamak.
-6. Phase-18 active pointer'i sonrasi da runtime implementation icin ayri
-   Phase-19 veya reviewed implementation karari.
+6. Phase-19 active pointer'i sonrasi runtime implementation icin ayri
+   reviewed implementation karari ve evidence package.
 
 ## 5. Technical Debt Control Rules
 
@@ -345,19 +341,19 @@ nondeterministic verification verdict'i uretmez.
 
 ### S5 - Phase-18 Platform Constitution Activation
 
-**Status:** ACTIVE AS PLATFORM CONSTITUTION / RUNTIME IMPLEMENTATION NOT AUTHORIZED
+**Status:** ACCEPTED PLATFORM CONSTITUTION REFERENCE SET / RUNTIME IMPLEMENTATION NOT AUTHORIZED
 
 Phase-17 closure precondition'lari saglanmistir ve Phase-18 yalniz Platform
-Constitution olarak aktiftir. Phase-18 authority zinciri
+Constitution reference set olarak korunur. Phase-18 authority zinciri
 `PHASE18_TRANSITION_DECISION.md`, Phase-18 RFC seti,
 `CROSS_CONSISTENCY_REVIEW.md`, `PHASE18_ACTIVATION_DECISION.md` ve
-`CURRENT_PHASE=18` pointer'i ile sinirlidir. Post-activation maintenance
+`CURRENT_PHASE=18` pointer decision record'u ile sinirlidir. Post-activation maintenance
 `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md` ve
 `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md` ile review
 edilir. Eski `PHASE18_ROADMAP.md` tarihsel runtime-validation backlog'u
 olarak tutulur.
 
-Phase-18 active scope su kararlari korumadan implementation planina
+Phase-18 accepted scope su kararlari korumadan implementation planina
 donusemez:
 
 1. Phase-18 = Platform Constitution.
@@ -367,7 +363,8 @@ donusemez:
 5. AI Runtime authority forbidden.
 6. Kernel ABI ile Platform ABI ayrimi acik.
 7. Trust level capability grant degildir.
-8. `CURRENT_PHASE=18` yalniz Platform Constitution authority kurar.
+8. `CURRENT_PHASE=18` yalniz Platform Constitution authority kurmustur;
+   `CURRENT_PHASE=19` bu Constitution'i runtime implementation'a donusturmez.
 9. Module Manifest, Capability Contract, Workspace Lifecycle, Package Metadata,
    Trust Classification, Plugin Boundary ve Platform ABI Validation Gate
    spec'leri fail-closed olarak review edilmeden implementation phase baslamaz.
@@ -386,19 +383,20 @@ donusemez:
     `compatible`, `binding`, `receipt`, `loader` ve `runtime` terimleri
     runtime authority olarak okunamaz.
 
-### S6 - Phase-19 Runtime Decision, RFC, Pointer Candidate and Preconditions Package
+### S6 - Phase-19 Platform Runtime MVP Planning Boundary
 
-**Status:** DECISION + PRE-IMPLEMENTATION RFC SET + CROSS-REVIEW + POINTER CANDIDATE + PRECONDITION REVIEW / PHASE-19 NOT ACTIVE / IMPLEMENTATION NOT AUTHORIZED
+**Status:** ACTIVE AS PLANNING / VALIDATION-INTEGRATION / ADMISSION-RECORD / RECEIPT BOUNDARY / IMPLEMENTATION NOT AUTHORIZED
 
-Phase-19 icin authority adayi `PHASE19_RUNTIME_DECISION.md` olarak
-kaydedilir. Bu belge Platform Runtime MVP'nin ne oldugunu ve ne olmadigini
-tanimlar; `CURRENT_PHASE=19` pointer transition'i, runtime source code,
+Phase-19 pointer transition `PHASE19_POINTER_TRANSITION_DECISION.md` ile
+kaydedilir. Bu karar `docs/roadmap/CURRENT_PHASE` pointer'ini `19` yapar,
+ancak yalniz Platform Runtime MVP planning, validation-integration,
+admission-record ve receipt-boundary authority kurar. Runtime source code,
 package installer, module loader, workspace runtime, plugin host, capability
 issuer, trust issuer, Semantic CLI authority veya AI Runtime authority
 kurmaz.
 
-Pre-implementation RFC seti `docs/specs/phase19-platform-runtime/` altinda
-acilir. Bu set runtime lifecycle, static input bundle, Platform ABI validation
+Runtime RFC seti `docs/specs/phase19-platform-runtime/` altinda aktiftir. Bu
+set runtime lifecycle, static input bundle, Platform ABI validation
 integration, workspace admission record, runtime receipt, evidence plan ve
 non-goal/denial sinirlarini tanimlar; parser, loader, installer, workspace
 runtime, plugin host, issuer, trust assignment veya execution authority
@@ -409,14 +407,13 @@ state, validation, admission, receipt, evidence ve denial sinirlarini capraz
 review eder. Bu review PASS sonucu Phase-19 pointer transition, runtime
 implementation veya closure authority kurmaz.
 
-`PHASE19_POINTER_TRANSITION_CANDIDATE.md`, daha sonraki exact-SHA
-`CURRENT_PHASE=19` pointer transition PR'i icin kosullari tanimlar. Bu aday
-belge pointer'i degistirmez ve runtime implementation yetkisi vermez.
+`PHASE19_POINTER_TRANSITION_CANDIDATE.md`, exact-SHA `CURRENT_PHASE=19`
+pointer transition PR'i icin kosullari tanimlayan accepted candidate kaydidir.
+Bu aday belge runtime implementation yetkisi vermez.
 
 `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, karar, RFC seti, cross-review ve
 pointer candidate zincirinin activation oncesi precondition setini review
-eder. Bu review PASS sonucu activation decision, pointer transition,
-`CURRENT_PHASE=19` veya runtime implementation authority kurmaz.
+eder. Bu review PASS sonucu runtime implementation authority kurmaz.
 
 Phase-19 karar siniri su kurallari korur:
 
@@ -428,20 +425,21 @@ Phase-19 karar siniri su kurallari korur:
    akisi install/load/mount/execute/issue/trust yapmaz.
 4. Phase-19 runtime RFC seti implementation authority degildir; ayri
    implementation karari olmadan PR acilmaz.
-5. `CURRENT_PHASE=19` ancak ayri exact-SHA pointer transition karariyla
-   degerlendirilebilir.
+5. `CURRENT_PHASE=19` yalniz exact-SHA pointer transition karariyla planning,
+   validation-integration, admission-record ve receipt-boundary authority
+   kurar.
 6. Kernel ABI `1000-1011` / 12 syscall / `0x00010001` olarak frozen kalir.
 7. Phase-20 registry/capability ecosystem, Phase-21 Semantic CLI, Phase-22 AI
    Runtime ve Phase-23+ agent sistemleri Phase-19 MVP'ye cekilemez.
 8. Phase-19 cross-review, pointer transition ve implementation karari
-   ayridir; review PASS tek basina `CURRENT_PHASE=19` yapmaz.
+   ayridir; review PASS tek basina implementation authority kurmaz.
 9. Every runtime artifact must be inert: input bundle, validation receipt,
    workspace admission record ve runtime receipt davranis, izin, loader,
    mount, execution, token, trust veya capability uretmez.
-10. Pointer transition candidate, pointer transition degildir; `CURRENT_PHASE`
-    yalniz ayri exact-SHA PR ile degistirilebilir.
-11. Activation preconditions review, activation decision degildir; pointer
-    transition ve implementation halen ayri exact-SHA karar gerektirir.
+10. Pointer transition candidate, pointer transition degildir; actual pointer
+    authority `PHASE19_POINTER_TRANSITION_DECISION.md` ile sinirlidir.
+11. Activation preconditions review, implementation decision degildir;
+    implementation halen ayri exact-SHA karar gerektirir.
 
 ## 7. PR Sequence and Coordination Matrix
 
@@ -475,11 +473,12 @@ Phase-19 karar siniri su kurallari korur:
 | Phase-18 Activation Decision Package | ACCEPTED / PLATFORM CONSTITUTION ACTIVE | Phase-18 aktivasyonu icin precondition, exact-SHA, fail-closed denial ve Constitution != Runtime sinirlarini kaydetmek | `PHASE18_ACTIVATION_DECISION.md` | Activation runtime implementation, capability issuance, trust assignment, workspace creation veya plugin loading yetkisi vermez |
 | Phase-18 Authority Drift Guard | ACTIVE REVIEW GUARD / DOCS-ONLY | Phase-18 aktifken constitutional text'in runtime, loader, issuer, workspace, plugin, trust, capability veya AI/Semantic authority'ye kaymasini fail-closed review etmek | `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md` | Guard runtime implementation, CI gate, merge authority, Phase-19 activation veya authority grant degildir |
 | Phase-18 Terminology Audit | ACCEPTED AUDIT / DOCS-ONLY | High-risk Phase-18 vocabulary'nin safe meaning, required qualifier ve forbidden reading sinirlarini kaydetmek | `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md` | Audit PASS runtime implementation, loader, issuer, token, mount, execution veya Phase-19 authority grant degildir |
-| Phase-19 Runtime Decision Package | DECISION PACKAGE / PHASE-19 NOT ACTIVE | Platform Runtime MVP'nin decision boundary, non-goal, RFC precondition ve fail-closed denial kosullarini kaydetmek | `PHASE19_RUNTIME_DECISION.md` | Package `CURRENT_PHASE=19`, runtime implementation, loader, installer, workspace runtime, capability issuer, trust issuer, Semantic CLI authority veya AI Runtime authority grant degildir |
-| Phase-19 Runtime RFC Set | PRE-IMPLEMENTATION RFC SET / PHASE-19 NOT ACTIVE | Runtime lifecycle, input bundle, validation integration, workspace admission record, receipt, evidence plan ve denial sinirlarini docs-only tanimlamak | `docs/specs/phase19-platform-runtime/README.md` | RFC set parser, runtime implementation, loader, installer, workspace runtime, capability issuer, trust issuer, Semantic CLI authority, AI Runtime authority veya `CURRENT_PHASE=19` grant degildir |
-| Phase-19 Runtime Cross-Consistency Review | ACCEPTED REVIEW / PHASE-19 NOT ACTIVE | Runtime RFC setinin lifecycle, input bundle, validation integration, workspace admission, receipt, evidence ve denial sinirlarinin celismedigini kaydetmek | `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` | Review PASS `CURRENT_PHASE=19`, runtime implementation, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
-| Phase-19 Pointer Transition Candidate | CANDIDATE / PHASE-19 NOT ACTIVE | Daha sonraki exact-SHA `CURRENT_PHASE=19` pointer transition kosullarini ve inert runtime artifact invariant'ini kaydetmek | `PHASE19_POINTER_TRANSITION_CANDIDATE.md` | Candidate `CURRENT_PHASE=19`, activation, runtime implementation, parser, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
-| Phase-19 Activation Preconditions Review | PRECONDITION REVIEW / PHASE-19 NOT ACTIVE | Decision/RFC/cross-review/pointer-candidate zincirinin activation oncesi precondition setini review etmek | `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` | Review PASS `CURRENT_PHASE=19`, activation decision, pointer transition, runtime implementation, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
+| Phase-19 Runtime Decision Package | DECISION PACKAGE / PLANNING BOUNDARY ACTIVE | Platform Runtime MVP'nin decision boundary, non-goal, RFC precondition ve fail-closed denial kosullarini kaydetmek | `PHASE19_RUNTIME_DECISION.md` | Package runtime implementation, loader, installer, workspace runtime, capability issuer, trust issuer, Semantic CLI authority veya AI Runtime authority grant degildir |
+| Phase-19 Runtime RFC Set | ACTIVE RFC SET / IMPLEMENTATION NOT AUTHORIZED | Runtime lifecycle, input bundle, validation integration, workspace admission record, receipt, evidence plan ve denial sinirlarini docs-only tanimlamak | `docs/specs/phase19-platform-runtime/README.md` | RFC set parser, runtime implementation, loader, installer, workspace runtime, capability issuer, trust issuer, Semantic CLI veya AI Runtime authority grant degildir |
+| Phase-19 Runtime Cross-Consistency Review | ACCEPTED REVIEW / IMPLEMENTATION NOT AUTHORIZED | Runtime RFC setinin lifecycle, input bundle, validation integration, workspace admission, receipt, evidence ve denial sinirlarinin celismedigini kaydetmek | `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` | Review PASS runtime implementation, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
+| Phase-19 Pointer Transition Candidate | ACCEPTED CANDIDATE / SUPERSEDED BY DECISION | Exact-SHA `CURRENT_PHASE=19` pointer transition kosullarini ve inert runtime artifact invariant'ini kaydetmek | `PHASE19_POINTER_TRANSITION_CANDIDATE.md` | Candidate runtime implementation, parser, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
+| Phase-19 Activation Preconditions Review | ACCEPTED PRECONDITION REVIEW / SUPERSEDED BY DECISION | Decision/RFC/cross-review/pointer-candidate zincirinin activation oncesi precondition setini review etmek | `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` | Review PASS runtime implementation, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
+| Phase-19 Pointer Transition Decision | CURRENT_PHASE=19 / IMPLEMENTATION NOT AUTHORIZED | Phase-19'i yalniz Runtime MVP planning, validation-integration, admission-record ve receipt-boundary olarak aktive etmek | `PHASE19_POINTER_TRANSITION_DECISION.md`, `docs/roadmap/CURRENT_PHASE` | Pointer transition runtime implementation, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
 
 PR koordinasyon kurallari:
 
@@ -1175,7 +1174,8 @@ Bu roadmap su olaylarda guncellenir:
 32. Phase-19 Runtime Cross-Consistency Review sonucu.
 33. Phase-19 Pointer Transition Candidate review/merge sonucu.
 34. Phase-19 Activation Preconditions Review sonucu.
-35. Yeni feature/ABI/authority surface onerisinin incelenmesi.
+35. Phase-19 Pointer Transition Decision sonucu.
+36. Yeni feature/ABI/authority surface onerisinin incelenmesi.
 
 ## References
 
@@ -1218,6 +1218,7 @@ Bu roadmap su olaylarda guncellenir:
 - `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`
 - `PHASE19_POINTER_TRANSITION_CANDIDATE.md`
 - `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`
+- `PHASE19_POINTER_TRANSITION_DECISION.md`
 - `PHASE18_ROADMAP.md`
 - `shared/abi/syscall_v2.h`
 - `shared/abi/ayken_abi.h`

--- a/docs/roadmap/CURRENT_PHASE
+++ b/docs/roadmap/CURRENT_PHASE
@@ -1,11 +1,13 @@
-CURRENT_PHASE=18
-# Status authority synchronized: 2026-06-05 (Phase-18 Platform Constitution pointer transition)
+CURRENT_PHASE=19
+# Status authority synchronized: 2026-06-06 (Phase-19 pointer transition decision)
 # Phase-16 OFFICIALLY CLOSED - 2026-04-25 - tag: phase16-official-closure
 # Phase-17 OFFICIALLY CLOSED - 2026-05-31 - tag: phase17-official-closure at 416a5392.
 # Phase-17 closure evidence remains bounded to the reviewed exact-SHA runtime/QEMU, freeze, and performance runs.
-# Phase-18 is ACTIVE as Platform Constitution only, not as runtime implementation.
-# Phase-18 direction: Platform Constitution, not kernel expansion.
+# Phase-18 remains the accepted Platform Constitution reference set.
+# Phase-19 is ACTIVE only as Platform Runtime MVP planning, validation-integration, admission-record, and receipt-boundary phase.
+# CURRENT_PHASE=19 does not authorize runtime implementation.
+# Runtime source code, loader, installer, workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI authority, AI Runtime authority, new syscall, kernel ABI expansion, and Ring0 policy remain unauthorized.
 # Active execution roadmap: docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
 # Remote evidence: ci-freeze 26712333892, Performance Gate 26715068398, Phase-17 lifecycle/determinism/public-e2e/worker/timeout/performance lanes all PASS on 416a5392.
-# Immediate work package: maintain Phase-18 Platform Constitution authority; Phase-19 activation preconditions review is not pointer transition, and any pointer transition remains a separate exact-SHA decision.
+# Immediate work package: maintain Phase-19 planning/admission/receipt authority boundary; any runtime implementation remains a separate reviewed decision and evidence package.
 # Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu: Kenan AY (informational metadata only).

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -2,7 +2,7 @@
 This document is subordinate to `ARCHITECTURE_FREEZE.md`. In case of conflict,
 the freeze contract prevails.
 
-**Last authority sync:** 2026-06-05 (Phase-19 Activation Preconditions Review)
+**Last authority sync:** 2026-06-06 (Phase-19 Pointer Transition Decision)
 **Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu:** Kenan AY
 **Attribution boundary:** Documentation metadata only; not runtime or merge authority.
 
@@ -12,7 +12,7 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 ## Current Authority Chain
 
 1. `../../ARCHITECTURE_FREEZE.md`: frozen mimari invariants ve merge siniri.
-2. `CURRENT_PHASE`: formal aktif faz pointer'i (`CURRENT_PHASE=18`).
+2. `CURRENT_PHASE`: formal aktif faz pointer'i (`CURRENT_PHASE=19`).
 3. `CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`: aktif execution
    roadmap; kapsam daraltma, technical debt kontrolu ve PR sirasi.
 4. `../../AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md`: mevcut changeset ve
@@ -54,20 +54,22 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
    accepted Phase-18 terminology audit; high-risk vocabulary icin runtime
    authority kurmaz.
 18. `../../PHASE19_RUNTIME_DECISION.md`: Phase-19 Platform Runtime MVP
-   decision package; phase pointer transition veya implementation authority
-   degildir.
+   decision package; implementation authority degildir.
 19. `../specs/phase19-platform-runtime/README.md`: Phase-19 Runtime MVP
-   pre-implementation RFC set; runtime implementation authority degildir.
+   active planning/admission/receipt RFC set; runtime implementation authority
+   degildir.
 20. `../specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`:
-   Phase-19 Runtime RFC set capraz tutarlilik review kaydi; phase pointer
-   transition veya runtime implementation yetkisi degildir.
+   Phase-19 Runtime RFC set capraz tutarlilik review kaydi; runtime
+   implementation yetkisi degildir.
 21. `../../PHASE19_POINTER_TRANSITION_CANDIDATE.md`: Phase-19 pointer
-   transition kosullarini tanimlayan candidate kaydi; `CURRENT_PHASE=19`
-   veya implementation authority degildir.
+   transition kosullarini tanimlayan accepted candidate kaydi; implementation
+   authority degildir.
 22. `../../PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`: Phase-19 activation
-   precondition review kaydi; activation, pointer transition veya
-   implementation authority degildir.
-23. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
+   precondition review kaydi; implementation authority degildir.
+23. `../../PHASE19_POINTER_TRANSITION_DECISION.md`: `CURRENT_PHASE=19`
+   pointer transition decision; yalniz planning/admission/receipt boundary
+   kurar, runtime implementation authority degildir.
+24. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
    planlamasi; aktif Phase-18 otoritesi degildir.
 
 ## Current Status
@@ -75,16 +77,19 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 | Konu | Durum |
 |---|---|
 | Son resmi kapanis | Phase-17 OFFICIALLY CLOSED (`phase17-official-closure` at `416a5392`) |
-| Aktif faz | Phase-18 ACTIVE / Platform Constitution only |
-| Aktif odak | Phase-18 Platform Constitution authority maintenance; runtime implementation remains out of scope |
-| Aday sonraki karar | Phase-19 Platform Runtime MVP decision/RFC/review/candidate/precondition set; `CURRENT_PHASE=19` veya implementation authority degildir |
+| Aktif faz | Phase-19 ACTIVE / Platform Runtime MVP planning, admission, and receipt boundary only |
+| Aktif odak | Phase-19 planning/admission/receipt authority maintenance; runtime implementation remains out of scope |
+| Aday sonraki karar | Phase-19 runtime implementation decision package; source code remains unauthorized until a separate exact-SHA decision |
 | ABI | Canonical `1000-1011` / 12 syscall, ABI version `0x00010001` |
-| Phase-18 | ACTIVE AS PLATFORM CONSTITUTION; kernel expansion, runtime implementation and new syscalls forbidden unless a separate phase RFC/closure authority exists |
+| Phase-18 | ACCEPTED PLATFORM CONSTITUTION REFERENCE SET; kernel expansion, runtime implementation and new syscalls forbidden unless a separate phase RFC/closure authority exists |
+| Phase-19 | ACTIVE AS PLANNING / VALIDATION-INTEGRATION / ADMISSION-RECORD / RECEIPT BOUNDARY; implementation forbidden until a separate decision |
 
 ## Active Execution Rule
 
 Phase-17 resmi kapanis tag'i `416a5392` uzerinde uretilip dogrulanmistir.
-Phase-18 aktif pointer'i yalniz Platform Constitution kapsamindadir.
+Phase-18 accepted pointer'i yalniz Platform Constitution kapsamindadir.
+`CURRENT_PHASE=19` yalniz Platform Runtime MVP planning,
+validation-integration, admission-record ve receipt-boundary kapsamindadir.
 Production roadmap'e yeni syscall, kernel ABI genislemesi, Ring0 policy,
 runtime loader, package installer, workspace runtime, plugin loading,
 capability issuer, trust issuer, authority-genisleten observability veya AI
@@ -92,8 +97,11 @@ orchestration isi alinmaz. Bounded runtime/QEMU lanes, strict `ci-freeze`,
 standalone locked Performance Gate ve scoped Phase-17 performance acceptance
 accepted `main` SHA `416a5392` uzerinde PASS vermistir. Bu closure, genis
 BCIB semantic/race/SMP kapsami veya Phase-19 runtime implementation kurmaz.
-Phase-18'in active direction'i Platform Constitution'dir: module/package,
-workspace, capability, trust classification ve plugin boundary kontratlari.
+Phase-18 reference direction'i Platform Constitution'dir:
+module/package/workspace, capability, trust classification ve plugin boundary
+kontratlari. Phase-19 active direction'i inert input bundle, validation
+integration, workspace admission record ve deterministic runtime receipt
+siniridir.
 
 ## Historical References
 
@@ -108,9 +116,9 @@ current execution priority otoritesi degildir:
 
 ---
 
-**Next action:** `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` Phase-19
-activation precondition setini review eder; `CURRENT_PHASE=19`, activation
-decision veya runtime implementation yetkisi vermez. Siradaki
-authority-changing is ancak ayri exact-SHA Phase-19 pointer transition PR'i
-olabilir. High-risk vocabulary `TERMINOLOGY_AUDIT.md` kaydina gore
+**Next action:** Phase-19 runtime implementation karar paketi ancak ayri
+exact-SHA PR ve evidence plan ile degerlendirilebilir. `CURRENT_PHASE=19`
+runtime source code, loader, installer, workspace runtime, plugin host,
+capability issuer, trust issuer, Semantic CLI authority veya AI Runtime
+authority vermez. High-risk vocabulary `TERMINOLOGY_AUDIT.md` kaydina gore
 denetlenir.

--- a/docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md
+++ b/docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md
@@ -4,10 +4,11 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
 `ARCHITECTURE_FREEZE.md`, `PHASE18_TRANSITION_DECISION.md`,
 `PHASE18_ACTIVATION_DECISION.md`, the Phase-18 Platform Constitution
 reference set, `AUTHORITY_DRIFT_GUARD.md`, `TERMINOLOGY_AUDIT.md`,
-`PHASE19_RUNTIME_DECISION.md`, and the Phase-19 Runtime RFC set. In case of
-conflict, those documents prevail.
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set, and
+`../../../PHASE19_POINTER_TRANSITION_DECISION.md`. In case of conflict, those
+documents prevail.
 
-**Status:** ACCEPTED REVIEW / PHASE-19 NOT ACTIVE / RUNTIME NOT AUTHORIZED
+**Status:** ACCEPTED REVIEW / PHASE-19 ACTIVE AS PLANNING BOUNDARY / RUNTIME IMPLEMENTATION NOT AUTHORIZED
 **Review date:** 2026-06-05
 **Review id:** `ayken.phase19.runtime.cross_consistency.review.v1`
 **Authority boundary:** Documentation/review record only; not
@@ -25,18 +26,19 @@ Do the Phase-19 Platform Runtime RFCs define a coherent deterministic
 admission/receipt MVP boundary without contradicting the active Phase-18
 Platform Constitution or widening the frozen kernel execution substrate?
 
-This document does not activate Phase-19. It records cross-document
-consistency findings that may be used by a later pointer-transition or
-implementation decision package.
+This document did not activate Phase-19 by itself. It records cross-document
+consistency findings that are now used by
+`PHASE19_POINTER_TRANSITION_DECISION.md` as an accepted input for the
+`CURRENT_PHASE=19` planning boundary.
 
-A later `PHASE19_POINTER_TRANSITION_CANDIDATE.md` may use this review as a
-precondition input. That candidate remains separate from a real
-`CURRENT_PHASE=19` pointer transition.
+`PHASE19_POINTER_TRANSITION_CANDIDATE.md` used this review as a precondition
+input. The later real `CURRENT_PHASE=19` pointer transition remains separate
+from runtime implementation.
 
-A later `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` may use this review and
-the pointer transition candidate as inputs to check whether activation
-preconditions are documented. That review remains separate from activation,
-pointer transition, and implementation authority.
+`PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` used this review and the pointer
+transition candidate as inputs to check whether activation preconditions were
+documented. That review remains separate from runtime implementation
+authority.
 
 ## Reviewed Inputs
 
@@ -57,12 +59,10 @@ The reviewed Phase-19 planning set is:
 **Verdict:** PASS
 
 No pointer-transition-blocking contradiction is identified across the reviewed
-RFC set. The documents consistently preserve `CURRENT_PHASE=18`, keep
-Phase-19 as planning only, and constrain the future MVP to an inert
-userspace admission/receipt pipeline.
+RFC set. The documents consistently constrain Phase-19 to planning only and
+preserve the future MVP as an inert userspace admission/receipt pipeline.
 
-This PASS is a review finding only. It does not authorize implementation and
-does not make Phase-19 active.
+This PASS is a review finding only. It does not authorize implementation.
 
 ## Core Consistency Finding
 
@@ -87,7 +87,7 @@ consistent with the Phase-18 Platform Constitution terminology audit.
 
 | Check | Finding | Result |
 |---|---|---|
-| Current phase pointer | Reviewed files preserve `CURRENT_PHASE=18` until a separate exact-SHA pointer transition exists | PASS |
+| Current phase pointer | Reviewed files preserved `CURRENT_PHASE=18` until the separate exact-SHA pointer transition decision | PASS |
 | Frozen syscall surface | Reviewed files preserve `1000-1011` / 12 syscall / ABI version `0x00010001` | PASS |
 | Kernel expansion | No reviewed RFC authorizes a new syscall, Ring0 policy, kernel loader, or kernel ABI expansion | PASS |
 | Runtime authority | No reviewed RFC authorizes runtime source code, package installation, module loading, workspace runtime, plugin loading, capability issuance, trust assignment, Semantic CLI authority, AI Runtime authority, registry, or agents | PASS |
@@ -127,7 +127,7 @@ This chain is internally coherent:
 
 | Contract | Positive scope | Explicit non-authority boundary | Review result |
 |---|---|---|---|
-| Runtime Decision | Defines the safe Platform Runtime MVP planning boundary | Does not activate Phase-19 or authorize implementation | PASS |
+| Runtime Decision | Defines the safe Platform Runtime MVP planning boundary | Does not authorize implementation | PASS |
 | Runtime RFC Set README | Indexes lifecycle, input, validation, admission, receipt, evidence, and denial RFCs | Does not grant runtime source code or `CURRENT_PHASE=19` | PASS |
 | Runtime Lifecycle | Defines deterministic admission/receipt states and transitions | Lifecycle states do not install, load, mount, execute, issue, trust, or grant authority | PASS |
 | Runtime Input Bundle | Defines static digest-bound input references | Bundle is not a parser, installer, loader, execution request, token request, or workspace creation request | PASS |

--- a/docs/specs/phase19-platform-runtime/PLATFORM_VALIDATION_INTEGRATION_SPECIFICATION.md
+++ b/docs/specs/phase19-platform-runtime/PLATFORM_VALIDATION_INTEGRATION_SPECIFICATION.md
@@ -1,11 +1,12 @@
 # Phase-19 Platform Validation Integration Specification
 
 This document is subordinate to `PHASE19_RUNTIME_DECISION.md`,
+`../../../PHASE19_POINTER_TRANSITION_DECISION.md`,
 `RUNTIME_INPUT_BUNDLE_SPECIFICATION.md`, and
 `../phase18-platform-constitution/PLATFORM_ABI_VALIDATION_GATE.md`. In case
 of conflict, those documents prevail.
 
-**Status:** PRE-IMPLEMENTATION RFC / PHASE-19 NOT ACTIVE / RUNTIME NOT AUTHORIZED
+**Status:** ACTIVE RFC / RUNTIME IMPLEMENTATION NOT AUTHORIZED
 **Contract id:** `ayken.phase19.platform_validation.integration.v1`
 **Authority boundary:** Documentation/specification only; not a validator
 implementation, runtime implementation, installer, loader, issuer, trust

--- a/docs/specs/phase19-platform-runtime/README.md
+++ b/docs/specs/phase19-platform-runtime/README.md
@@ -3,28 +3,31 @@
 This directory is subordinate to PHASE 0 - FOUNDATIONAL OATH,
 `ARCHITECTURE_FREEZE.md`, `PHASE18_TRANSITION_DECISION.md`,
 `PHASE18_ACTIVATION_DECISION.md`, the Phase-18 Platform Constitution
-reference set, `AUTHORITY_DRIFT_GUARD.md`, `TERMINOLOGY_AUDIT.md`, and
-`PHASE19_RUNTIME_DECISION.md`. In case of conflict, those documents prevail.
+reference set, `AUTHORITY_DRIFT_GUARD.md`, `TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, and
+`../../../PHASE19_POINTER_TRANSITION_DECISION.md`. In case of conflict, those
+documents prevail.
 
-**Status:** PRE-IMPLEMENTATION RFC SET / PHASE-19 NOT ACTIVE / RUNTIME NOT AUTHORIZED
-**Authority basis:** `PHASE19_RUNTIME_DECISION.md`
+**Status:** ACTIVE PHASE-19 RFC SET / RUNTIME IMPLEMENTATION NOT AUTHORIZED
+**Authority basis:** `PHASE19_RUNTIME_DECISION.md` and
+`../../../PHASE19_POINTER_TRANSITION_DECISION.md`
 **Attribution:** Documentation metadata only; not runtime, merge, or execution
 authority.
 
 ## Purpose
 
-This directory defines the first Phase-19 Platform Runtime MVP RFC set.
+This directory defines the active Phase-19 Platform Runtime MVP RFC set.
 
 The set narrows the future runtime implementation question before any runtime
 source code exists. It defines lifecycle, static input bundle, validation
 integration, workspace admission record, runtime receipt, evidence plan, and
 non-goal boundaries.
 
-It does not activate Phase-19. It does not update `CURRENT_PHASE`. It does not
-authorize package installation, module loading, workspace creation, real
-filesystem mounts, plugin loading, capability issuance, trust assignment,
-Semantic CLI authority, AI Runtime authority, new syscalls, or kernel ABI
-expansion.
+`CURRENT_PHASE=19` activates this planning/admission/receipt boundary only.
+It does not authorize package installation, module loading, workspace
+creation, real filesystem mounts, plugin loading, capability issuance, trust
+assignment, Semantic CLI authority, AI Runtime authority, new syscalls, kernel
+ABI expansion, or runtime implementation.
 
 ## Current RFCs
 
@@ -47,28 +50,33 @@ expansion.
 
 `CROSS_CONSISTENCY_REVIEW.md` records the accepted cross-document review for
 the Phase-19 Runtime RFC set. The review PASS is documentation evidence only.
-It does not activate Phase-19, update `CURRENT_PHASE`, or authorize runtime
-implementation.
+It does not authorize runtime implementation.
 
 `../../../PHASE19_POINTER_TRANSITION_CANDIDATE.md` records the later pointer
-transition preconditions. It is a candidate record only; it does not activate
-Phase-19, update `CURRENT_PHASE`, or authorize runtime implementation.
+transition preconditions. It is a candidate record only; it does not authorize
+runtime implementation.
 
 `../../../PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` records the review of
 documented activation preconditions. It is not an activation decision; it does
-not activate Phase-19, update `CURRENT_PHASE`, or authorize runtime
-implementation.
+not authorize runtime implementation.
+
+`../../../PHASE19_POINTER_TRANSITION_DECISION.md` records the phase pointer
+transition to `CURRENT_PHASE=19`. That transition activates only this
+documented Runtime MVP planning, validation-integration, admission-record, and
+receipt-boundary phase. It does not authorize runtime implementation.
 
 ## Core Rule
 
 ```text
 Runtime RFC set != runtime implementation
+CURRENT_PHASE=19 != runtime implementation
 ```
 
-The existence of these RFCs means only that the Phase-19 Runtime MVP boundary
-is documented for later review. A separate exact-SHA pointer transition,
-implementation RFC acceptance, runtime evidence implementation, and remote CI
-authority remain required before any runtime code can be accepted.
+The existence of these RFCs and the `CURRENT_PHASE=19` pointer means only that
+the Phase-19 Runtime MVP boundary is active as planning authority. A separate
+implementation decision, implementation RFC acceptance, runtime evidence
+implementation, and remote CI authority remain required before any runtime
+code can be accepted.
 
 ## MVP Boundary
 
@@ -88,20 +96,19 @@ schedule anything.
 
 No file in this directory may grant:
 
-1. `CURRENT_PHASE=19`.
-2. Runtime source code authority.
-3. Package installation or execution.
-4. Module loading.
-5. Plugin loading or instantiation.
-6. Workspace creation or real mounts.
-7. Capability token minting or issuance.
-8. Trust assignment.
-9. Registry publication.
-10. Semantic CLI execution authority.
-11. AI Runtime authority.
-12. Agent authority.
-13. New syscalls.
-14. Kernel ABI expansion.
-15. Ring0 policy.
+1. Runtime source code authority.
+2. Package installation or execution.
+3. Module loading.
+4. Plugin loading or instantiation.
+5. Workspace creation or real mounts.
+6. Capability token minting or issuance.
+7. Trust assignment.
+8. Registry publication.
+9. Semantic CLI execution authority.
+10. AI Runtime authority.
+11. Agent authority.
+12. New syscalls.
+13. Kernel ABI expansion.
+14. Ring0 policy.
 
 Unknown authority readings fail closed.

--- a/docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_PLAN.md
+++ b/docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_PLAN.md
@@ -1,9 +1,10 @@
 # Phase-19 Runtime Evidence Plan
 
-This document is subordinate to `PHASE19_RUNTIME_DECISION.md` and the Phase-19
-Runtime RFC set. In case of conflict, those documents prevail.
+This document is subordinate to `PHASE19_RUNTIME_DECISION.md`,
+`../../../PHASE19_POINTER_TRANSITION_DECISION.md`, and the Phase-19 Runtime
+RFC set. In case of conflict, those documents prevail.
 
-**Status:** PRE-IMPLEMENTATION RFC / PHASE-19 NOT ACTIVE / RUNTIME NOT AUTHORIZED
+**Status:** ACTIVE RFC / RUNTIME IMPLEMENTATION NOT AUTHORIZED
 **Contract id:** `ayken.phase19.runtime.evidence_plan.v1`
 **Authority boundary:** Documentation/specification only; not a CI gate
 implementation, runtime implementation, loader, installer, workspace runtime,
@@ -13,7 +14,8 @@ syscall, kernel ABI expansion, or closure authority.
 ## Purpose
 
 This plan defines the evidence that a later Phase-19 Runtime MVP
-implementation must produce before activation or acceptance can be considered.
+implementation must produce before implementation acceptance can be
+considered.
 
 It does not implement any evidence gate.
 

--- a/docs/specs/phase19-platform-runtime/RUNTIME_INPUT_BUNDLE_SPECIFICATION.md
+++ b/docs/specs/phase19-platform-runtime/RUNTIME_INPUT_BUNDLE_SPECIFICATION.md
@@ -1,10 +1,11 @@
 # Phase-19 Runtime Input Bundle Specification
 
 This document is subordinate to `PHASE19_RUNTIME_DECISION.md`,
+`../../../PHASE19_POINTER_TRANSITION_DECISION.md`,
 `RUNTIME_LIFECYCLE_SPECIFICATION.md`, and the Phase-18 Platform Constitution
 reference set. In case of conflict, those documents prevail.
 
-**Status:** PRE-IMPLEMENTATION RFC / PHASE-19 NOT ACTIVE / RUNTIME NOT AUTHORIZED
+**Status:** ACTIVE RFC / RUNTIME IMPLEMENTATION NOT AUTHORIZED
 **Contract id:** `ayken.phase19.runtime.input_bundle.v1`
 **Authority boundary:** Documentation/specification only; not a parser,
 installer, loader, workspace creator, mount engine, plugin host, issuer,

--- a/docs/specs/phase19-platform-runtime/RUNTIME_LIFECYCLE_SPECIFICATION.md
+++ b/docs/specs/phase19-platform-runtime/RUNTIME_LIFECYCLE_SPECIFICATION.md
@@ -1,10 +1,10 @@
 # Phase-19 Runtime Lifecycle Specification
 
-This document is subordinate to `PHASE19_RUNTIME_DECISION.md` and the
-Phase-18 Platform Constitution reference set. In case of conflict, those
-documents prevail.
+This document is subordinate to `PHASE19_RUNTIME_DECISION.md`,
+`../../../PHASE19_POINTER_TRANSITION_DECISION.md`, and the Phase-18 Platform
+Constitution reference set. In case of conflict, those documents prevail.
 
-**Status:** PRE-IMPLEMENTATION RFC / PHASE-19 NOT ACTIVE / RUNTIME NOT AUTHORIZED
+**Status:** ACTIVE RFC / RUNTIME IMPLEMENTATION NOT AUTHORIZED
 **Contract id:** `ayken.phase19.runtime.lifecycle.v1`
 **Authority boundary:** Documentation/specification only; not runtime source
 code, scheduler policy, package installer, module loader, workspace runtime,
@@ -17,7 +17,7 @@ This RFC defines the deterministic lifecycle for the first possible
 Phase-19 Platform Runtime MVP.
 
 The lifecycle exists to bound future implementation. It does not implement a
-runtime and does not activate Phase-19.
+runtime and does not authorize runtime implementation.
 
 ## Core Rule
 

--- a/docs/specs/phase19-platform-runtime/RUNTIME_NON_GOALS_AND_DENIALS.md
+++ b/docs/specs/phase19-platform-runtime/RUNTIME_NON_GOALS_AND_DENIALS.md
@@ -1,11 +1,12 @@
 # Phase-19 Runtime Non-Goals And Denials
 
 This document is subordinate to `PHASE19_RUNTIME_DECISION.md`,
+`../../../PHASE19_POINTER_TRANSITION_DECISION.md`,
 `../phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
 `../phase18-platform-constitution/TERMINOLOGY_AUDIT.md`, and the Phase-19
 Runtime RFC set. In case of conflict, those documents prevail.
 
-**Status:** PRE-IMPLEMENTATION RFC / PHASE-19 NOT ACTIVE / RUNTIME NOT AUTHORIZED
+**Status:** ACTIVE RFC / RUNTIME IMPLEMENTATION NOT AUTHORIZED
 **Contract id:** `ayken.phase19.runtime.non_goals.denials.v1`
 **Authority boundary:** Documentation/specification only; not runtime source
 code, installer, loader, workspace runtime, plugin host, capability issuer,

--- a/docs/specs/phase19-platform-runtime/RUNTIME_RECEIPT_SPECIFICATION.md
+++ b/docs/specs/phase19-platform-runtime/RUNTIME_RECEIPT_SPECIFICATION.md
@@ -1,12 +1,13 @@
 # Phase-19 Runtime Receipt Specification
 
 This document is subordinate to `PHASE19_RUNTIME_DECISION.md`,
+`../../../PHASE19_POINTER_TRANSITION_DECISION.md`,
 `RUNTIME_LIFECYCLE_SPECIFICATION.md`,
 `WORKSPACE_ADMISSION_RUNTIME_SPECIFICATION.md`, and
 `../phase18-platform-constitution/TERMINOLOGY_AUDIT.md`. In case of conflict,
 those documents prevail.
 
-**Status:** PRE-IMPLEMENTATION RFC / PHASE-19 NOT ACTIVE / RUNTIME NOT AUTHORIZED
+**Status:** ACTIVE RFC / RUNTIME IMPLEMENTATION NOT AUTHORIZED
 **Contract id:** `ayken.phase19.runtime.receipt.v1`
 **Authority boundary:** Documentation/specification only; not a token,
 capability, runtime handle, loader handle, workspace handle, plugin instance,

--- a/docs/specs/phase19-platform-runtime/WORKSPACE_ADMISSION_RUNTIME_SPECIFICATION.md
+++ b/docs/specs/phase19-platform-runtime/WORKSPACE_ADMISSION_RUNTIME_SPECIFICATION.md
@@ -1,11 +1,12 @@
 # Phase-19 Workspace Admission Runtime Specification
 
 This document is subordinate to `PHASE19_RUNTIME_DECISION.md`,
+`../../../PHASE19_POINTER_TRANSITION_DECISION.md`,
 `PLATFORM_VALIDATION_INTEGRATION_SPECIFICATION.md`, and
 `../phase18-platform-constitution/WORKSPACE_LIFECYCLE_SPECIFICATION.md`. In
 case of conflict, those documents prevail.
 
-**Status:** PRE-IMPLEMENTATION RFC / PHASE-19 NOT ACTIVE / RUNTIME NOT AUTHORIZED
+**Status:** ACTIVE RFC / RUNTIME IMPLEMENTATION NOT AUTHORIZED
 **Contract id:** `ayken.phase19.workspace_admission.runtime.v1`
 **Authority boundary:** Documentation/specification only; not workspace
 creation, real mount authority, filesystem implementation, package


### PR DESCRIPTION
## Summary
- add PHASE19_POINTER_TRANSITION_DECISION.md as the exact pointer-transition decision package
- update docs/roadmap/CURRENT_PHASE from 18 to 19
- synchronize README, roadmap, status report, documentation index, and Phase-19 RFC status surfaces

## Authority Boundary
- CURRENT_PHASE=19 activates only Platform Runtime MVP planning, validation-integration, admission-record, and receipt-boundary authority
- runtime implementation remains unauthorized
- no loader, installer, workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI authority, AI Runtime authority, new syscall, kernel ABI expansion, Ring0 policy, CI workflow, baseline, or source code change is included

## Local Validation
- git diff --check: PASS
- make ci-gate-spec-purity RUN_ID=local-phase19-pointer-transition-spec-purity-final-20260606 EVIDENCE_ROOT=evidence: PASS
- make ci-gate-governance RUN_ID=local-phase19-pointer-transition-governance-final-20260606 EVIDENCE_ROOT=evidence: PASS

## Exact SHA
- subject SHA: 53df9a9a8f5c166b117ab5658a921d642d7c14b5
- remote ci-freeze and Dev Loop must pass on this PR subject SHA before merge