### PR TITLE
docs: add Phase-19 implementation decision candidate

### DIFF
--- a/AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md
+++ b/AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md
@@ -29,6 +29,9 @@
 > `PHASE19_POINTER_TRANSITION_DECISION.md` records the exact phase pointer
 > transition to `CURRENT_PHASE=19`; it activates only Runtime MVP planning,
 > validation-integration, admission-record and receipt-boundary authority.
+> `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` records the later
+> implementation decision candidate boundary; it does not authorize runtime
+> source code or implementation.
 > PR #172 merged the pointer transition to `main` at
 > `37d0bf46898d2c01b75863d72f68910524e596a7`; post-merge `ci-freeze`
 > run `27062096603` and Dev Loop CI run `27062096584` passed for that
@@ -46,7 +49,7 @@
 | Phase-17 kapanisi | `reports/phase17_official_closure_candidate/` official closure package ve verified tag mevcut | Closure authority exact-SHA subject ile sinirlidir; Phase-18'i aktive etmez |
 | Phase-17.5 | PR #142, PR #144, PR #148, PR #149/#151/#150, PR #152 ve closure decision package `main`e kabul edildi | Accepted subject SHA `416a5392` icin bounded evidence resmi closure'a baglandi |
 | Phase-18 | `PHASE18_TRANSITION_DECISION.md` + `PHASE18_ACTIVATION_DECISION.md` + `AUTHORITY_DRIFT_GUARD.md` + `TERMINOLOGY_AUDIT.md` | Accepted Platform Constitution reference set; runtime implementation yetkisi degildir |
-| Phase-19 | `PHASE19_RUNTIME_DECISION.md` + `docs/specs/phase19-platform-runtime/README.md` + `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` + `PHASE19_POINTER_TRANSITION_CANDIDATE.md` + `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` + `PHASE19_POINTER_TRANSITION_DECISION.md` | Runtime MVP planning/admission/receipt boundary active; implementation yetkisi yoktur |
+| Phase-19 | `PHASE19_RUNTIME_DECISION.md` + `docs/specs/phase19-platform-runtime/README.md` + `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` + `PHASE19_POINTER_TRANSITION_CANDIDATE.md` + `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` + `PHASE19_POINTER_TRANSITION_DECISION.md` + `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` | Runtime MVP planning/admission/receipt boundary active; implementation candidate docs-only; implementation yetkisi yoktur |
 | Aktif execution roadmap | `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution reference set + Phase-19 Runtime MVP planning boundary | Ayri implementation karari olmadan runtime baslatilmaz; authority drift review guard ve terminology audit korunur |
 | Canonical performance baseline | `scripts/ci/perf-baseline.lock.json` | Accepted `main` SHA `416a5392`: standalone Performance Gate `26715068398` ve scoped Phase-17 acceptance `26712374737` PASS; closure tag dogrulandi |
 | Review enforcement | Issue #145 tek-maintainer ADR'i, `@kenanay` CODEOWNERS accountability metadata'si ve canli `main` `freeze` protection paritesi ile kapatildi | Bagimsiz self-review iddiasi yoktur; remote CI ve kayitli maintainer karari merge siniridir |

--- a/PHASE19_POINTER_TRANSITION_DECISION.md
+++ b/PHASE19_POINTER_TRANSITION_DECISION.md
@@ -47,6 +47,10 @@ The safe default remains no runtime behavior unless a later reviewed
 implementation decision grants a specific bounded behavior and supplies its
 own evidence package.
 
+`PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` may narrow the shape of
+that later implementation decision, but it is not the implementation decision
+and does not authorize runtime source code.
+
 ## Transition Basis
 
 The pointer transition is based on the accepted pre-transition chain:

--- a/PHASE19_RUNTIME_DECISION.md
+++ b/PHASE19_RUNTIME_DECISION.md
@@ -140,6 +140,12 @@ After that review, `PHASE19_POINTER_TRANSITION_DECISION.md` transitions
 `docs/roadmap/CURRENT_PHASE` to `19` as planning/admission/receipt authority
 only. That pointer transition is still not runtime implementation authority.
 
+After the pointer transition,
+`PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` records the candidate
+boundary for a later implementation decision. That candidate does not
+authorize runtime source code and does not replace a future exact-SHA
+implementation decision.
+
 `MODULE_LOADING_MODEL.md`, `PLUGIN_INSTANTIATION_MODEL.md`, package
 execution, real workspace mounts, capability issuance, trust assignment,
 Semantic CLI authority, AI Runtime authority, and agent behavior are not part

--- a/PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md
+++ b/PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md
@@ -1,0 +1,194 @@
+# Phase-19 Runtime Implementation Decision Candidate
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, `PHASE18_TRANSITION_DECISION.md`,
+`PHASE18_ACTIVATION_DECISION.md`, the Phase-18 Platform Constitution
+reference set, `AUTHORITY_DRIFT_GUARD.md`, `TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`,
+`PHASE19_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, and
+`PHASE19_POINTER_TRANSITION_DECISION.md`. In case of conflict, those
+documents prevail.
+
+**Status:** CANDIDATE / IMPLEMENTATION DECISION NOT ACCEPTED / RUNTIME SOURCE CODE NOT AUTHORIZED
+**Candidate date:** 2026-06-06
+**Candidate id:** `ayken.phase19.runtime_implementation_decision_candidate.v1`
+**Authority boundary:** Candidate documentation only; not runtime source code,
+not an implementation decision, not a manifest parser, not a package
+installer, not a package executor, not a module loader, not workspace runtime,
+not workspace creation, not real mount authority, not plugin host, not plugin
+loading, not capability token minting, not capability issuance, not trust
+assignment, not registry publication, not Semantic CLI authority, not AI
+Runtime authority, not agent authority, not a syscall, not kernel ABI
+expansion, not Ring0 policy, not merge authority, and not closure authority.
+
+## Purpose
+
+This candidate defines the narrowest acceptable shape for a later
+Phase-19 Runtime MVP implementation decision.
+
+It does not accept that implementation decision.
+
+It does not authorize code.
+
+It exists to prevent the next step from expanding from an admission/receipt
+MVP into loader, installer, workspace runtime, issuer, Semantic CLI, AI, or
+agent behavior.
+
+## Core Rule
+
+```text
+implementation decision candidate != implementation decision
+implementation decision != runtime implementation
+runtime MVP artifact != behavior source
+```
+
+The safe default remains no runtime source code.
+
+## Candidate Decision Shape
+
+A later implementation decision may be considered only if it is limited to a
+minimal userspace admission harness for the accepted Phase-19 Runtime MVP
+boundary.
+
+The candidate decision may describe only this inert flow:
+
+```text
+static input bundle
+  -> Phase-18 Platform ABI validation integration record
+  -> workspace admission record
+  -> deterministic runtime receipt
+```
+
+The flow must not install, load, mount, execute, issue, trust, publish,
+schedule, grant, or bind anything.
+
+## First Permitted Behavior Candidate
+
+If a later exact-SHA implementation decision is accepted, the first behavior
+that may be proposed is a bounded userspace harness that:
+
+1. Reads a static, test-owned input bundle.
+2. Checks the bundle against accepted Phase-18 declarative contracts.
+3. Emits a validation-integration record.
+4. Emits a workspace admission record.
+5. Emits a deterministic runtime receipt.
+6. Fails closed before receipt success on unknown, stale, contradictory, or
+   authority-bearing input.
+
+This behavior candidate is not a general manifest parser. It is not a package
+installer. It is not a module loader. It is not a workspace runtime. It is not
+a plugin host. It is not an issuer. It is not an executor.
+
+## Required Preconditions For A Later Decision
+
+A later implementation decision PR must fail closed unless all of the
+following are true:
+
+| ID | Precondition | Required result |
+|---|---|---|
+| P19-I1 | Phase pointer stable | `CURRENT_PHASE=19` remains active only as planning/admission/receipt boundary |
+| P19-I2 | RFC set accepted | all Phase-19 Runtime RFCs remain accepted and unchanged or are reviewed in the same decision chain |
+| P19-I3 | Evidence plan mapped | `RUNTIME_EVIDENCE_PLAN.md` positive, negative, determinism, remote, and performance requirements are mapped to concrete checks |
+| P19-I4 | Inert artifact invariant preserved | input bundle, validation receipt, workspace admission record, and runtime receipt remain non-authority records |
+| P19-I5 | Kernel ABI unchanged | syscall IDs `1000-1011`, syscall count `12`, and ABI version `0x00010001` remain frozen |
+| P19-I6 | Runtime source separated | implementation code is reviewed in a later PR after this candidate; this candidate stays docs-only |
+| P19-I7 | No authority drift | loader, installer, mount, execution, issuer, trust, Semantic CLI, AI, registry, and agent readings are denied |
+| P19-I8 | Exact-SHA evidence required | strict `ci-freeze`, Dev Loop, and any new runtime-specific gates must PASS on the implementation decision subject |
+
+Missing, ambiguous, or partially satisfied preconditions fail closed.
+
+## Candidate Implementation Surface Limits
+
+A later decision may propose a userspace-only source surface for a bounded
+admission/receipt harness.
+
+That later decision must not touch:
+
+1. `kernel/` behavior.
+2. `shared/abi/` syscall declarations or ABI layout.
+3. Bootloader behavior.
+4. Performance baselines.
+5. CI workflow authority.
+6. Package installer code.
+7. Module loader code.
+8. Workspace runtime or real mount code.
+9. Plugin host or plugin loading code.
+10. Capability issuer or token minting code.
+11. Trust issuer or trust assignment code.
+12. Semantic CLI authority paths.
+13. AI Runtime authority paths.
+14. Registry or agent code.
+
+If any of these surfaces are required, the proposal must move to a separate
+reviewed phase or authority decision.
+
+## Required Evidence For A Later Implementation Decision
+
+A later implementation decision must define exact evidence before runtime code
+can be accepted:
+
+1. Positive admission/receipt transcript for one static input bundle.
+2. Deterministic repeat of lifecycle transcript digest.
+3. Deterministic repeat of admission record digest.
+4. Deterministic repeat of runtime receipt digest.
+5. Negative unknown-field denial.
+6. Negative stale-digest denial.
+7. Negative missing Platform ABI validation denial.
+8. Negative workspace real-mount denial.
+9. Negative receipt-as-token denial.
+10. Negative trust-as-capability denial.
+11. Negative plugin-compatibility-as-loading denial.
+12. Negative Semantic CLI output-as-authority denial.
+13. Negative AI output-as-authority denial.
+14. Kernel ABI freeze preservation.
+15. Production default behavior.
+
+Evidence is output only. It must not become runtime control input.
+
+## Explicit Non-Goals
+
+This candidate must not be read to authorize:
+
+1. Runtime implementation.
+2. General manifest parser implementation.
+3. Package installation.
+4. Package execution.
+5. Module loading.
+6. Plugin host, plugin loading, or plugin instantiation.
+7. Workspace creation, workspace runtime, or real mounts.
+8. Capability token minting.
+9. Capability issuance.
+10. Trust assignment or trust issuer behavior.
+11. Registry publication or marketplace behavior.
+12. Semantic CLI execution authority.
+13. AI Runtime authority.
+14. Agent behavior.
+15. New syscalls.
+16. Kernel ABI expansion.
+17. Ring0 policy.
+18. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Relationship To Later Phases
+
+This candidate does not pull later phases into Phase-19:
+
+1. Phase-20 registry/capability ecosystem remains later work.
+2. Phase-21 Semantic CLI authority remains later work.
+3. Phase-22 AI Runtime remains later work.
+4. Phase-23+ agent systems remain later work.
+
+Those phases require their own reviewed decision packages.
+
+## Candidate Conclusion
+
+This file records a candidate boundary for a later Phase-19 Runtime MVP
+implementation decision.
+
+The candidate allows discussion of the minimum admission/receipt harness
+shape only.
+
+Runtime implementation remains unauthorized.

--- a/PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md
+++ b/PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md
@@ -70,16 +70,19 @@ If a later exact-SHA implementation decision is accepted, the first behavior
 that may be proposed is a bounded userspace harness that:
 
 1. Reads a static, test-owned input bundle.
-2. Checks the bundle against accepted Phase-18 declarative contracts.
+2. Checks only the bounded static test-owned bundle shape and referenced
+   Phase-18 declarative contract metadata required for admission/receipt
+   evidence.
 3. Emits a validation-integration record.
 4. Emits a workspace admission record.
 5. Emits a deterministic runtime receipt.
 6. Fails closed before receipt success on unknown, stale, contradictory, or
    authority-bearing input.
 
-This behavior candidate is not a general manifest parser. It is not a package
-installer. It is not a module loader. It is not a workspace runtime. It is not
-a plugin host. It is not an issuer. It is not an executor.
+This behavior candidate is not a general parser. It is not a general manifest
+parser. It is not a package installer. It is not a module loader. It is not a
+workspace runtime. It is not a plugin host. It is not an issuer. It is not an
+executor.
 
 ## Required Preconditions For A Later Decision
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **CURRENT_PHASE:** `19` (`Phase-19 ACTIVE: Platform Runtime MVP planning/admission/receipt boundary`; runtime implementation yetkisi değildir)
 **Freeze Zinciri:** `make ci-freeze` = 40 kapılı strict suite (normative spec-purity dahil) | `make ci-freeze-local` = local performance authority
 **Authority Durumu:** Issue #145 tek-maintainer authority kararıyla giderildi; PR #142, PR #144, PR #148, PR #149, PR #151, PR #150, PR #152 ve Phase-17 closure decision package birleşti. Closure exact-SHA kanıtı `main` SHA `416a5392` üzerinde yenilendi, gerekli uzak acceptance kontrolleri PASS verdi ve `phase17-official-closure` tag'i aynı SHA'ya doğrulandı
-**Yakın Hedef:** Phase-19 Platform Runtime MVP planning/admission/receipt sınırını korumak; mevcut somut girdiler `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` ve `PHASE19_POINTER_TRANSITION_DECISION.md`; `CURRENT_PHASE=19` runtime implementation, loader, installer, workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI authority veya AI Runtime authority vermez
+**Yakın Hedef:** Phase-19 Platform Runtime MVP planning/admission/receipt sınırını korumak; mevcut somut girdiler `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, `PHASE19_POINTER_TRANSITION_DECISION.md` ve `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`; `CURRENT_PHASE=19` runtime implementation, loader, installer, workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI authority veya AI Runtime authority vermez
 **Ring0 Export Ceiling:** `193 symbols` (current enforced ceiling)
 **Performance Baseline Candidate:** `gha-ubuntu24-20260518.149.1-X64` (authorized run `26370359958` artifact'i PR'a import edildi; SHA `f129d4aa` locked acceptance PASS verdi, ancak tek basina closure authority değildir)
 **Development Status:** Phase-16 OFFICIALLY CLOSED ✅ | Phase-17 OFFICIALLY CLOSED ✅ | SINGLE-MAINTAINER AUTHORITY ALIGNED (#145 RESOLVED) ✅ | PR #142/#144/#148/#149/#151/#150/#152 + closure decision package MERGED ✅ | EXACT-SHA REMOTE EVIDENCE PASS ✅ | Phase-18 PLATFORM CONSTITUTION ACCEPTED ✅ | Phase-19 POINTER TRANSITION ACTIVE AS PLANNING BOUNDARY ✅
@@ -41,7 +41,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **Phase 16 Status:** OFFICIALLY CLOSED ✅ | Verification Layer MVP COMPLETE | Evidence chain integrity verified | Trust anchor established | `make verify-system` → 3 gates → PASS | Constitutional rule enforcement active | Fail-closed behavior confirmed
 **Phase 17 Status:** OFFICIALLY CLOSED ✅ | tag `phase17-official-closure` at `416a5392` | full `ci-freeze` (`26712333892`), locked performance (`26715068398`, `26712374737`) ve Phase-17 QEMU evidence lanes (`26712374742`, `26712374736`, `26712374727`, `26712374744`, `26712374728`) PASS | `reports/phase17_official_closure_candidate/`
 **Phase 18 Status:** ACCEPTED PLATFORM CONSTITUTION REFERENCE SET | Authority drift guard and terminology audit active | Runtime implementation, kernel expansion, new syscalls, Ring0 policy and AI authority remain forbidden unless a separate phase RFC and closure authority exists
-**Phase 19 Status:** ACTIVE AS PLATFORM RUNTIME MVP PLANNING / ADMISSION / RECEIPT BOUNDARY | `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, and `PHASE19_POINTER_TRANSITION_DECISION.md` define and activate the planning boundary only; runtime implementation is not authorized
+**Phase 19 Status:** ACTIVE AS PLATFORM RUNTIME MVP PLANNING / ADMISSION / RECEIPT BOUNDARY | `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, `PHASE19_POINTER_TRANSITION_DECISION.md`, and `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` define the planning and future-decision boundary only; runtime implementation is not authorized
 **Architecture Quick Map:** `docs/specs/phase12-trust-layer/AYKENOS_GATE_ARCHITECTURE.md`
 **Active Execution Roadmap:** `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution reference set + Phase-19 Runtime MVP planning boundary | accepted `main` SHA `416a5392` uzerinde bounded Phase-17 uzak evidence PASS; official closure tag doğrulandı; `CURRENT_PHASE=19` runtime implementation yetkisi vermez
 **Canonical Technical Definition:** AykenOS is a deterministic verification architecture that separates kernel execution, verification semantics, evidence artifacts, and distributed diagnostics into explicit layers. The kernel provides mechanism, userspace verification services produce artifact-bound verdicts and receipts, and parity/topology surfaces expose cross-node observability without elevating diagnostics into authority or consensus.
@@ -55,7 +55,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 - **Current Phase:** `19`
 - **Status:** `ACTIVE / PLATFORM RUNTIME MVP PLANNING, ADMISSION, AND RECEIPT BOUNDARY ONLY`
 - **Last Official Closure:** `17` (Execution Pipeline, 2026-05-31)
-- **Candidate Next Authority Action:** Phase-19 runtime implementation decision package; runtime source code remains unauthorized until then
+- **Candidate Next Authority Action:** `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` constrains a later Phase-19 runtime implementation decision package; runtime source code remains unauthorized until a separate exact-SHA decision
 - **Verification Layer:** `COMPLETE` (MVP delivered 2026-04-25)
 - **Closure Index:** `reports/phase17_official_closure_candidate/closure_index.json`
 - **Phase-19 Authority Note:** `CURRENT_PHASE=19` activates only Runtime MVP planning, validation-integration, admission-record, and receipt-boundary authority; runtime implementation still requires a separate decision.
@@ -69,7 +69,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 - **Evidence:** A, B, C karakterleri başarıyla syscall üzerinden basıldı
 - **Result:** Ring3 infrastructure PROVEN, syscall path WORKING, instruction retirement VALIDATED
 
-**Next Focus:** `CURRENT_PHASE=19` altında Runtime MVP planning/admission/receipt sınırını korumak ve runtime implementasyonunu ayrı karar/evidence paketine ayırmak. Runtime source code, loader, installer, workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI authority ve AI Runtime authority hâlâ kapalıdır.
+**Next Focus:** `CURRENT_PHASE=19` altında Runtime MVP planning/admission/receipt sınırını korumak ve `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` ile sonraki implementation decision sınırını dar tutmak. Runtime source code, loader, installer, workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI authority ve AI Runtime authority hâlâ kapalıdır.
 
 ## Authority Model
 
@@ -328,6 +328,7 @@ Phase 12 trust layer kapsamında tamamlananlar:
 - **Phase-19 Pointer Transition Candidate:** `PHASE19_POINTER_TRANSITION_CANDIDATE.md`
 - **Phase-19 Activation Preconditions Review:** `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`
 - **Phase-19 Pointer Transition Decision:** `PHASE19_POINTER_TRANSITION_DECISION.md`
+- **Phase-19 Runtime Implementation Decision Candidate:** `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`
 - **Documentation Index:** `docs/development/DOCUMENTATION_INDEX.md`
 - **Ring3 User-Leaf Rule:** `docs/governance/RING3_USER_LEAF_ALLOCATION_RULE.md`
 - **Ring3 Runtime Closure Note:** `docs/governance/RING3_RUNTIME_CLOSURE_NOTE.md`
@@ -375,6 +376,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 - Phase-19 pointer transition candidate: `PHASE19_POINTER_TRANSITION_CANDIDATE.md`; exact-SHA pointer transition kosullarini tanimlayan accepted candidate kaydidir, implementation yetkisi vermez.
 - Phase-19 activation preconditions review: `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`; precondition review PASS kaydidir, runtime implementation yetkisi vermez.
 - Phase-19 pointer transition decision: `PHASE19_POINTER_TRANSITION_DECISION.md`; `CURRENT_PHASE=19` pointer'ini planning/admission/receipt sinirinda aktive eder, runtime implementation yetkisi vermez.
+- Phase-19 runtime implementation decision candidate: `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`; sonraki implementation decision sinirini daraltan candidate kaydidir, runtime source code veya implementation authority vermez.
 - Phase-19 runtime MVP icin ayri implementation RFC/evidence plan/closure boundary hazirlanmadikca package installer, workspace runtime, plugin loader, capability issuer veya trust issuer yazilmaz.
 
 **Orta Vadeli:**
@@ -390,7 +392,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 
 ---
 
-**Son Güncelleme:** 06 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=19; Phase-18 Platform Constitution reference set korunur; `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` ve `PHASE19_POINTER_TRANSITION_DECISION.md` Runtime MVP planning/admission/receipt sinirini aktive eder, ancak runtime implementation yetkisi yoktur.
+**Son Güncelleme:** 06 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=19; Phase-18 Platform Constitution reference set korunur; `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, `PHASE19_POINTER_TRANSITION_DECISION.md` ve `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` Runtime MVP planning/admission/receipt ve future-decision sinirini tanimlar, ancak runtime implementation yetkisi yoktur.
 **Düzenleyen / Geliştiren / Oluşturan / Mimari Sorumlu:** Kenan AY *(metadata only; runtime/karar yetkisi değildir).*
 
 **© 2026 Kenan AY — AykenOS Project**

--- a/docs/development/DOCUMENTATION_INDEX.md
+++ b/docs/development/DOCUMENTATION_INDEX.md
@@ -18,7 +18,7 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict
 - **Formal Governance Pointer:** `CURRENT_PHASE=19`
 - **Active Phase:** Phase-19 ACTIVE / Platform Runtime MVP planning, admission, and receipt boundary only
 - **Active Execution Priority:** Maintain Phase-19 planning/admission/receipt authority without runtime implementation
-- **Candidate Next Decision:** Phase-19 runtime implementation decision package; source code remains unauthorized until a separate exact-SHA decision
+- **Candidate Next Decision:** `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`; source code remains unauthorized until a separate exact-SHA implementation decision
 - **Scope Boundary:** `CURRENT_PHASE=19` does not authorize runtime implementation; kernel expansion, new syscalls, Ring0 policy and AI Runtime authority remain forbidden
 
 ## Primary Truth Sources
@@ -52,14 +52,15 @@ Current repo truth icin once su dosyalari referans alin:
 26. `PHASE19_POINTER_TRANSITION_CANDIDATE.md` — **Phase-19 pointer transition candidate; implementation not authorized**
 27. `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` — **Phase-19 activation preconditions review; implementation not authorized**
 28. `PHASE19_POINTER_TRANSITION_DECISION.md` — **Phase-19 pointer transition decision; `CURRENT_PHASE=19`, runtime implementation not authorized**
-29. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
-30. `reports/phase15_official_closure/closure_index.json`
-31. `reports/phase13_official_closure_candidate/closure_index.json`
-32. `reports/phase12_official_closure_candidate/closure_manifest.json`
-33. `reports/phase10_phase11_official_closure_index.json`
-34. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
-35. `Makefile`
-36. `.github/workflows/ci-freeze.yml`
+29. `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` — **Phase-19 implementation decision candidate; runtime source code not authorized**
+30. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
+31. `reports/phase15_official_closure/closure_index.json`
+32. `reports/phase13_official_closure_candidate/closure_index.json`
+33. `reports/phase12_official_closure_candidate/closure_manifest.json`
+34. `reports/phase10_phase11_official_closure_index.json`
+35. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
+36. `Makefile`
+37. `.github/workflows/ci-freeze.yml`
 
 Phase-14 workstream numbering ve aktif durum yorumu icin canonical truth source:
 
@@ -110,13 +111,14 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 22. `PHASE19_POINTER_TRANSITION_CANDIDATE.md` — Phase-19 pointer transition candidate; not implementation authority
 23. `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` — Phase-19 activation preconditions review; not implementation authority
 24. `PHASE19_POINTER_TRANSITION_DECISION.md` — Phase-19 pointer transition decision; not implementation authority
-25. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
-26. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
-27. `docs/specs/phase16-ayken-orchestration/README.md`
-28. `docs/specs/authority-lineage-v1/README.md`
-29. `docs/specs/phase14-distributed-observability/README.md`
-30. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
-31. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
+25. `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` — Phase-19 implementation decision candidate; not implementation authority
+26. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
+27. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
+28. `docs/specs/phase16-ayken-orchestration/README.md`
+29. `docs/specs/authority-lineage-v1/README.md`
+30. `docs/specs/phase14-distributed-observability/README.md`
+31. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
+32. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
 
 ## Phase-18 Reference Set
 1. `PHASE18_TRANSITION_DECISION.md`
@@ -155,6 +157,9 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 13. `PHASE19_POINTER_TRANSITION_DECISION.md` — pointer transition decision;
     activates `CURRENT_PHASE=19` only as planning/admission/receipt boundary
     and does not authorize implementation.
+14. `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` —
+    implementation decision candidate; narrows a later exact-SHA decision and
+    does not authorize runtime source code.
 
 ## Phase-14 Reference Set
 ### Architecture and Observability Surfaces

--- a/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
+++ b/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
@@ -415,6 +415,12 @@ Bu aday belge runtime implementation yetkisi vermez.
 pointer candidate zincirinin activation oncesi precondition setini review
 eder. Bu review PASS sonucu runtime implementation authority kurmaz.
 
+`PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`, sonraki
+implementation decision icin en dar admission/receipt harness sinirini
+candidate olarak kaydeder. Bu candidate runtime source code, implementation
+decision, parser, loader, installer, workspace runtime, issuer, Semantic CLI
+authority veya AI Runtime authority kurmaz.
+
 Phase-19 karar siniri su kurallari korur:
 
 1. Runtime decision runtime implementation degildir.
@@ -440,6 +446,9 @@ Phase-19 karar siniri su kurallari korur:
     authority `PHASE19_POINTER_TRANSITION_DECISION.md` ile sinirlidir.
 11. Activation preconditions review, implementation decision degildir;
     implementation halen ayri exact-SHA karar gerektirir.
+12. Implementation decision candidate, implementation decision degildir;
+    runtime source code halen ayri exact-SHA decision ve evidence package
+    gerektirir.
 
 ## 7. PR Sequence and Coordination Matrix
 
@@ -479,6 +488,7 @@ Phase-19 karar siniri su kurallari korur:
 | Phase-19 Pointer Transition Candidate | ACCEPTED CANDIDATE / SUPERSEDED BY DECISION | Exact-SHA `CURRENT_PHASE=19` pointer transition kosullarini ve inert runtime artifact invariant'ini kaydetmek | `PHASE19_POINTER_TRANSITION_CANDIDATE.md` | Candidate runtime implementation, parser, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
 | Phase-19 Activation Preconditions Review | ACCEPTED PRECONDITION REVIEW / SUPERSEDED BY DECISION | Decision/RFC/cross-review/pointer-candidate zincirinin activation oncesi precondition setini review etmek | `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` | Review PASS runtime implementation, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
 | Phase-19 Pointer Transition Decision | CURRENT_PHASE=19 / IMPLEMENTATION NOT AUTHORIZED | Phase-19'i yalniz Runtime MVP planning, validation-integration, admission-record ve receipt-boundary olarak aktive etmek | `PHASE19_POINTER_TRANSITION_DECISION.md`, `docs/roadmap/CURRENT_PHASE` | Pointer transition runtime implementation, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
+| Phase-19 Runtime Implementation Decision Candidate | CANDIDATE / IMPLEMENTATION NOT AUTHORIZED | Sonraki exact-SHA implementation decision icin minimal userspace admission/receipt harness sinirini ve evidence precondition'larini docs-only kaydetmek | `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` | Candidate runtime source code, implementation decision, parser, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
 
 PR koordinasyon kurallari:
 
@@ -1175,7 +1185,8 @@ Bu roadmap su olaylarda guncellenir:
 33. Phase-19 Pointer Transition Candidate review/merge sonucu.
 34. Phase-19 Activation Preconditions Review sonucu.
 35. Phase-19 Pointer Transition Decision sonucu.
-36. Yeni feature/ABI/authority surface onerisinin incelenmesi.
+36. Phase-19 Runtime Implementation Decision Candidate sonucu.
+37. Yeni feature/ABI/authority surface onerisinin incelenmesi.
 
 ## References
 
@@ -1219,6 +1230,7 @@ Bu roadmap su olaylarda guncellenir:
 - `PHASE19_POINTER_TRANSITION_CANDIDATE.md`
 - `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`
 - `PHASE19_POINTER_TRANSITION_DECISION.md`
+- `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`
 - `PHASE18_ROADMAP.md`
 - `shared/abi/syscall_v2.h`
 - `shared/abi/ayken_abi.h`

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -69,7 +69,10 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 23. `../../PHASE19_POINTER_TRANSITION_DECISION.md`: `CURRENT_PHASE=19`
    pointer transition decision; yalniz planning/admission/receipt boundary
    kurar, runtime implementation authority degildir.
-24. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
+24. `../../PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`:
+   implementation decision candidate; sonraki exact-SHA decision sinirini
+   daraltir, runtime source code veya implementation authority kurmaz.
+25. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
    planlamasi; aktif Phase-18 otoritesi degildir.
 
 ## Current Status
@@ -79,7 +82,7 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 | Son resmi kapanis | Phase-17 OFFICIALLY CLOSED (`phase17-official-closure` at `416a5392`) |
 | Aktif faz | Phase-19 ACTIVE / Platform Runtime MVP planning, admission, and receipt boundary only |
 | Aktif odak | Phase-19 planning/admission/receipt authority maintenance; runtime implementation remains out of scope |
-| Aday sonraki karar | Phase-19 runtime implementation decision package; source code remains unauthorized until a separate exact-SHA decision |
+| Aday sonraki karar | `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`; source code remains unauthorized until a separate exact-SHA implementation decision |
 | ABI | Canonical `1000-1011` / 12 syscall, ABI version `0x00010001` |
 | Phase-18 | ACCEPTED PLATFORM CONSTITUTION REFERENCE SET; kernel expansion, runtime implementation and new syscalls forbidden unless a separate phase RFC/closure authority exists |
 | Phase-19 | ACTIVE AS PLANNING / VALIDATION-INTEGRATION / ADMISSION-RECORD / RECEIPT BOUNDARY; implementation forbidden until a separate decision |
@@ -116,9 +119,10 @@ current execution priority otoritesi degildir:
 
 ---
 
-**Next action:** Phase-19 runtime implementation karar paketi ancak ayri
-exact-SHA PR ve evidence plan ile degerlendirilebilir. `CURRENT_PHASE=19`
-runtime source code, loader, installer, workspace runtime, plugin host,
-capability issuer, trust issuer, Semantic CLI authority veya AI Runtime
-authority vermez. High-risk vocabulary `TERMINOLOGY_AUDIT.md` kaydina gore
-denetlenir.
+**Next action:** `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`
+sonraki implementation decision sinirini docs-only olarak daraltir. Gercek
+Phase-19 runtime implementation karar paketi ancak ayri exact-SHA PR ve
+evidence plan ile degerlendirilebilir. `CURRENT_PHASE=19` runtime source code,
+loader, installer, workspace runtime, plugin host, capability issuer, trust
+issuer, Semantic CLI authority veya AI Runtime authority vermez. High-risk
+vocabulary `TERMINOLOGY_AUDIT.md` kaydina gore denetlenir.

--- a/docs/specs/phase19-platform-runtime/README.md
+++ b/docs/specs/phase19-platform-runtime/README.md
@@ -65,6 +65,10 @@ transition to `CURRENT_PHASE=19`. That transition activates only this
 documented Runtime MVP planning, validation-integration, admission-record, and
 receipt-boundary phase. It does not authorize runtime implementation.
 
+`../../../PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` records the
+later implementation decision candidate boundary. It does not authorize
+runtime source code or implementation.
+
 ## Core Rule
 
 ```text
@@ -76,7 +80,8 @@ The existence of these RFCs and the `CURRENT_PHASE=19` pointer means only that
 the Phase-19 Runtime MVP boundary is active as planning authority. A separate
 implementation decision, implementation RFC acceptance, runtime evidence
 implementation, and remote CI authority remain required before any runtime
-code can be accepted.
+code can be accepted. The implementation decision candidate narrows that
+future decision, but is not itself implementation authority.
 
 ## MVP Boundary
 


### PR DESCRIPTION
## Summary

- Add PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md as a docs-only candidate boundary for a later Phase-19 implementation decision.
- Sync README, roadmap, documentation index, status report, and Phase-19 RFC references.
- Preserve the rule that CURRENT_PHASE=19 does not authorize runtime source code, loader, installer, workspace runtime, issuer, Semantic CLI authority, AI Runtime authority, new syscalls, or kernel ABI expansion.

## Validation

- git diff --check
- make ci-gate-spec-purity RUN_ID=local-phase19-implementation-candidate-spec-purity-20260606 EVIDENCE_ROOT=evidence
- make ci-gate-governance RUN_ID=local-phase19-implementation-candidate-governance-20260606 EVIDENCE_ROOT=evidence

## Authority boundary

This PR is documentation-only. It does not authorize runtime implementation or change CURRENT_PHASE, kernel ABI, CI workflow authority, baseline data, or runtime source code.