### PR TITLE
docs: add Phase-19 runtime evidence matrix

### DIFF
--- a/AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md
+++ b/AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md
@@ -32,6 +32,9 @@
 > `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` records the later
 > implementation decision candidate boundary; it does not authorize runtime
 > source code or implementation.
+> `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md` maps
+> future artifact/evidence rows for a later implementation decision; it is
+> not evidence PASS, a CI gate, or implementation authority.
 > PR #172 merged the pointer transition to `main` at
 > `37d0bf46898d2c01b75863d72f68910524e596a7`; post-merge `ci-freeze`
 > run `27062096603` and Dev Loop CI run `27062096584` passed for that
@@ -49,7 +52,7 @@
 | Phase-17 kapanisi | `reports/phase17_official_closure_candidate/` official closure package ve verified tag mevcut | Closure authority exact-SHA subject ile sinirlidir; Phase-18'i aktive etmez |
 | Phase-17.5 | PR #142, PR #144, PR #148, PR #149/#151/#150, PR #152 ve closure decision package `main`e kabul edildi | Accepted subject SHA `416a5392` icin bounded evidence resmi closure'a baglandi |
 | Phase-18 | `PHASE18_TRANSITION_DECISION.md` + `PHASE18_ACTIVATION_DECISION.md` + `AUTHORITY_DRIFT_GUARD.md` + `TERMINOLOGY_AUDIT.md` | Accepted Platform Constitution reference set; runtime implementation yetkisi degildir |
-| Phase-19 | `PHASE19_RUNTIME_DECISION.md` + `docs/specs/phase19-platform-runtime/README.md` + `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` + `PHASE19_POINTER_TRANSITION_CANDIDATE.md` + `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` + `PHASE19_POINTER_TRANSITION_DECISION.md` + `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` | Runtime MVP planning/admission/receipt boundary active; implementation candidate docs-only; implementation yetkisi yoktur |
+| Phase-19 | `PHASE19_RUNTIME_DECISION.md` + `docs/specs/phase19-platform-runtime/README.md` + `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md` + `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` + `PHASE19_POINTER_TRANSITION_CANDIDATE.md` + `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` + `PHASE19_POINTER_TRANSITION_DECISION.md` + `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` | Runtime MVP planning/admission/receipt boundary active; evidence matrix and implementation candidate docs-only; implementation yetkisi yoktur |
 | Aktif execution roadmap | `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution reference set + Phase-19 Runtime MVP planning boundary | Ayri implementation karari olmadan runtime baslatilmaz; authority drift review guard ve terminology audit korunur |
 | Canonical performance baseline | `scripts/ci/perf-baseline.lock.json` | Accepted `main` SHA `416a5392`: standalone Performance Gate `26715068398` ve scoped Phase-17 acceptance `26712374737` PASS; closure tag dogrulandi |
 | Review enforcement | Issue #145 tek-maintainer ADR'i, `@kenanay` CODEOWNERS accountability metadata'si ve canli `main` `freeze` protection paritesi ile kapatildi | Bagimsiz self-review iddiasi yoktur; remote CI ve kayitli maintainer karari merge siniridir |

--- a/PHASE19_RUNTIME_DECISION.md
+++ b/PHASE19_RUNTIME_DECISION.md
@@ -99,7 +99,9 @@ running artifact must be a minimal userspace admission harness.
 That harness may only prove the following bounded behavior:
 
 1. It consumes a static, test-owned input bundle.
-2. It checks the bundle against accepted Phase-18 declarative contracts.
+2. It checks only the bounded static test-owned bundle shape and referenced
+   Phase-18 declarative contract metadata required for admission/receipt
+   evidence.
 3. It emits a deterministic receipt.
 4. It fails closed on unknown fields, missing links, stale hashes, invalid
    dependency declarations, authority drift, or ambiguous terms.
@@ -117,7 +119,8 @@ remain accepted:
 4. `WORKSPACE_ADMISSION_RUNTIME_SPECIFICATION.md`
 5. `RUNTIME_RECEIPT_SPECIFICATION.md`
 6. `RUNTIME_EVIDENCE_PLAN.md`
-7. `RUNTIME_NON_GOALS_AND_DENIALS.md`
+7. `RUNTIME_EVIDENCE_MATRIX.md`
+8. `RUNTIME_NON_GOALS_AND_DENIALS.md`
 
 The accepted RFC set lives under `docs/specs/phase19-platform-runtime/`. The
 existence of that directory does not authorize implementation.
@@ -179,7 +182,7 @@ This decision package must not authorize:
 19. Observability-as-authority.
 
 Any such work requires a separate reviewed decision, RFC set, evidence plan,
-and acceptance boundary.
+evidence matrix, and acceptance boundary.
 
 ## Preconditions For Phase-19 Activation Consideration
 
@@ -197,7 +200,7 @@ are true:
 | P19-A7 | Kernel ABI remains frozen | syscall IDs remain `1000-1011`, count remains `12`, ABI version remains `0x00010001` |
 | P19-A8 | Exact-SHA CI passes | strict `ci-freeze` and Dev Loop pass on the pointer transition candidate SHA |
 | P19-A9 | Implementation is separated | pointer transition does not include runtime source code |
-| P19-A10 | Evidence plan is accepted | runtime evidence paths, receipts, negative cases, and fail-closed behavior are defined |
+| P19-A10 | Evidence plan and matrix are accepted | runtime evidence paths, artifact evidence rows, receipts, negative cases, and fail-closed behavior are defined |
 | P19-A11 | Runtime RFC cross-review is accepted | Phase-19 runtime RFC set has a reviewed cross-consistency record |
 | P19-A12 | Pointer transition candidate is accepted | `PHASE19_POINTER_TRANSITION_CANDIDATE.md` defines exact-SHA transition conditions without changing `CURRENT_PHASE` |
 | P19-A13 | Activation preconditions review is accepted | `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` reviews preconditions without activating Phase-19 |

--- a/PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md
+++ b/PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md
@@ -93,7 +93,7 @@ following are true:
 |---|---|---|
 | P19-I1 | Phase pointer stable | `CURRENT_PHASE=19` remains active only as planning/admission/receipt boundary |
 | P19-I2 | RFC set accepted | all Phase-19 Runtime RFCs remain accepted and unchanged or are reviewed in the same decision chain |
-| P19-I3 | Evidence plan mapped | `RUNTIME_EVIDENCE_PLAN.md` positive, negative, determinism, remote, and performance requirements are mapped to concrete checks |
+| P19-I3 | Evidence plan and matrix mapped | `RUNTIME_EVIDENCE_PLAN.md` and `RUNTIME_EVIDENCE_MATRIX.md` positive, negative, determinism, remote, production-default, and performance requirements are mapped to concrete checks |
 | P19-I4 | Inert artifact invariant preserved | input bundle, validation receipt, workspace admission record, and runtime receipt remain non-authority records |
 | P19-I5 | Kernel ABI unchanged | syscall IDs `1000-1011`, syscall count `12`, and ABI version `0x00010001` remain frozen |
 | P19-I6 | Runtime source separated | implementation code is reviewed in a later PR after this candidate; this candidate stays docs-only |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **CURRENT_PHASE:** `19` (`Phase-19 ACTIVE: Platform Runtime MVP planning/admission/receipt boundary`; runtime implementation yetkisi değildir)
 **Freeze Zinciri:** `make ci-freeze` = 40 kapılı strict suite (normative spec-purity dahil) | `make ci-freeze-local` = local performance authority
 **Authority Durumu:** Issue #145 tek-maintainer authority kararıyla giderildi; PR #142, PR #144, PR #148, PR #149, PR #151, PR #150, PR #152 ve Phase-17 closure decision package birleşti. Closure exact-SHA kanıtı `main` SHA `416a5392` üzerinde yenilendi, gerekli uzak acceptance kontrolleri PASS verdi ve `phase17-official-closure` tag'i aynı SHA'ya doğrulandı
-**Yakın Hedef:** Phase-19 Platform Runtime MVP planning/admission/receipt sınırını korumak; mevcut somut girdiler `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, `PHASE19_POINTER_TRANSITION_DECISION.md` ve `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`; `CURRENT_PHASE=19` runtime implementation, loader, installer, workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI authority veya AI Runtime authority vermez
+**Yakın Hedef:** Phase-19 Platform Runtime MVP planning/admission/receipt sınırını korumak; mevcut somut girdiler `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, `PHASE19_POINTER_TRANSITION_DECISION.md` ve `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`; `CURRENT_PHASE=19` runtime implementation, loader, installer, workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI authority veya AI Runtime authority vermez
 **Ring0 Export Ceiling:** `193 symbols` (current enforced ceiling)
 **Performance Baseline Candidate:** `gha-ubuntu24-20260518.149.1-X64` (authorized run `26370359958` artifact'i PR'a import edildi; SHA `f129d4aa` locked acceptance PASS verdi, ancak tek basina closure authority değildir)
 **Development Status:** Phase-16 OFFICIALLY CLOSED ✅ | Phase-17 OFFICIALLY CLOSED ✅ | SINGLE-MAINTAINER AUTHORITY ALIGNED (#145 RESOLVED) ✅ | PR #142/#144/#148/#149/#151/#150/#152 + closure decision package MERGED ✅ | EXACT-SHA REMOTE EVIDENCE PASS ✅ | Phase-18 PLATFORM CONSTITUTION ACCEPTED ✅ | Phase-19 POINTER TRANSITION ACTIVE AS PLANNING BOUNDARY ✅
@@ -41,7 +41,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **Phase 16 Status:** OFFICIALLY CLOSED ✅ | Verification Layer MVP COMPLETE | Evidence chain integrity verified | Trust anchor established | `make verify-system` → 3 gates → PASS | Constitutional rule enforcement active | Fail-closed behavior confirmed
 **Phase 17 Status:** OFFICIALLY CLOSED ✅ | tag `phase17-official-closure` at `416a5392` | full `ci-freeze` (`26712333892`), locked performance (`26715068398`, `26712374737`) ve Phase-17 QEMU evidence lanes (`26712374742`, `26712374736`, `26712374727`, `26712374744`, `26712374728`) PASS | `reports/phase17_official_closure_candidate/`
 **Phase 18 Status:** ACCEPTED PLATFORM CONSTITUTION REFERENCE SET | Authority drift guard and terminology audit active | Runtime implementation, kernel expansion, new syscalls, Ring0 policy and AI authority remain forbidden unless a separate phase RFC and closure authority exists
-**Phase 19 Status:** ACTIVE AS PLATFORM RUNTIME MVP PLANNING / ADMISSION / RECEIPT BOUNDARY | `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, `PHASE19_POINTER_TRANSITION_DECISION.md`, and `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` define the planning and future-decision boundary only; runtime implementation is not authorized
+**Phase 19 Status:** ACTIVE AS PLATFORM RUNTIME MVP PLANNING / ADMISSION / RECEIPT BOUNDARY | `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, `PHASE19_POINTER_TRANSITION_DECISION.md`, and `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` define the planning, evidence-mapping, and future-decision boundary only; runtime implementation is not authorized
 **Architecture Quick Map:** `docs/specs/phase12-trust-layer/AYKENOS_GATE_ARCHITECTURE.md`
 **Active Execution Roadmap:** `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution reference set + Phase-19 Runtime MVP planning boundary | accepted `main` SHA `416a5392` uzerinde bounded Phase-17 uzak evidence PASS; official closure tag doğrulandı; `CURRENT_PHASE=19` runtime implementation yetkisi vermez
 **Canonical Technical Definition:** AykenOS is a deterministic verification architecture that separates kernel execution, verification semantics, evidence artifacts, and distributed diagnostics into explicit layers. The kernel provides mechanism, userspace verification services produce artifact-bound verdicts and receipts, and parity/topology surfaces expose cross-node observability without elevating diagnostics into authority or consensus.
@@ -55,7 +55,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 - **Current Phase:** `19`
 - **Status:** `ACTIVE / PLATFORM RUNTIME MVP PLANNING, ADMISSION, AND RECEIPT BOUNDARY ONLY`
 - **Last Official Closure:** `17` (Execution Pipeline, 2026-05-31)
-- **Candidate Next Authority Action:** `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` constrains a later Phase-19 runtime implementation decision package; runtime source code remains unauthorized until a separate exact-SHA decision
+- **Next Evidence Mapping Action:** `RUNTIME_EVIDENCE_MATRIX.md` maps Phase-19 runtime artifacts to required evidence rows for a later implementation decision package; runtime source code remains unauthorized until a separate exact-SHA decision
 - **Verification Layer:** `COMPLETE` (MVP delivered 2026-04-25)
 - **Closure Index:** `reports/phase17_official_closure_candidate/closure_index.json`
 - **Phase-19 Authority Note:** `CURRENT_PHASE=19` activates only Runtime MVP planning, validation-integration, admission-record, and receipt-boundary authority; runtime implementation still requires a separate decision.
@@ -69,7 +69,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 - **Evidence:** A, B, C karakterleri başarıyla syscall üzerinden basıldı
 - **Result:** Ring3 infrastructure PROVEN, syscall path WORKING, instruction retirement VALIDATED
 
-**Next Focus:** `CURRENT_PHASE=19` altında Runtime MVP planning/admission/receipt sınırını korumak ve `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` ile sonraki implementation decision sınırını dar tutmak. Runtime source code, loader, installer, workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI authority ve AI Runtime authority hâlâ kapalıdır.
+**Next Focus:** `CURRENT_PHASE=19` altında Runtime MVP planning/admission/receipt sınırını korumak ve `RUNTIME_EVIDENCE_MATRIX.md` ile sonraki implementation decision icin artifact/evidence mapping yuzeyini dar tutmak. Runtime source code, loader, installer, workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI authority ve AI Runtime authority hâlâ kapalıdır.
 
 ## Authority Model
 
@@ -324,6 +324,7 @@ Phase 12 trust layer kapsamında tamamlananlar:
 - **Phase-18 Terminology Audit:** `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`
 - **Phase-19 Runtime Decision Package:** `PHASE19_RUNTIME_DECISION.md`
 - **Phase-19 Runtime RFC Set:** `docs/specs/phase19-platform-runtime/README.md`
+- **Phase-19 Runtime Evidence Matrix:** `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`
 - **Phase-19 Runtime Cross-Consistency Review:** `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`
 - **Phase-19 Pointer Transition Candidate:** `PHASE19_POINTER_TRANSITION_CANDIDATE.md`
 - **Phase-19 Activation Preconditions Review:** `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`
@@ -371,13 +372,14 @@ AykenOS iki lisans modeli ile dağıtılır:
 - Phase-18 authority drift guard: `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`; active review guard'dir, runtime veya Phase-19 authority grant degildir.
 - Phase-18 terminology audit: `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`; high-risk vocabulary icin accepted audit kaydidir, runtime authority degildir.
 - Phase-19 runtime decision package: `PHASE19_RUNTIME_DECISION.md`; Platform Runtime MVP sinirini tanimlar, runtime implementation yetkisi vermez.
-- Phase-19 runtime RFC set: `docs/specs/phase19-platform-runtime/README.md`; lifecycle, input bundle, validation integration, workspace admission record, receipt, evidence plan ve denial sinirlarini aktif planning boundary olarak tanimlar; implementation yetkisi vermez.
+- Phase-19 runtime RFC set: `docs/specs/phase19-platform-runtime/README.md`; lifecycle, input bundle, validation integration, workspace admission record, receipt, evidence plan, evidence matrix ve denial sinirlarini aktif planning boundary olarak tanimlar; implementation yetkisi vermez.
+- Phase-19 runtime evidence matrix: `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`; artifact, positive, negative, determinism, remote ve production-default kanit satirlarini map eder; CI gate, evidence PASS veya implementation authority degildir.
 - Phase-19 runtime cross-consistency review: `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`; RFC set PASS review kaydidir, implementation yetkisi vermez.
 - Phase-19 pointer transition candidate: `PHASE19_POINTER_TRANSITION_CANDIDATE.md`; exact-SHA pointer transition kosullarini tanimlayan accepted candidate kaydidir, implementation yetkisi vermez.
 - Phase-19 activation preconditions review: `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`; precondition review PASS kaydidir, runtime implementation yetkisi vermez.
 - Phase-19 pointer transition decision: `PHASE19_POINTER_TRANSITION_DECISION.md`; `CURRENT_PHASE=19` pointer'ini planning/admission/receipt sinirinda aktive eder, runtime implementation yetkisi vermez.
 - Phase-19 runtime implementation decision candidate: `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`; sonraki implementation decision sinirini daraltan candidate kaydidir, runtime source code veya implementation authority vermez.
-- Phase-19 runtime MVP icin ayri implementation RFC/evidence plan/closure boundary hazirlanmadikca package installer, workspace runtime, plugin loader, capability issuer veya trust issuer yazilmaz.
+- Phase-19 runtime MVP icin ayri implementation RFC/evidence plan/evidence matrix/closure boundary hazirlanmadikca package installer, workspace runtime, plugin loader, capability issuer veya trust issuer yazilmaz.
 
 **Orta Vadeli:**
 - Phase-19 Platform Runtime MVP.
@@ -392,7 +394,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 
 ---
 
-**Son Güncelleme:** 06 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=19; Phase-18 Platform Constitution reference set korunur; `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, `PHASE19_POINTER_TRANSITION_DECISION.md` ve `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` Runtime MVP planning/admission/receipt ve future-decision sinirini tanimlar, ancak runtime implementation yetkisi yoktur.
+**Son Güncelleme:** 11 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=19; Phase-18 Platform Constitution reference set korunur; `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, `PHASE19_POINTER_TRANSITION_DECISION.md` ve `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` Runtime MVP planning/admission/receipt, evidence-mapping ve future-decision sinirini tanimlar, ancak runtime implementation yetkisi yoktur.
 **Düzenleyen / Geliştiren / Oluşturan / Mimari Sorumlu:** Kenan AY *(metadata only; runtime/karar yetkisi değildir).*
 
 **© 2026 Kenan AY — AykenOS Project**

--- a/docs/development/DOCUMENTATION_INDEX.md
+++ b/docs/development/DOCUMENTATION_INDEX.md
@@ -1,7 +1,7 @@
 # AykenOS Documentation Index
 This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict, Phase 0 prevails.
 
-**Last Updated:** 2026-06-06
+**Last Updated:** 2026-06-11
 **Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu:** Kenan AY
 **Attribution Boundary:** Human-readable documentation metadata only; not runtime authority or execution evidence.
 **Current Authority Basis:** `phase17-official-closure` + `CURRENT_PHASE=19` + `PHASE19_POINTER_TRANSITION_DECISION.md` + `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`
@@ -48,19 +48,20 @@ Current repo truth icin once su dosyalari referans alin:
 22. `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md` — **accepted Phase-18 terminology audit; runtime not authorized**
 23. `PHASE19_RUNTIME_DECISION.md` — **Phase-19 Runtime MVP decision package; implementation not authorized**
 24. `docs/specs/phase19-platform-runtime/README.md` — **Phase-19 Runtime MVP active planning/admission/receipt RFC set; runtime not authorized**
-25. `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` — **Phase-19 Runtime RFC set cross-consistency review; runtime not authorized**
-26. `PHASE19_POINTER_TRANSITION_CANDIDATE.md` — **Phase-19 pointer transition candidate; implementation not authorized**
-27. `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` — **Phase-19 activation preconditions review; implementation not authorized**
-28. `PHASE19_POINTER_TRANSITION_DECISION.md` — **Phase-19 pointer transition decision; `CURRENT_PHASE=19`, runtime implementation not authorized**
-29. `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` — **Phase-19 implementation decision candidate; runtime source code not authorized**
-30. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
-31. `reports/phase15_official_closure/closure_index.json`
-32. `reports/phase13_official_closure_candidate/closure_index.json`
-33. `reports/phase12_official_closure_candidate/closure_manifest.json`
-34. `reports/phase10_phase11_official_closure_index.json`
-35. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
-36. `Makefile`
-37. `.github/workflows/ci-freeze.yml`
+25. `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md` — **Phase-19 Runtime evidence matrix; evidence PASS and runtime not authorized**
+26. `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` — **Phase-19 Runtime RFC set cross-consistency review; runtime not authorized**
+27. `PHASE19_POINTER_TRANSITION_CANDIDATE.md` — **Phase-19 pointer transition candidate; implementation not authorized**
+28. `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` — **Phase-19 activation preconditions review; implementation not authorized**
+29. `PHASE19_POINTER_TRANSITION_DECISION.md` — **Phase-19 pointer transition decision; `CURRENT_PHASE=19`, runtime implementation not authorized**
+30. `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` — **Phase-19 implementation decision candidate; runtime source code not authorized**
+31. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
+32. `reports/phase15_official_closure/closure_index.json`
+33. `reports/phase13_official_closure_candidate/closure_index.json`
+34. `reports/phase12_official_closure_candidate/closure_manifest.json`
+35. `reports/phase10_phase11_official_closure_index.json`
+36. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
+37. `Makefile`
+38. `.github/workflows/ci-freeze.yml`
 
 Phase-14 workstream numbering ve aktif durum yorumu icin canonical truth source:
 
@@ -107,18 +108,19 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 18. `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md` — accepted terminology audit
 19. `PHASE19_RUNTIME_DECISION.md` — Phase-19 Runtime MVP decision package; not implementation authority
 20. `docs/specs/phase19-platform-runtime/README.md` — Phase-19 Runtime MVP active planning/admission/receipt RFC set; not implementation authority
-21. `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` — Phase-19 Runtime RFC set cross-consistency review; not active implementation authority
-22. `PHASE19_POINTER_TRANSITION_CANDIDATE.md` — Phase-19 pointer transition candidate; not implementation authority
-23. `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` — Phase-19 activation preconditions review; not implementation authority
-24. `PHASE19_POINTER_TRANSITION_DECISION.md` — Phase-19 pointer transition decision; not implementation authority
-25. `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` — Phase-19 implementation decision candidate; not implementation authority
-26. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
-27. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
-28. `docs/specs/phase16-ayken-orchestration/README.md`
-29. `docs/specs/authority-lineage-v1/README.md`
-30. `docs/specs/phase14-distributed-observability/README.md`
-31. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
-32. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
+21. `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md` — Phase-19 Runtime evidence matrix; not evidence PASS or implementation authority
+22. `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` — Phase-19 Runtime RFC set cross-consistency review; not active implementation authority
+23. `PHASE19_POINTER_TRANSITION_CANDIDATE.md` — Phase-19 pointer transition candidate; not implementation authority
+24. `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` — Phase-19 activation preconditions review; not implementation authority
+25. `PHASE19_POINTER_TRANSITION_DECISION.md` — Phase-19 pointer transition decision; not implementation authority
+26. `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` — Phase-19 implementation decision candidate; not implementation authority
+27. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
+28. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
+29. `docs/specs/phase16-ayken-orchestration/README.md`
+30. `docs/specs/authority-lineage-v1/README.md`
+31. `docs/specs/phase14-distributed-observability/README.md`
+32. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
+33. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
 
 ## Phase-18 Reference Set
 1. `PHASE18_TRANSITION_DECISION.md`
@@ -147,17 +149,18 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 6. `docs/specs/phase19-platform-runtime/WORKSPACE_ADMISSION_RUNTIME_SPECIFICATION.md`
 7. `docs/specs/phase19-platform-runtime/RUNTIME_RECEIPT_SPECIFICATION.md`
 8. `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_PLAN.md`
-9. `docs/specs/phase19-platform-runtime/RUNTIME_NON_GOALS_AND_DENIALS.md`
-10. `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` —
+9. `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`
+10. `docs/specs/phase19-platform-runtime/RUNTIME_NON_GOALS_AND_DENIALS.md`
+11. `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` —
     accepted cross-consistency review; does not authorize implementation.
-11. `PHASE19_POINTER_TRANSITION_CANDIDATE.md` — pointer transition
+12. `PHASE19_POINTER_TRANSITION_CANDIDATE.md` — pointer transition
     precondition candidate; does not authorize implementation.
-12. `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` — activation
+13. `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` — activation
     preconditions review; does not authorize implementation.
-13. `PHASE19_POINTER_TRANSITION_DECISION.md` — pointer transition decision;
+14. `PHASE19_POINTER_TRANSITION_DECISION.md` — pointer transition decision;
     activates `CURRENT_PHASE=19` only as planning/admission/receipt boundary
     and does not authorize implementation.
-14. `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` —
+15. `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` —
     implementation decision candidate; narrows a later exact-SHA decision and
     does not authorize runtime source code.
 

--- a/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
+++ b/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
@@ -397,10 +397,10 @@ kurmaz.
 
 Runtime RFC seti `docs/specs/phase19-platform-runtime/` altinda aktiftir. Bu
 set runtime lifecycle, static input bundle, Platform ABI validation
-integration, workspace admission record, runtime receipt, evidence plan ve
-non-goal/denial sinirlarini tanimlar; parser, loader, installer, workspace
-runtime, plugin host, issuer, trust assignment veya execution authority
-kurmaz.
+integration, workspace admission record, runtime receipt, evidence plan,
+evidence matrix ve non-goal/denial sinirlarini tanimlar; parser, loader,
+installer, workspace runtime, plugin host, issuer, trust assignment veya
+execution authority kurmaz.
 
 `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, RFC setinin
 state, validation, admission, receipt, evidence ve denial sinirlarini capraz
@@ -420,6 +420,12 @@ implementation decision icin en dar admission/receipt harness sinirini
 candidate olarak kaydeder. Bu candidate runtime source code, implementation
 decision, parser, loader, installer, workspace runtime, issuer, Semantic CLI
 authority veya AI Runtime authority kurmaz.
+
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`, sonraki
+implementation decision icin artifact, positive, negative, determinism,
+remote, production-default ve performance-boundary evidence satirlarini
+map eder. Bu matrix CI gate, evidence PASS, implementation decision veya
+runtime authority kurmaz.
 
 Phase-19 karar siniri su kurallari korur:
 
@@ -449,6 +455,8 @@ Phase-19 karar siniri su kurallari korur:
 12. Implementation decision candidate, implementation decision degildir;
     runtime source code halen ayri exact-SHA decision ve evidence package
     gerektirir.
+13. Evidence matrix, evidence PASS degildir; matrix satirlari yalniz sonraki
+    implementation decision icin zorunlu kanit yuzeylerini tanimlar.
 
 ## 7. PR Sequence and Coordination Matrix
 
@@ -483,12 +491,13 @@ Phase-19 karar siniri su kurallari korur:
 | Phase-18 Authority Drift Guard | ACTIVE REVIEW GUARD / DOCS-ONLY | Phase-18 aktifken constitutional text'in runtime, loader, issuer, workspace, plugin, trust, capability veya AI/Semantic authority'ye kaymasini fail-closed review etmek | `docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md` | Guard runtime implementation, CI gate, merge authority, Phase-19 activation veya authority grant degildir |
 | Phase-18 Terminology Audit | ACCEPTED AUDIT / DOCS-ONLY | High-risk Phase-18 vocabulary'nin safe meaning, required qualifier ve forbidden reading sinirlarini kaydetmek | `docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md` | Audit PASS runtime implementation, loader, issuer, token, mount, execution veya Phase-19 authority grant degildir |
 | Phase-19 Runtime Decision Package | DECISION PACKAGE / PLANNING BOUNDARY ACTIVE | Platform Runtime MVP'nin decision boundary, non-goal, RFC precondition ve fail-closed denial kosullarini kaydetmek | `PHASE19_RUNTIME_DECISION.md` | Package runtime implementation, loader, installer, workspace runtime, capability issuer, trust issuer, Semantic CLI authority veya AI Runtime authority grant degildir |
-| Phase-19 Runtime RFC Set | ACTIVE RFC SET / IMPLEMENTATION NOT AUTHORIZED | Runtime lifecycle, input bundle, validation integration, workspace admission record, receipt, evidence plan ve denial sinirlarini docs-only tanimlamak | `docs/specs/phase19-platform-runtime/README.md` | RFC set parser, runtime implementation, loader, installer, workspace runtime, capability issuer, trust issuer, Semantic CLI veya AI Runtime authority grant degildir |
+| Phase-19 Runtime RFC Set | ACTIVE RFC SET / IMPLEMENTATION NOT AUTHORIZED | Runtime lifecycle, input bundle, validation integration, workspace admission record, receipt, evidence plan, evidence matrix ve denial sinirlarini docs-only tanimlamak | `docs/specs/phase19-platform-runtime/README.md` | RFC set parser, runtime implementation, loader, installer, workspace runtime, capability issuer, trust issuer, Semantic CLI veya AI Runtime authority grant degildir |
 | Phase-19 Runtime Cross-Consistency Review | ACCEPTED REVIEW / IMPLEMENTATION NOT AUTHORIZED | Runtime RFC setinin lifecycle, input bundle, validation integration, workspace admission, receipt, evidence ve denial sinirlarinin celismedigini kaydetmek | `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` | Review PASS runtime implementation, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
 | Phase-19 Pointer Transition Candidate | ACCEPTED CANDIDATE / SUPERSEDED BY DECISION | Exact-SHA `CURRENT_PHASE=19` pointer transition kosullarini ve inert runtime artifact invariant'ini kaydetmek | `PHASE19_POINTER_TRANSITION_CANDIDATE.md` | Candidate runtime implementation, parser, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
 | Phase-19 Activation Preconditions Review | ACCEPTED PRECONDITION REVIEW / SUPERSEDED BY DECISION | Decision/RFC/cross-review/pointer-candidate zincirinin activation oncesi precondition setini review etmek | `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` | Review PASS runtime implementation, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
 | Phase-19 Pointer Transition Decision | CURRENT_PHASE=19 / IMPLEMENTATION NOT AUTHORIZED | Phase-19'i yalniz Runtime MVP planning, validation-integration, admission-record ve receipt-boundary olarak aktive etmek | `PHASE19_POINTER_TRANSITION_DECISION.md`, `docs/roadmap/CURRENT_PHASE` | Pointer transition runtime implementation, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
 | Phase-19 Runtime Implementation Decision Candidate | CANDIDATE / IMPLEMENTATION NOT AUTHORIZED | Sonraki exact-SHA implementation decision icin minimal userspace admission/receipt harness sinirini ve evidence precondition'larini docs-only kaydetmek | `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` | Candidate runtime source code, implementation decision, parser, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
+| Phase-19 Runtime Evidence Matrix | ACTIVE RFC / IMPLEMENTATION NOT AUTHORIZED | Sonraki implementation decision icin artifact, positive, negative, determinism, remote, production-default ve performance-boundary evidence satirlarini map etmek | `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md` | Matrix CI gate, evidence PASS, implementation decision, parser, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
 
 PR koordinasyon kurallari:
 
@@ -1225,6 +1234,7 @@ Bu roadmap su olaylarda guncellenir:
 - `docs/specs/phase19-platform-runtime/WORKSPACE_ADMISSION_RUNTIME_SPECIFICATION.md`
 - `docs/specs/phase19-platform-runtime/RUNTIME_RECEIPT_SPECIFICATION.md`
 - `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_PLAN.md`
+- `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`
 - `docs/specs/phase19-platform-runtime/RUNTIME_NON_GOALS_AND_DENIALS.md`
 - `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`
 - `PHASE19_POINTER_TRANSITION_CANDIDATE.md`

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -58,21 +58,24 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 19. `../specs/phase19-platform-runtime/README.md`: Phase-19 Runtime MVP
    active planning/admission/receipt RFC set; runtime implementation authority
    degildir.
-20. `../specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`:
+20. `../specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`:
+   Phase-19 Runtime evidence matrix; evidence PASS veya implementation
+   authority degildir.
+21. `../specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`:
    Phase-19 Runtime RFC set capraz tutarlilik review kaydi; runtime
    implementation yetkisi degildir.
-21. `../../PHASE19_POINTER_TRANSITION_CANDIDATE.md`: Phase-19 pointer
+22. `../../PHASE19_POINTER_TRANSITION_CANDIDATE.md`: Phase-19 pointer
    transition kosullarini tanimlayan accepted candidate kaydi; implementation
    authority degildir.
-22. `../../PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`: Phase-19 activation
+23. `../../PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`: Phase-19 activation
    precondition review kaydi; implementation authority degildir.
-23. `../../PHASE19_POINTER_TRANSITION_DECISION.md`: `CURRENT_PHASE=19`
+24. `../../PHASE19_POINTER_TRANSITION_DECISION.md`: `CURRENT_PHASE=19`
    pointer transition decision; yalniz planning/admission/receipt boundary
    kurar, runtime implementation authority degildir.
-24. `../../PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`:
+25. `../../PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`:
    implementation decision candidate; sonraki exact-SHA decision sinirini
    daraltir, runtime source code veya implementation authority kurmaz.
-25. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
+26. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
    planlamasi; aktif Phase-18 otoritesi degildir.
 
 ## Current Status
@@ -82,7 +85,7 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 | Son resmi kapanis | Phase-17 OFFICIALLY CLOSED (`phase17-official-closure` at `416a5392`) |
 | Aktif faz | Phase-19 ACTIVE / Platform Runtime MVP planning, admission, and receipt boundary only |
 | Aktif odak | Phase-19 planning/admission/receipt authority maintenance; runtime implementation remains out of scope |
-| Aday sonraki karar | `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`; source code remains unauthorized until a separate exact-SHA implementation decision |
+| Siradaki docs-only odak | `RUNTIME_EVIDENCE_MATRIX.md` sonraki implementation decision icin kanit satirlarini map eder; source code remains unauthorized until a separate exact-SHA implementation decision |
 | ABI | Canonical `1000-1011` / 12 syscall, ABI version `0x00010001` |
 | Phase-18 | ACCEPTED PLATFORM CONSTITUTION REFERENCE SET; kernel expansion, runtime implementation and new syscalls forbidden unless a separate phase RFC/closure authority exists |
 | Phase-19 | ACTIVE AS PLANNING / VALIDATION-INTEGRATION / ADMISSION-RECORD / RECEIPT BOUNDARY; implementation forbidden until a separate decision |
@@ -119,10 +122,12 @@ current execution priority otoritesi degildir:
 
 ---
 
-**Next action:** `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`
-sonraki implementation decision sinirini docs-only olarak daraltir. Gercek
-Phase-19 runtime implementation karar paketi ancak ayri exact-SHA PR ve
-evidence plan ile degerlendirilebilir. `CURRENT_PHASE=19` runtime source code,
-loader, installer, workspace runtime, plugin host, capability issuer, trust
-issuer, Semantic CLI authority veya AI Runtime authority vermez. High-risk
-vocabulary `TERMINOLOGY_AUDIT.md` kaydina gore denetlenir.
+**Next action:** `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`
+sonraki implementation decision icin artifact, positive, negative,
+determinism, remote ve production-default kanit satirlarini docs-only olarak
+map eder. Gercek Phase-19 runtime implementation karar paketi ancak ayri
+exact-SHA PR ve evidence package ile degerlendirilebilir. `CURRENT_PHASE=19`
+runtime source code, loader, installer, workspace runtime, plugin host,
+capability issuer, trust issuer, Semantic CLI authority veya AI Runtime
+authority vermez. High-risk vocabulary `TERMINOLOGY_AUDIT.md` kaydina gore
+denetlenir.

--- a/docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md
+++ b/docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md
@@ -10,6 +10,7 @@ documents prevail.
 
 **Status:** ACCEPTED REVIEW / PHASE-19 ACTIVE AS PLANNING BOUNDARY / RUNTIME IMPLEMENTATION NOT AUTHORIZED
 **Review date:** 2026-06-05
+**Evidence matrix sync:** 2026-06-11
 **Review id:** `ayken.phase19.runtime.cross_consistency.review.v1`
 **Authority boundary:** Documentation/review record only; not
 `CURRENT_PHASE=19`, not runtime implementation, not a parser, not a package
@@ -52,7 +53,8 @@ The reviewed Phase-19 planning set is:
 6. `docs/specs/phase19-platform-runtime/WORKSPACE_ADMISSION_RUNTIME_SPECIFICATION.md`
 7. `docs/specs/phase19-platform-runtime/RUNTIME_RECEIPT_SPECIFICATION.md`
 8. `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_PLAN.md`
-9. `docs/specs/phase19-platform-runtime/RUNTIME_NON_GOALS_AND_DENIALS.md`
+9. `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`
+10. `docs/specs/phase19-platform-runtime/RUNTIME_NON_GOALS_AND_DENIALS.md`
 
 ## Review Verdict
 
@@ -77,6 +79,7 @@ validation integration != authority grant
 workspace admission record != workspace creation
 receipt != token
 evidence plan != evidence PASS
+evidence matrix != evidence PASS
 MVP boundary denial is mandatory
 ```
 
@@ -118,7 +121,9 @@ This chain is internally coherent:
    `RUNNING`, `LOADED`, `ACTIVE`, `EXECUTING`, or `MOUNTED`.
 6. `RUNTIME_EVIDENCE_PLAN.md` requires positive, negative, deterministic, and
    remote evidence for any later implementation.
-7. `RUNTIME_NON_GOALS_AND_DENIALS.md` rejects any expansion beyond this
+7. `RUNTIME_EVIDENCE_MATRIX.md` maps inert artifacts to positive, negative,
+   deterministic, remote, production-default, and performance evidence rows.
+8. `RUNTIME_NON_GOALS_AND_DENIALS.md` rejects any expansion beyond this
    bounded chain.
 
 **Result:** PASS
@@ -135,6 +140,7 @@ This chain is internally coherent:
 | Workspace Admission Runtime | Defines an inert workspace admission record | Admission record does not create a workspace, mount, handle, context, or permission | PASS |
 | Runtime Receipt | Defines deterministic digest-bound receipt output | Receipt is not a bearer token, capability token, handle, workspace handle, plugin binding, or execution right | PASS |
 | Runtime Evidence Plan | Defines future proof surfaces and negative cases | Evidence plan is not a CI gate implementation or evidence PASS | PASS |
+| Runtime Evidence Matrix | Maps artifacts and denial cases to future evidence rows | Evidence matrix is not a CI gate implementation, evidence PASS, or runtime authority | PASS |
 | Runtime Non-Goals And Denials | Defines mandatory denial boundaries | Denial list grants no runtime behavior and blocks later-phase work from entering Phase-19 | PASS |
 
 ## Lifecycle And Record Dependency Review
@@ -216,13 +222,18 @@ The reviewed RFCs consistently require fail-closed rejection for these leaks:
 | New syscall or kernel ABI expansion requested | Reject | PASS |
 | Later-phase registry, Semantic CLI, AI Runtime, or agents pulled into Phase-19 | Reject | PASS |
 
-## Evidence Plan Review
+## Evidence Plan And Matrix Review
 
 `RUNTIME_EVIDENCE_PLAN.md` is consistent with the RFC set because it requires
 future evidence for both the positive inert pipeline and negative authority
 drift cases before any implementation can be considered.
 
-The evidence plan correctly preserves:
+`RUNTIME_EVIDENCE_MATRIX.md` is consistent with the evidence plan because it
+maps those required proof surfaces to explicit artifact, positive, negative,
+deterministic, remote, production-default, and performance-boundary rows
+without granting implementation authority.
+
+The evidence plan and matrix correctly preserve:
 
 1. Exact-SHA local and remote evidence requirement.
 2. Strict `ci-freeze` and Dev Loop requirement on a candidate SHA.
@@ -231,6 +242,8 @@ The evidence plan correctly preserves:
 5. Negative cases for trust-to-capability, plugin-to-loading, Semantic CLI,
    AI, receipt-to-token, and kernel ABI drift.
 6. Performance measurement only if runtime hot paths are touched.
+7. Matrix rows as future proof obligations, not evidence PASS or CI gate
+   implementation.
 
 **Result:** PASS
 

--- a/docs/specs/phase19-platform-runtime/README.md
+++ b/docs/specs/phase19-platform-runtime/README.md
@@ -20,8 +20,8 @@ This directory defines the active Phase-19 Platform Runtime MVP RFC set.
 
 The set narrows the future runtime implementation question before any runtime
 source code exists. It defines lifecycle, static input bundle, validation
-integration, workspace admission record, runtime receipt, evidence plan, and
-non-goal boundaries.
+integration, workspace admission record, runtime receipt, evidence plan,
+evidence matrix, and non-goal boundaries.
 
 `CURRENT_PHASE=19` activates this planning/admission/receipt boundary only.
 It does not authorize package installation, module loading, workspace
@@ -43,7 +43,9 @@ ABI expansion, or runtime implementation.
    and digest binding.
 6. `RUNTIME_EVIDENCE_PLAN.md` - required local/remote evidence surfaces for a
    later implementation.
-7. `RUNTIME_NON_GOALS_AND_DENIALS.md` - explicit denial list for installer,
+7. `RUNTIME_EVIDENCE_MATRIX.md` - artifact-to-evidence mapping for positive,
+   negative, deterministic, remote, and production-default proof obligations.
+8. `RUNTIME_NON_GOALS_AND_DENIALS.md` - explicit denial list for installer,
    loader, issuer, trust, Semantic CLI, AI Runtime, registry, and agent drift.
 
 ## Current Review Record
@@ -69,11 +71,16 @@ receipt-boundary phase. It does not authorize runtime implementation.
 later implementation decision candidate boundary. It does not authorize
 runtime source code or implementation.
 
+`RUNTIME_EVIDENCE_MATRIX.md` maps accepted evidence obligations to future
+proof rows. It is not a CI gate, evidence PASS, implementation decision, or
+runtime authority.
+
 ## Core Rule
 
 ```text
 Runtime RFC set != runtime implementation
 CURRENT_PHASE=19 != runtime implementation
+evidence matrix != evidence PASS
 ```
 
 The existence of these RFCs and the `CURRENT_PHASE=19` pointer means only that

--- a/docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md
+++ b/docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md
@@ -1,0 +1,182 @@
+# Phase-19 Runtime Evidence Matrix
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, `PHASE18_TRANSITION_DECISION.md`,
+`PHASE18_ACTIVATION_DECISION.md`, the Phase-18 Platform Constitution
+reference set, `AUTHORITY_DRIFT_GUARD.md`, `TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, `../../../PHASE19_POINTER_TRANSITION_DECISION.md`,
+the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_PLAN.md`, and
+`../../../PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`. In case of
+conflict, those documents prevail.
+
+**Status:** ACTIVE RFC / EVIDENCE MATRIX ONLY / RUNTIME IMPLEMENTATION NOT AUTHORIZED
+**Contract id:** `ayken.phase19.runtime.evidence_matrix.v1`
+**Authority boundary:** Documentation/specification only; not a CI gate
+implementation, not evidence PASS, not runtime implementation, not a manifest
+parser, not a package installer, not a module loader, not workspace runtime,
+not real mount authority, not plugin loading, not capability issuance, not
+trust assignment, not Semantic CLI authority, not AI Runtime authority, not a
+syscall, not kernel ABI expansion, not merge authority, and not closure
+authority.
+
+## Purpose
+
+This matrix maps the Phase-19 Runtime MVP artifacts to the evidence that a
+later implementation decision must require before runtime source code can be
+accepted.
+
+It does not implement the evidence. It does not accept any implementation
+decision. It does not authorize runtime source code.
+
+## Core Rule
+
+```text
+evidence matrix != evidence PASS
+evidence row != CI gate
+artifact evidence != authority grant
+```
+
+The safe default remains no runtime behavior unless a later exact-SHA
+implementation decision grants a specific bounded behavior and its own
+evidence package passes.
+
+## Matrix Scope
+
+The matrix covers only the accepted Phase-19 Runtime MVP shape:
+
+```text
+static input bundle
+  -> Phase-18 Platform ABI validation integration record
+  -> workspace admission record
+  -> deterministic runtime receipt
+```
+
+This flow must remain inert. It must not install, load, mount, execute, issue,
+trust, publish, schedule, bind, or grant anything.
+
+## Artifact Evidence Matrix
+
+| Artifact | Positive evidence required later | Determinism evidence required later | Mandatory denial evidence | Forbidden reading |
+|---|---|---|---|---|
+| Static input bundle | One static, test-owned bundle is digest-bound and accepted as input | Same bundle produces the same input bundle digest | Unknown field, duplicate key, missing reference, stale digest, contradictory subject | Parser, installer request, loader request, execution request, token request, workspace creation request |
+| Validation integration record | Phase-18 Platform ABI validation evidence is bound to the same input subject | Same validation input produces the same validation-integration digest | Missing validation receipt, validation FAIL, subject mismatch, validation-as-authority | Authorization, install permission, load permission, trust grant, capability grant |
+| Workspace admission record | Admission record is emitted only after validation integration succeeds | Same accepted input produces the same admission record digest | Real mount request, workspace handle claim, namespace creation claim, access grant claim | Workspace creation, filesystem mount, namespace creation, handle, access grant |
+| Runtime receipt | Receipt binds lifecycle, input, validation, and admission digests | Same accepted input produces the same receipt digest | Receipt-as-token, receipt-as-handle, receipt-as-execution-right | Bearer token, capability token, workspace handle, plugin binding, execution right |
+| Lifecycle transcript | Transcript shows the bounded inert order ending at receipt emission | Same accepted input produces the same lifecycle transcript digest | Any `LOADED`, `RUNNING`, `EXECUTING`, `MOUNTED`, issuer, trust, registry, Semantic CLI, AI, or agent authority phase | Scheduler state, loader state, execution state, workspace runtime state |
+
+## Positive Evidence Matrix
+
+| ID | Evidence target | Required later proof | Does not prove |
+|---|---|---|---|
+| P19-M-P1 | Input binding | Static test-owned input bundle is accepted with canonical digest and subject binding | General parsing, installability, loadability, execution |
+| P19-M-P2 | Validation integration | Validation-integration record references the accepted Phase-18 declarative contract metadata required for admission/receipt evidence | Authorization, trust, capability, workspace, plugin, Semantic CLI, AI authority |
+| P19-M-P3 | Admission record | Workspace admission record is emitted as an inert record after validation integration succeeds | Workspace creation, real mount, namespace creation, handle, access grant |
+| P19-M-P4 | Runtime receipt | Receipt binds lifecycle, input, validation, and admission digests | Token minting, capability issuance, execution right, plugin binding |
+| P19-M-P5 | Bounded transcript | Lifecycle transcript follows the accepted inert order without loader, executor, issuer, trust, registry, Semantic CLI, AI, or agent phases | General runtime execution |
+
+## Negative Evidence Matrix
+
+Every negative case must fail closed before receipt success emission.
+
+| ID | Negative case | Required denial point | Required stable reason class |
+|---|---|---|---|
+| P19-M-N1 | Unknown input bundle field | Before input binding success | `unknown_input_field` |
+| P19-M-N2 | Duplicate input bundle key | Before input binding success | `duplicate_input_key` |
+| P19-M-N3 | Missing manifest reference | Before validation integration success | `missing_manifest_reference` |
+| P19-M-N4 | Stale manifest digest | Before validation integration success | `stale_manifest_digest` |
+| P19-M-N5 | Package and manifest subject mismatch | Before validation integration success | `subject_mismatch` |
+| P19-M-N6 | Missing Platform ABI validation receipt | Before validation integration success | `missing_platform_validation` |
+| P19-M-N7 | Platform ABI validation FAIL | Before admission record success | `platform_validation_failed` |
+| P19-M-N8 | Workspace declaration requests real mount | Before admission record success | `real_mount_denied` |
+| P19-M-N9 | Admission record claims workspace handle | Before admission record success | `workspace_handle_denied` |
+| P19-M-N10 | Receipt declares token authority | Before receipt success | `receipt_token_denied` |
+| P19-M-N11 | Trust classification treated as capability grant | Before receipt success | `trust_capability_denied` |
+| P19-M-N12 | Plugin compatibility treated as loading | Before receipt success | `plugin_loading_denied` |
+| P19-M-N13 | Semantic CLI output treated as runtime authority | Before receipt success | `semantic_cli_authority_denied` |
+| P19-M-N14 | AI output treated as runtime authority | Before receipt success | `ai_authority_denied` |
+| P19-M-N15 | New syscall or kernel ABI expansion request | Before input binding success | `kernel_abi_expansion_denied` |
+
+## Determinism Matrix
+
+| ID | Deterministic surface | Required later repeat proof |
+|---|---|---|
+| P19-M-D1 | Lifecycle transcript digest | Same accepted input produces the same transcript digest across repeated runs |
+| P19-M-D2 | Input bundle digest | Same bundle produces the same canonical input digest |
+| P19-M-D3 | Validation integration digest | Same validation evidence and subject binding produce the same integration digest |
+| P19-M-D4 | Admission record digest | Same accepted input and validation integration produce the same admission digest |
+| P19-M-D5 | Runtime receipt digest | Same accepted input, validation, admission, and lifecycle produce the same receipt digest |
+| P19-M-D6 | Denial reason digest | Same negative input produces the same denial reason class and digest |
+
+Wall-clock, host timing, runner identity, debug log ordering, or advisory text
+must not affect authoritative verdicts.
+
+## Remote Evidence Matrix
+
+| ID | Remote requirement | Required later result |
+|---|---|---|
+| P19-M-R1 | Strict freeze | `ci-freeze` PASS on the exact implementation decision subject SHA |
+| P19-M-R2 | Dev Loop | Dev Loop PASS on the exact implementation decision subject SHA |
+| P19-M-R3 | Runtime-specific gate | Any new admission/receipt runtime gate PASS on the exact subject SHA |
+| P19-M-R4 | Kernel ABI preservation | Syscall IDs `1000-1011`, count `12`, and ABI version `0x00010001` remain unchanged |
+| P19-M-R5 | Authority drift guard | Loader, installer, mount, execution, issuer, trust, registry, Semantic CLI, AI, and agent readings remain denied |
+| P19-M-R6 | Production default | Any validation-only path is default-off and documented with owner, measured surface, and closure condition |
+
+## Performance Evidence Boundary
+
+This matrix does not create a performance claim.
+
+If a later implementation touches runtime hot paths, that implementation
+decision must define:
+
+1. Measured surface.
+2. Baseline authority.
+3. Threshold policy.
+4. Local diagnostic boundary.
+5. Remote acceptance boundary.
+6. Evidence artifact location.
+
+Docs-only evidence-matrix changes do not require baseline renewal and do not
+authorize performance acceptance.
+
+## Later Decision Acceptance Boundary
+
+A later Phase-19 implementation decision is not ready unless it maps every
+accepted positive, negative, deterministic, remote, production-default, and
+performance-relevant matrix row to concrete evidence paths.
+
+Missing, ambiguous, stale, or partially mapped rows fail closed.
+
+## Non-Authority Rule
+
+This matrix must not be read to authorize:
+
+1. Runtime source code.
+2. General manifest parser implementation.
+3. Package installation.
+4. Package execution.
+5. Module loading.
+6. Plugin host, plugin loading, or plugin instantiation.
+7. Workspace creation, workspace runtime, or real mounts.
+8. Capability token minting.
+9. Capability issuance.
+10. Trust assignment or trust issuer behavior.
+11. Registry publication or marketplace behavior.
+12. Semantic CLI execution authority.
+13. AI Runtime authority.
+14. Agent behavior.
+15. New syscalls.
+16. Kernel ABI expansion.
+17. Ring0 policy.
+18. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Matrix Conclusion
+
+This matrix converts the Phase-19 evidence plan into a reviewable evidence
+mapping for a later implementation decision.
+
+It is still documentation only.
+
+Runtime implementation remains unauthorized.


### PR DESCRIPTION
## Summary
- Add `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md` for Phase-19 artifact-to-evidence mapping.
- Sync Phase-19 README, cross-consistency review, roadmap, status report, and documentation index.
- Keep `CURRENT_PHASE=19` as planning/admission/receipt boundary only.

## Authority Boundary
- Docs-only change.
- No runtime source code.
- No kernel, syscall, ABI, baseline, or CI workflow change.
- No loader, installer, workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI authority, AI Runtime authority, or agent authority.

## Local Validation
- `git diff --check` PASS.
- `make ci-gate-spec-purity RUN_ID=local-phase19-runtime-evidence-matrix-spec-purity-20260611 EVIDENCE_ROOT=evidence` PASS.
- `make ci-gate-governance RUN_ID=local-phase19-runtime-evidence-matrix-governance-20260611 EVIDENCE_ROOT=evidence` PASS.