### PR TITLE
docs: add Phase-19 implementation decision package candidate

### DIFF
--- a/AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md
+++ b/AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md
@@ -32,6 +32,10 @@
 > `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` records the later
 > implementation decision candidate boundary; it does not authorize runtime
 > source code or implementation.
+> `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` records the
+> later implementation decision package candidate boundary; it is not an
+> implementation decision and does not authorize runtime source code or
+> implementation.
 > `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md` maps
 > future artifact/evidence rows for a later implementation decision; it is
 > not evidence PASS, a CI gate, or implementation authority.
@@ -52,7 +56,7 @@
 | Phase-17 kapanisi | `reports/phase17_official_closure_candidate/` official closure package ve verified tag mevcut | Closure authority exact-SHA subject ile sinirlidir; Phase-18'i aktive etmez |
 | Phase-17.5 | PR #142, PR #144, PR #148, PR #149/#151/#150, PR #152 ve closure decision package `main`e kabul edildi | Accepted subject SHA `416a5392` icin bounded evidence resmi closure'a baglandi |
 | Phase-18 | `PHASE18_TRANSITION_DECISION.md` + `PHASE18_ACTIVATION_DECISION.md` + `AUTHORITY_DRIFT_GUARD.md` + `TERMINOLOGY_AUDIT.md` | Accepted Platform Constitution reference set; runtime implementation yetkisi degildir |
-| Phase-19 | `PHASE19_RUNTIME_DECISION.md` + `docs/specs/phase19-platform-runtime/README.md` + `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md` + `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` + `PHASE19_POINTER_TRANSITION_CANDIDATE.md` + `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` + `PHASE19_POINTER_TRANSITION_DECISION.md` + `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` | Runtime MVP planning/admission/receipt boundary active; evidence matrix and implementation candidate docs-only; implementation yetkisi yoktur |
+| Phase-19 | `PHASE19_RUNTIME_DECISION.md` + `docs/specs/phase19-platform-runtime/README.md` + `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md` + `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` + `PHASE19_POINTER_TRANSITION_CANDIDATE.md` + `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` + `PHASE19_POINTER_TRANSITION_DECISION.md` + `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` + `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` | Runtime MVP planning/admission/receipt boundary active; evidence matrix, implementation candidate and decision package candidate docs-only; implementation yetkisi yoktur |
 | Aktif execution roadmap | `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution reference set + Phase-19 Runtime MVP planning boundary | Ayri implementation karari olmadan runtime baslatilmaz; authority drift review guard ve terminology audit korunur |
 | Canonical performance baseline | `scripts/ci/perf-baseline.lock.json` | Accepted `main` SHA `416a5392`: standalone Performance Gate `26715068398` ve scoped Phase-17 acceptance `26712374737` PASS; closure tag dogrulandi |
 | Review enforcement | Issue #145 tek-maintainer ADR'i, `@kenanay` CODEOWNERS accountability metadata'si ve canli `main` `freeze` protection paritesi ile kapatildi | Bagimsiz self-review iddiasi yoktur; remote CI ve kayitli maintainer karari merge siniridir |

--- a/PHASE19_RUNTIME_DECISION.md
+++ b/PHASE19_RUNTIME_DECISION.md
@@ -149,6 +149,12 @@ boundary for a later implementation decision. That candidate does not
 authorize runtime source code and does not replace a future exact-SHA
 implementation decision.
 
+`PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` records the
+candidate shape for that later decision package. It maps the minimum behavior,
+evidence-row closure, exact-SHA acceptance preconditions, and fail-closed
+conditions that a separate implementation decision package must satisfy. It
+does not authorize runtime source code or implementation.
+
 `MODULE_LOADING_MODEL.md`, `PLUGIN_INSTANTIATION_MODEL.md`, package
 execution, real workspace mounts, capability issuance, trust assignment,
 Semantic CLI authority, AI Runtime authority, and agent behavior are not part

--- a/PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md
+++ b/PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md
@@ -36,6 +36,10 @@ It exists to prevent the next step from expanding from an admission/receipt
 MVP into loader, installer, workspace runtime, issuer, Semantic CLI, AI, or
 agent behavior.
 
+`PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` may narrow the
+shape of a later implementation decision package, but it is not the
+implementation decision package and does not authorize runtime source code.
+
 ## Core Rule
 
 ```text

--- a/PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md
+++ b/PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md
@@ -1,0 +1,207 @@
+# Phase-19 Runtime Implementation Decision Package Candidate
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, `PHASE18_TRANSITION_DECISION.md`,
+`PHASE18_ACTIVATION_DECISION.md`, the Phase-18 Platform Constitution
+reference set, `AUTHORITY_DRIFT_GUARD.md`, `TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`,
+`PHASE19_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`,
+`PHASE19_POINTER_TRANSITION_DECISION.md`,
+`PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`, and
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`. In case of
+conflict, those documents prevail.
+
+**Status:** CANDIDATE / DECISION PACKAGE NOT ACCEPTED / RUNTIME SOURCE CODE NOT AUTHORIZED
+**Candidate date:** 2026-06-12
+**Candidate id:** `ayken.phase19.runtime_implementation_decision_package_candidate.v1`
+**Authority boundary:** Candidate documentation only; not an implementation
+decision, not runtime source code, not a manifest parser, not a general
+parser, not a userspace harness implementation, not a CI workflow, not a test
+script, not a performance threshold, not package installation, not package
+execution, not module loading, not workspace runtime, not workspace creation,
+not real mount authority, not plugin host, not plugin loading, not capability
+token minting, not capability issuance, not trust assignment, not registry
+publication, not Semantic CLI authority, not AI Runtime authority, not agent
+authority, not a syscall, not kernel ABI expansion, not Ring0 policy, not
+merge authority, and not closure authority.
+
+## Purpose
+
+This package candidate defines what a later exact-SHA Phase-19 Runtime MVP
+implementation decision package must contain before runtime source code can be
+reviewed.
+
+It does not accept the implementation decision.
+
+It does not authorize runtime source code.
+
+It exists to keep the future decision package narrow: minimum inert
+admission/receipt behavior, complete evidence mapping, exact-SHA acceptance
+preconditions, and fail-closed denial rules only.
+
+## Core Rule
+
+```text
+decision package candidate != implementation decision package
+decision package candidate != implementation decision
+implementation decision != runtime implementation
+bounded implementation != loader / installer / issuer / executor authority
+```
+
+The safe default remains no runtime source code and no runtime behavior.
+
+## Candidate Package Scope
+
+A later implementation decision package may be considered only if it answers
+these four questions:
+
+1. What is the exact minimum behavior?
+2. Which evidence path closes each required matrix row?
+3. What exact-SHA remote checks must pass before the decision can be accepted?
+4. Which conditions fail closed before implementation authority can exist?
+
+The package candidate must not include implementation design beyond those
+questions.
+
+## Minimum Behavior Boundary
+
+The only behavior a later implementation decision package may discuss is:
+
+```text
+static input bundle
+  -> Phase-18 Platform ABI validation integration record
+  -> workspace admission record
+  -> deterministic runtime receipt
+```
+
+The future behavior must remain inert. It must not install, load, mount,
+execute, issue, trust, publish, schedule, bind, grant, tokenize, instantiate,
+or create anything.
+
+## Matrix Row Mapping Requirement
+
+A later implementation decision package must map every accepted
+`RUNTIME_EVIDENCE_MATRIX.md` row to a future evidence path.
+
+This candidate records the expected mapping shape only:
+
+| Matrix area | Future evidence path class | Acceptance meaning | Forbidden reading |
+|---|---|---|---|
+| Positive input binding | Positive transcript and input digest evidence | Static test-owned bundle was accepted as inert input | General parser, installer request, loader request |
+| Positive validation integration | Validation integration record and subject-binding evidence | Required Phase-18 declarative metadata was checked for admission/receipt evidence | Authorization, trust, capability, workspace grant |
+| Positive admission record | Workspace admission record evidence | Inert record was emitted after validation integration | Workspace creation, real mount, namespace, handle |
+| Positive runtime receipt | Receipt digest and transcript binding evidence | Receipt binds lifecycle, input, validation, and admission digests | Token, capability, workspace handle, execution right |
+| Unknown or duplicate input denial | Negative denial transcript | Rejected before input binding success | Lenient parse or partial accept |
+| Missing or stale validation denial | Negative denial transcript | Rejected before validation integration success | Validation fallback or assumed compatibility |
+| Workspace mount or handle denial | Negative denial transcript | Rejected before admission record success | Workspace runtime, real mount, access grant |
+| Receipt-as-token denial | Negative denial transcript | Rejected before receipt success | Bearer token or capability token |
+| Trust-as-capability denial | Negative denial transcript | Rejected before receipt success | Trust issuer or capability grant |
+| Plugin-as-loading denial | Negative denial transcript | Rejected before receipt success | Plugin loading, binding, instantiation |
+| Semantic CLI output-as-authority denial | Negative denial transcript | Rejected before receipt success | Semantic CLI execution authority |
+| AI output-as-authority denial | Negative denial transcript | Rejected before receipt success | AI Runtime authority |
+| Kernel ABI expansion denial | Negative denial transcript and ABI freeze proof | Rejected before input binding success | New syscall or ABI widening |
+| Deterministic digest rows | Repeated digest evidence | Same input produces same transcript, record, receipt, and denial digests | Wall-clock, host timing, debug log ordering |
+| Remote proof rows | Exact-SHA remote run evidence | Required checks passed on the decision subject SHA | Historical PASS inheritance |
+| Production-default row | Default profile evidence | Validation-only behavior remains default-off unless separately accepted | Production runtime authority |
+
+Rows may be refined by a later accepted matrix update, but missing,
+ambiguous, stale, or partially mapped rows fail closed.
+
+## Exact-SHA Acceptance Preconditions
+
+A later implementation decision package is not acceptable unless it requires
+all of the following for the exact decision subject SHA:
+
+1. Strict `ci-freeze` PASS.
+2. Dev Loop PASS.
+3. Runtime-specific admission/receipt gates PASS if those gates are proposed.
+4. Positive admission/receipt evidence PASS.
+5. Required negative denial evidence PASS.
+6. Deterministic digest repeat evidence PASS.
+7. Production-default evidence PASS.
+8. Kernel ABI freeze proof PASS.
+9. No CI workflow authority widening unless separately reviewed.
+10. No performance threshold or baseline change unless separately reviewed.
+
+Historical PASS results may be cited as context only. They cannot be inherited
+as authority for the later decision subject SHA.
+
+## Fail-Closed Conditions
+
+A later implementation decision package must fail closed if any of these
+conditions exist:
+
+1. A matrix row has no mapped evidence path.
+2. Positive receipt evidence is missing.
+3. A negative denial case reaches receipt success.
+4. Lifecycle, admission, receipt, or denial digest repeat is nondeterministic.
+5. A receipt is treated as a token, handle, right, or capability.
+6. Trust classification is treated as capability grant.
+7. Plugin compatibility is treated as loading, binding, or instantiation.
+8. Semantic CLI output is treated as runtime authority.
+9. AI output is treated as runtime authority.
+10. Workspace admission is treated as workspace creation or real mount.
+11. Static input bundle acceptance is treated as install, load, or execute
+    permission.
+12. Kernel ABI `1000-1011` / 12 syscall / `0x00010001` changes.
+13. Ring0 policy is introduced.
+14. Evidence becomes runtime control input.
+15. The package includes runtime source code, parser design, CI workflow,
+    test script, or performance threshold details.
+
+Unknown authority readings fail closed.
+
+## Prohibited Package Contents
+
+This package candidate must not include, and a later decision package must not
+smuggle in:
+
+1. Runtime source code.
+2. Manifest parser design.
+3. General parser design.
+4. Harness implementation details.
+5. CI workflow files.
+6. Test scripts.
+7. Performance threshold values.
+8. `CURRENT_PHASE` changes.
+9. Closure language.
+10. Runtime activation language beyond the bounded decision subject.
+11. Loader, installer, package executor, or workspace runtime.
+12. Plugin host or plugin loading.
+13. Capability issuer or token minting.
+14. Trust issuer or trust assignment.
+15. Semantic CLI authority.
+16. AI Runtime authority.
+17. Agent authority.
+18. New syscalls or kernel ABI expansion.
+
+## Relationship To Later Decision And Code
+
+This file is one step before a possible implementation decision package.
+
+The order remains:
+
+```text
+decision package candidate
+  -> separate exact-SHA implementation decision package
+  -> separate implementation PR
+  -> evidence package
+  -> remote PASS
+  -> acceptance review
+```
+
+No step in that chain can inherit implementation authority from this
+candidate.
+
+## Candidate Conclusion
+
+This file records the candidate shape for a later Phase-19 Runtime MVP
+implementation decision package.
+
+The candidate narrows the decision package to minimum inert behavior,
+evidence-row mapping, exact-SHA acceptance preconditions, and fail-closed
+conditions.
+
+Runtime implementation remains unauthorized.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **CURRENT_PHASE:** `19` (`Phase-19 ACTIVE: Platform Runtime MVP planning/admission/receipt boundary`; runtime implementation yetkisi değildir)
 **Freeze Zinciri:** `make ci-freeze` = 40 kapılı strict suite (normative spec-purity dahil) | `make ci-freeze-local` = local performance authority
 **Authority Durumu:** Issue #145 tek-maintainer authority kararıyla giderildi; PR #142, PR #144, PR #148, PR #149, PR #151, PR #150, PR #152 ve Phase-17 closure decision package birleşti. Closure exact-SHA kanıtı `main` SHA `416a5392` üzerinde yenilendi, gerekli uzak acceptance kontrolleri PASS verdi ve `phase17-official-closure` tag'i aynı SHA'ya doğrulandı
-**Yakın Hedef:** Phase-19 Platform Runtime MVP planning/admission/receipt sınırını korumak; mevcut somut girdiler `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, `PHASE19_POINTER_TRANSITION_DECISION.md` ve `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`; `CURRENT_PHASE=19` runtime implementation, loader, installer, workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI authority veya AI Runtime authority vermez
+**Yakın Hedef:** Phase-19 Platform Runtime MVP planning/admission/receipt sınırını korumak; mevcut somut girdiler `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, `PHASE19_POINTER_TRANSITION_DECISION.md`, `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` ve `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md`; `CURRENT_PHASE=19` runtime implementation, loader, installer, workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI authority veya AI Runtime authority vermez
 **Ring0 Export Ceiling:** `193 symbols` (current enforced ceiling)
 **Performance Baseline Candidate:** `gha-ubuntu24-20260518.149.1-X64` (authorized run `26370359958` artifact'i PR'a import edildi; SHA `f129d4aa` locked acceptance PASS verdi, ancak tek basina closure authority değildir)
 **Development Status:** Phase-16 OFFICIALLY CLOSED ✅ | Phase-17 OFFICIALLY CLOSED ✅ | SINGLE-MAINTAINER AUTHORITY ALIGNED (#145 RESOLVED) ✅ | PR #142/#144/#148/#149/#151/#150/#152 + closure decision package MERGED ✅ | EXACT-SHA REMOTE EVIDENCE PASS ✅ | Phase-18 PLATFORM CONSTITUTION ACCEPTED ✅ | Phase-19 POINTER TRANSITION ACTIVE AS PLANNING BOUNDARY ✅
@@ -41,7 +41,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **Phase 16 Status:** OFFICIALLY CLOSED ✅ | Verification Layer MVP COMPLETE | Evidence chain integrity verified | Trust anchor established | `make verify-system` → 3 gates → PASS | Constitutional rule enforcement active | Fail-closed behavior confirmed
 **Phase 17 Status:** OFFICIALLY CLOSED ✅ | tag `phase17-official-closure` at `416a5392` | full `ci-freeze` (`26712333892`), locked performance (`26715068398`, `26712374737`) ve Phase-17 QEMU evidence lanes (`26712374742`, `26712374736`, `26712374727`, `26712374744`, `26712374728`) PASS | `reports/phase17_official_closure_candidate/`
 **Phase 18 Status:** ACCEPTED PLATFORM CONSTITUTION REFERENCE SET | Authority drift guard and terminology audit active | Runtime implementation, kernel expansion, new syscalls, Ring0 policy and AI authority remain forbidden unless a separate phase RFC and closure authority exists
-**Phase 19 Status:** ACTIVE AS PLATFORM RUNTIME MVP PLANNING / ADMISSION / RECEIPT BOUNDARY | `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, `PHASE19_POINTER_TRANSITION_DECISION.md`, and `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` define the planning, evidence-mapping, and future-decision boundary only; runtime implementation is not authorized
+**Phase 19 Status:** ACTIVE AS PLATFORM RUNTIME MVP PLANNING / ADMISSION / RECEIPT BOUNDARY | `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, `PHASE19_POINTER_TRANSITION_DECISION.md`, `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`, and `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` define the planning, evidence-mapping, and future-decision-package boundary only; runtime implementation is not authorized
 **Architecture Quick Map:** `docs/specs/phase12-trust-layer/AYKENOS_GATE_ARCHITECTURE.md`
 **Active Execution Roadmap:** `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution reference set + Phase-19 Runtime MVP planning boundary | accepted `main` SHA `416a5392` uzerinde bounded Phase-17 uzak evidence PASS; official closure tag doğrulandı; `CURRENT_PHASE=19` runtime implementation yetkisi vermez
 **Canonical Technical Definition:** AykenOS is a deterministic verification architecture that separates kernel execution, verification semantics, evidence artifacts, and distributed diagnostics into explicit layers. The kernel provides mechanism, userspace verification services produce artifact-bound verdicts and receipts, and parity/topology surfaces expose cross-node observability without elevating diagnostics into authority or consensus.
@@ -55,7 +55,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 - **Current Phase:** `19`
 - **Status:** `ACTIVE / PLATFORM RUNTIME MVP PLANNING, ADMISSION, AND RECEIPT BOUNDARY ONLY`
 - **Last Official Closure:** `17` (Execution Pipeline, 2026-05-31)
-- **Next Evidence Mapping Action:** `RUNTIME_EVIDENCE_MATRIX.md` maps Phase-19 runtime artifacts to required evidence rows for a later implementation decision package; runtime source code remains unauthorized until a separate exact-SHA decision
+- **Next Decision Package Action:** `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` narrows the minimum behavior, matrix-row evidence closure, exact-SHA preconditions, and fail-closed conditions for a later implementation decision package; runtime source code remains unauthorized until a separate exact-SHA decision
 - **Verification Layer:** `COMPLETE` (MVP delivered 2026-04-25)
 - **Closure Index:** `reports/phase17_official_closure_candidate/closure_index.json`
 - **Phase-19 Authority Note:** `CURRENT_PHASE=19` activates only Runtime MVP planning, validation-integration, admission-record, and receipt-boundary authority; runtime implementation still requires a separate decision.
@@ -69,7 +69,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 - **Evidence:** A, B, C karakterleri başarıyla syscall üzerinden basıldı
 - **Result:** Ring3 infrastructure PROVEN, syscall path WORKING, instruction retirement VALIDATED
 
-**Next Focus:** `CURRENT_PHASE=19` altında Runtime MVP planning/admission/receipt sınırını korumak ve `RUNTIME_EVIDENCE_MATRIX.md` ile sonraki implementation decision icin artifact/evidence mapping yuzeyini dar tutmak. Runtime source code, loader, installer, workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI authority ve AI Runtime authority hâlâ kapalıdır.
+**Next Focus:** `CURRENT_PHASE=19` altında Runtime MVP planning/admission/receipt sınırını korumak ve `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` ile sonraki implementation decision package yuzeyini dar tutmak. Runtime source code, loader, installer, workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI authority ve AI Runtime authority hâlâ kapalıdır.
 
 ## Authority Model
 
@@ -330,6 +330,7 @@ Phase 12 trust layer kapsamında tamamlananlar:
 - **Phase-19 Activation Preconditions Review:** `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`
 - **Phase-19 Pointer Transition Decision:** `PHASE19_POINTER_TRANSITION_DECISION.md`
 - **Phase-19 Runtime Implementation Decision Candidate:** `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`
+- **Phase-19 Runtime Implementation Decision Package Candidate:** `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md`
 - **Documentation Index:** `docs/development/DOCUMENTATION_INDEX.md`
 - **Ring3 User-Leaf Rule:** `docs/governance/RING3_USER_LEAF_ALLOCATION_RULE.md`
 - **Ring3 Runtime Closure Note:** `docs/governance/RING3_RUNTIME_CLOSURE_NOTE.md`
@@ -379,6 +380,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 - Phase-19 activation preconditions review: `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`; precondition review PASS kaydidir, runtime implementation yetkisi vermez.
 - Phase-19 pointer transition decision: `PHASE19_POINTER_TRANSITION_DECISION.md`; `CURRENT_PHASE=19` pointer'ini planning/admission/receipt sinirinda aktive eder, runtime implementation yetkisi vermez.
 - Phase-19 runtime implementation decision candidate: `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`; sonraki implementation decision sinirini daraltan candidate kaydidir, runtime source code veya implementation authority vermez.
+- Phase-19 runtime implementation decision package candidate: `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md`; sonraki implementation decision package icin minimum behavior, matrix-row evidence closure, exact-SHA precondition ve fail-closed sinirlarini daraltir, runtime source code veya implementation authority vermez.
 - Phase-19 runtime MVP icin ayri implementation RFC/evidence plan/evidence matrix/closure boundary hazirlanmadikca package installer, workspace runtime, plugin loader, capability issuer veya trust issuer yazilmaz.
 
 **Orta Vadeli:**
@@ -394,7 +396,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 
 ---
 
-**Son Güncelleme:** 11 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=19; Phase-18 Platform Constitution reference set korunur; `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, `PHASE19_POINTER_TRANSITION_DECISION.md` ve `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` Runtime MVP planning/admission/receipt, evidence-mapping ve future-decision sinirini tanimlar, ancak runtime implementation yetkisi yoktur.
+**Son Güncelleme:** 12 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=19; Phase-18 Platform Constitution reference set korunur; `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, `PHASE19_POINTER_TRANSITION_DECISION.md`, `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` ve `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` Runtime MVP planning/admission/receipt, evidence-mapping ve future-decision-package sinirini tanimlar, ancak runtime implementation yetkisi yoktur.
 **Düzenleyen / Geliştiren / Oluşturan / Mimari Sorumlu:** Kenan AY *(metadata only; runtime/karar yetkisi değildir).*
 
 **© 2026 Kenan AY — AykenOS Project**

--- a/docs/development/DOCUMENTATION_INDEX.md
+++ b/docs/development/DOCUMENTATION_INDEX.md
@@ -1,7 +1,7 @@
 # AykenOS Documentation Index
 This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict, Phase 0 prevails.
 
-**Last Updated:** 2026-06-11
+**Last Updated:** 2026-06-12
 **Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu:** Kenan AY
 **Attribution Boundary:** Human-readable documentation metadata only; not runtime authority or execution evidence.
 **Current Authority Basis:** `phase17-official-closure` + `CURRENT_PHASE=19` + `PHASE19_POINTER_TRANSITION_DECISION.md` + `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`
@@ -18,7 +18,7 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict
 - **Formal Governance Pointer:** `CURRENT_PHASE=19`
 - **Active Phase:** Phase-19 ACTIVE / Platform Runtime MVP planning, admission, and receipt boundary only
 - **Active Execution Priority:** Maintain Phase-19 planning/admission/receipt authority without runtime implementation
-- **Candidate Next Decision:** `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`; source code remains unauthorized until a separate exact-SHA implementation decision
+- **Candidate Next Decision:** `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md`; source code remains unauthorized until a separate exact-SHA implementation decision
 - **Scope Boundary:** `CURRENT_PHASE=19` does not authorize runtime implementation; kernel expansion, new syscalls, Ring0 policy and AI Runtime authority remain forbidden
 
 ## Primary Truth Sources
@@ -54,14 +54,15 @@ Current repo truth icin once su dosyalari referans alin:
 28. `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` — **Phase-19 activation preconditions review; implementation not authorized**
 29. `PHASE19_POINTER_TRANSITION_DECISION.md` — **Phase-19 pointer transition decision; `CURRENT_PHASE=19`, runtime implementation not authorized**
 30. `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` — **Phase-19 implementation decision candidate; runtime source code not authorized**
-31. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
-32. `reports/phase15_official_closure/closure_index.json`
-33. `reports/phase13_official_closure_candidate/closure_index.json`
-34. `reports/phase12_official_closure_candidate/closure_manifest.json`
-35. `reports/phase10_phase11_official_closure_index.json`
-36. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
-37. `Makefile`
-38. `.github/workflows/ci-freeze.yml`
+31. `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` — **Phase-19 implementation decision package candidate; runtime source code not authorized**
+32. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
+33. `reports/phase15_official_closure/closure_index.json`
+34. `reports/phase13_official_closure_candidate/closure_index.json`
+35. `reports/phase12_official_closure_candidate/closure_manifest.json`
+36. `reports/phase10_phase11_official_closure_index.json`
+37. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
+38. `Makefile`
+39. `.github/workflows/ci-freeze.yml`
 
 Phase-14 workstream numbering ve aktif durum yorumu icin canonical truth source:
 
@@ -114,13 +115,14 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 24. `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` — Phase-19 activation preconditions review; not implementation authority
 25. `PHASE19_POINTER_TRANSITION_DECISION.md` — Phase-19 pointer transition decision; not implementation authority
 26. `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` — Phase-19 implementation decision candidate; not implementation authority
-27. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
-28. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
-29. `docs/specs/phase16-ayken-orchestration/README.md`
-30. `docs/specs/authority-lineage-v1/README.md`
-31. `docs/specs/phase14-distributed-observability/README.md`
-32. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
-33. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
+27. `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` — Phase-19 implementation decision package candidate; not implementation authority
+28. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
+29. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
+30. `docs/specs/phase16-ayken-orchestration/README.md`
+31. `docs/specs/authority-lineage-v1/README.md`
+32. `docs/specs/phase14-distributed-observability/README.md`
+33. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
+34. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
 
 ## Phase-18 Reference Set
 1. `PHASE18_TRANSITION_DECISION.md`
@@ -163,6 +165,9 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 15. `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` —
     implementation decision candidate; narrows a later exact-SHA decision and
     does not authorize runtime source code.
+16. `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` —
+    implementation decision package candidate; narrows the package contents
+    for a later exact-SHA decision and does not authorize runtime source code.
 
 ## Phase-14 Reference Set
 ### Architecture and Observability Surfaces

--- a/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
+++ b/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
@@ -427,6 +427,13 @@ remote, production-default ve performance-boundary evidence satirlarini
 map eder. Bu matrix CI gate, evidence PASS, implementation decision veya
 runtime authority kurmaz.
 
+`PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md`, sonraki
+exact-SHA implementation decision package icin minimum behavior, matrix-row
+evidence closure, exact-SHA precondition ve fail-closed kosullarini candidate
+olarak kaydeder. Bu candidate implementation decision, runtime source code,
+parser, loader, installer, workspace runtime, issuer, Semantic CLI authority
+veya AI Runtime authority kurmaz.
+
 Phase-19 karar siniri su kurallari korur:
 
 1. Runtime decision runtime implementation degildir.
@@ -457,6 +464,9 @@ Phase-19 karar siniri su kurallari korur:
     gerektirir.
 13. Evidence matrix, evidence PASS degildir; matrix satirlari yalniz sonraki
     implementation decision icin zorunlu kanit yuzeylerini tanimlar.
+14. Implementation decision package candidate, implementation decision package
+    degildir; minimum behavior, evidence-row closure ve fail-closed kosullari
+    yalniz sonraki exact-SHA karar paketini daraltir.
 
 ## 7. PR Sequence and Coordination Matrix
 
@@ -498,6 +508,7 @@ Phase-19 karar siniri su kurallari korur:
 | Phase-19 Pointer Transition Decision | CURRENT_PHASE=19 / IMPLEMENTATION NOT AUTHORIZED | Phase-19'i yalniz Runtime MVP planning, validation-integration, admission-record ve receipt-boundary olarak aktive etmek | `PHASE19_POINTER_TRANSITION_DECISION.md`, `docs/roadmap/CURRENT_PHASE` | Pointer transition runtime implementation, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
 | Phase-19 Runtime Implementation Decision Candidate | CANDIDATE / IMPLEMENTATION NOT AUTHORIZED | Sonraki exact-SHA implementation decision icin minimal userspace admission/receipt harness sinirini ve evidence precondition'larini docs-only kaydetmek | `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` | Candidate runtime source code, implementation decision, parser, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
 | Phase-19 Runtime Evidence Matrix | ACTIVE RFC / IMPLEMENTATION NOT AUTHORIZED | Sonraki implementation decision icin artifact, positive, negative, determinism, remote, production-default ve performance-boundary evidence satirlarini map etmek | `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md` | Matrix CI gate, evidence PASS, implementation decision, parser, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
+| Phase-19 Runtime Implementation Decision Package Candidate | CANDIDATE / IMPLEMENTATION NOT AUTHORIZED | Sonraki exact-SHA implementation decision package icin minimum behavior, evidence-row closure, exact-SHA precondition ve fail-closed kosullarini docs-only kaydetmek | `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` | Candidate implementation decision package, runtime source code, parser, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
 
 PR koordinasyon kurallari:
 
@@ -1195,7 +1206,9 @@ Bu roadmap su olaylarda guncellenir:
 34. Phase-19 Activation Preconditions Review sonucu.
 35. Phase-19 Pointer Transition Decision sonucu.
 36. Phase-19 Runtime Implementation Decision Candidate sonucu.
-37. Yeni feature/ABI/authority surface onerisinin incelenmesi.
+37. Phase-19 Runtime Evidence Matrix sonucu.
+38. Phase-19 Runtime Implementation Decision Package Candidate sonucu.
+39. Yeni feature/ABI/authority surface onerisinin incelenmesi.
 
 ## References
 
@@ -1241,6 +1254,7 @@ Bu roadmap su olaylarda guncellenir:
 - `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`
 - `PHASE19_POINTER_TRANSITION_DECISION.md`
 - `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`
+- `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md`
 - `PHASE18_ROADMAP.md`
 - `shared/abi/syscall_v2.h`
 - `shared/abi/ayken_abi.h`

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -2,7 +2,7 @@
 This document is subordinate to `ARCHITECTURE_FREEZE.md`. In case of conflict,
 the freeze contract prevails.
 
-**Last authority sync:** 2026-06-06 (Phase-19 Pointer Transition Decision)
+**Last authority sync:** 2026-06-12 (Phase-19 Runtime Implementation Decision Package Candidate)
 **Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu:** Kenan AY
 **Attribution boundary:** Documentation metadata only; not runtime or merge authority.
 
@@ -75,7 +75,11 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 25. `../../PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`:
    implementation decision candidate; sonraki exact-SHA decision sinirini
    daraltir, runtime source code veya implementation authority kurmaz.
-26. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
+26. `../../PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md`:
+   implementation decision package candidate; sonraki exact-SHA decision
+   package sinirini daraltir, runtime source code veya implementation
+   authority kurmaz.
+27. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
    planlamasi; aktif Phase-18 otoritesi degildir.
 
 ## Current Status
@@ -85,7 +89,7 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 | Son resmi kapanis | Phase-17 OFFICIALLY CLOSED (`phase17-official-closure` at `416a5392`) |
 | Aktif faz | Phase-19 ACTIVE / Platform Runtime MVP planning, admission, and receipt boundary only |
 | Aktif odak | Phase-19 planning/admission/receipt authority maintenance; runtime implementation remains out of scope |
-| Siradaki docs-only odak | `RUNTIME_EVIDENCE_MATRIX.md` sonraki implementation decision icin kanit satirlarini map eder; source code remains unauthorized until a separate exact-SHA implementation decision |
+| Siradaki docs-only odak | `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` sonraki implementation decision package icin minimum behavior, evidence-row closure, exact-SHA precondition ve fail-closed kosullarini daraltir; source code remains unauthorized until a separate exact-SHA implementation decision |
 | ABI | Canonical `1000-1011` / 12 syscall, ABI version `0x00010001` |
 | Phase-18 | ACCEPTED PLATFORM CONSTITUTION REFERENCE SET; kernel expansion, runtime implementation and new syscalls forbidden unless a separate phase RFC/closure authority exists |
 | Phase-19 | ACTIVE AS PLANNING / VALIDATION-INTEGRATION / ADMISSION-RECORD / RECEIPT BOUNDARY; implementation forbidden until a separate decision |
@@ -122,12 +126,12 @@ current execution priority otoritesi degildir:
 
 ---
 
-**Next action:** `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`
-sonraki implementation decision icin artifact, positive, negative,
-determinism, remote ve production-default kanit satirlarini docs-only olarak
-map eder. Gercek Phase-19 runtime implementation karar paketi ancak ayri
-exact-SHA PR ve evidence package ile degerlendirilebilir. `CURRENT_PHASE=19`
-runtime source code, loader, installer, workspace runtime, plugin host,
-capability issuer, trust issuer, Semantic CLI authority veya AI Runtime
-authority vermez. High-risk vocabulary `TERMINOLOGY_AUDIT.md` kaydina gore
-denetlenir.
+**Next action:** `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md`
+sonraki implementation decision package icin minimum behavior, matrix-row
+evidence closure, exact-SHA precondition ve fail-closed kosullarini docs-only
+olarak daraltir. Gercek Phase-19 runtime implementation karar paketi ancak
+ayri exact-SHA PR ve evidence package ile degerlendirilebilir.
+`CURRENT_PHASE=19` runtime source code, loader, installer, workspace runtime,
+plugin host, capability issuer, trust issuer, Semantic CLI authority veya AI
+Runtime authority vermez. High-risk vocabulary `TERMINOLOGY_AUDIT.md` kaydina
+gore denetlenir.

--- a/docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md
+++ b/docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md
@@ -11,13 +11,15 @@ documents prevail.
 **Status:** ACCEPTED REVIEW / PHASE-19 ACTIVE AS PLANNING BOUNDARY / RUNTIME IMPLEMENTATION NOT AUTHORIZED
 **Review date:** 2026-06-05
 **Evidence matrix sync:** 2026-06-11
+**Decision package candidate sync:** 2026-06-12
 **Review id:** `ayken.phase19.runtime.cross_consistency.review.v1`
 **Authority boundary:** Documentation/review record only; not
 `CURRENT_PHASE=19`, not runtime implementation, not a parser, not a package
 installer, not a module loader, not workspace runtime, not real mount
 authority, not plugin loading, not capability issuance, not trust assignment,
 not Semantic CLI authority, not AI Runtime authority, not a syscall, not
-kernel ABI expansion, not merge authority, and not closure authority.
+kernel ABI expansion, not an implementation decision package, not merge
+authority, and not closure authority.
 
 ## Purpose
 
@@ -40,6 +42,11 @@ from runtime implementation.
 transition candidate as inputs to check whether activation preconditions were
 documented. That review remains separate from runtime implementation
 authority.
+
+`PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` may use this
+review as background consistency evidence for a later decision package
+candidate. That candidate remains separate from an implementation decision
+and from runtime source code.
 
 ## Reviewed Inputs
 
@@ -80,6 +87,7 @@ workspace admission record != workspace creation
 receipt != token
 evidence plan != evidence PASS
 evidence matrix != evidence PASS
+decision package candidate != implementation decision
 MVP boundary denial is mandatory
 ```
 
@@ -247,6 +255,30 @@ The evidence plan and matrix correctly preserve:
 
 **Result:** PASS
 
+## Implementation Decision Package Candidate Boundary
+
+`PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` is outside the
+reviewed Runtime RFC set. It is consistent with this review only if it remains
+a candidate package boundary and does not become an implementation decision.
+
+The acceptable package-candidate reading is:
+
+1. Minimum inert behavior boundary only.
+2. Matrix-row evidence closure only.
+3. Exact-SHA preconditions only.
+4. Fail-closed conditions only.
+
+The unacceptable reading is:
+
+1. Runtime source code.
+2. Parser design.
+3. Harness implementation details.
+4. CI workflow or test script implementation.
+5. Loader, installer, workspace runtime, issuer, Semantic CLI, AI Runtime, or
+   agent authority.
+
+**Result:** PASS
+
 ## Non-Blocking Wording Risks
 
 The following terms remain acceptable, but future pointer-transition or
@@ -291,6 +323,7 @@ pre-implementation planning reference for a later pointer-transition
 decision.
 
 The safe next step after this review is still not runtime implementation.
-Phase-19 remains inactive until a separate pointer transition is reviewed and
-accepted, and runtime code remains unauthorized until a later implementation
-decision and evidence package exists.
+Phase-19 is now active only as planning, validation-integration,
+admission-record, and receipt-boundary authority. Runtime code remains
+unauthorized until a later implementation decision and evidence package
+exists.

--- a/docs/specs/phase19-platform-runtime/README.md
+++ b/docs/specs/phase19-platform-runtime/README.md
@@ -71,6 +71,10 @@ receipt-boundary phase. It does not authorize runtime implementation.
 later implementation decision candidate boundary. It does not authorize
 runtime source code or implementation.
 
+`../../../PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md`
+records the later implementation decision package candidate boundary. It is
+not an implementation decision and does not authorize runtime source code.
+
 `RUNTIME_EVIDENCE_MATRIX.md` maps accepted evidence obligations to future
 proof rows. It is not a CI gate, evidence PASS, implementation decision, or
 runtime authority.
@@ -81,6 +85,7 @@ runtime authority.
 Runtime RFC set != runtime implementation
 CURRENT_PHASE=19 != runtime implementation
 evidence matrix != evidence PASS
+decision package candidate != implementation decision
 ```
 
 The existence of these RFCs and the `CURRENT_PHASE=19` pointer means only that


### PR DESCRIPTION
## Summary
- Add `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` as the candidate boundary for a later exact-SHA implementation decision package.
- Sync Phase-19 runtime decision, implementation candidate, Runtime RFC README, cross-consistency review, roadmap, status report, and documentation index.
- Keep Phase-19 active only as planning/admission/receipt boundary.

## Authority Boundary
- Docs-only change.
- No runtime source code.
- No parser, harness implementation, CI workflow, test script, or performance threshold.
- No kernel, syscall, ABI, baseline, loader, installer, workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI authority, AI Runtime authority, or agent authority.

## Local Validation
- `git diff --cached --check` PASS.
- `make ci-gate-spec-purity RUN_ID=local-phase19-runtime-decision-package-candidate-spec-purity-20260612 EVIDENCE_ROOT=evidence` PASS.
- `make ci-gate-governance RUN_ID=local-phase19-runtime-decision-package-candidate-governance-20260612 EVIDENCE_ROOT=evidence` PASS.