### PR TITLE
docs: add Phase-19 implementation decision package draft

### DIFF
--- a/AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md
+++ b/AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md
@@ -2,7 +2,7 @@
 
 **Durum tarihi:** 2026-05-23
 **Uygulama ek kaydi:** 2026-05-24/26 (Phase-17 S1.E2E, PR-2B fixture worker completion, PR-3 IRQ timeout-race, PR-4 local performance readiness, PR-4A/PR-4B variance isolation, full-freeze timer witness integration repair, validation flag matrix, issue #145 tek-maintainer authority giderimi, PR #142/#144 merge, PR #148 performance authority onarimi, accepted-main exact-SHA remote evidence PASS ve Phase-17 closure-candidate kaydi)
-**Authority sync:** 2026-06-06 (`CURRENT_PHASE=19`; Phase-19 active as Platform Runtime MVP planning/admission/receipt boundary only)
+**Authority sync:** 2026-06-13 (`CURRENT_PHASE=19`; Phase-19 active as Platform Runtime MVP planning/admission/receipt boundary only)
 **Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu:** Kenan AY
 **Dijital imza siniri:** Bu atif yalnizca insan-okunur dokumantasyon ve metadata icindir; runtime log, karar veya yetki kaynagi degildir.
 
@@ -36,6 +36,10 @@
 > later implementation decision package candidate boundary; it is not an
 > implementation decision and does not authorize runtime source code or
 > implementation.
+> `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md` records the
+> later implementation decision package draft boundary; it is not the
+> implementation decision package and does not authorize runtime source code or
+> implementation.
 > `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md` maps
 > future artifact/evidence rows for a later implementation decision; it is
 > not evidence PASS, a CI gate, or implementation authority.
@@ -56,7 +60,7 @@
 | Phase-17 kapanisi | `reports/phase17_official_closure_candidate/` official closure package ve verified tag mevcut | Closure authority exact-SHA subject ile sinirlidir; Phase-18'i aktive etmez |
 | Phase-17.5 | PR #142, PR #144, PR #148, PR #149/#151/#150, PR #152 ve closure decision package `main`e kabul edildi | Accepted subject SHA `416a5392` icin bounded evidence resmi closure'a baglandi |
 | Phase-18 | `PHASE18_TRANSITION_DECISION.md` + `PHASE18_ACTIVATION_DECISION.md` + `AUTHORITY_DRIFT_GUARD.md` + `TERMINOLOGY_AUDIT.md` | Accepted Platform Constitution reference set; runtime implementation yetkisi degildir |
-| Phase-19 | `PHASE19_RUNTIME_DECISION.md` + `docs/specs/phase19-platform-runtime/README.md` + `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md` + `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` + `PHASE19_POINTER_TRANSITION_CANDIDATE.md` + `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` + `PHASE19_POINTER_TRANSITION_DECISION.md` + `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` + `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` | Runtime MVP planning/admission/receipt boundary active; evidence matrix, implementation candidate and decision package candidate docs-only; implementation yetkisi yoktur |
+| Phase-19 | `PHASE19_RUNTIME_DECISION.md` + `docs/specs/phase19-platform-runtime/README.md` + `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md` + `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md` + `PHASE19_POINTER_TRANSITION_CANDIDATE.md` + `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md` + `PHASE19_POINTER_TRANSITION_DECISION.md` + `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` + `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` + `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md` | Runtime MVP planning/admission/receipt boundary active; evidence matrix, implementation candidate, decision package candidate and decision package draft docs-only; implementation yetkisi yoktur |
 | Aktif execution roadmap | `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution reference set + Phase-19 Runtime MVP planning boundary | Ayri implementation karari olmadan runtime baslatilmaz; authority drift review guard ve terminology audit korunur |
 | Canonical performance baseline | `scripts/ci/perf-baseline.lock.json` | Accepted `main` SHA `416a5392`: standalone Performance Gate `26715068398` ve scoped Phase-17 acceptance `26712374737` PASS; closure tag dogrulandi |
 | Review enforcement | Issue #145 tek-maintainer ADR'i, `@kenanay` CODEOWNERS accountability metadata'si ve canli `main` `freeze` protection paritesi ile kapatildi | Bagimsiz self-review iddiasi yoktur; remote CI ve kayitli maintainer karari merge siniridir |

--- a/PHASE19_RUNTIME_DECISION.md
+++ b/PHASE19_RUNTIME_DECISION.md
@@ -155,6 +155,12 @@ evidence-row closure, exact-SHA acceptance preconditions, and fail-closed
 conditions that a separate implementation decision package must satisfy. It
 does not authorize runtime source code or implementation.
 
+`PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md` records the draft
+shape for that later decision package. It narrows the minimum behavior,
+evidence binding, exact-SHA preconditions, and fail-closed denials further,
+but it is still not the implementation decision package and does not authorize
+runtime source code or implementation.
+
 `MODULE_LOADING_MODEL.md`, `PLUGIN_INSTANTIATION_MODEL.md`, package
 execution, real workspace mounts, capability issuance, trust assignment,
 Semantic CLI authority, AI Runtime authority, and agent behavior are not part

--- a/PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md
+++ b/PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md
@@ -40,6 +40,10 @@ agent behavior.
 shape of a later implementation decision package, but it is not the
 implementation decision package and does not authorize runtime source code.
 
+`PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md` may narrow the
+draft shape of a later implementation decision package, but it is not the
+implementation decision package and does not authorize runtime source code.
+
 ## Core Rule
 
 ```text

--- a/PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md
+++ b/PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md
@@ -185,6 +185,7 @@ The order remains:
 
 ```text
 decision package candidate
+  -> implementation decision package draft
   -> separate exact-SHA implementation decision package
   -> separate implementation PR
   -> evidence package
@@ -194,6 +195,10 @@ decision package candidate
 
 No step in that chain can inherit implementation authority from this
 candidate.
+
+`PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md` may narrow the
+draft shape of that later package, but it is not the implementation decision
+package and does not authorize runtime source code.
 
 ## Candidate Conclusion
 

--- a/PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md
+++ b/PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md
@@ -1,0 +1,209 @@
+# Phase-19 Runtime Implementation Decision Package Draft
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, `PHASE18_TRANSITION_DECISION.md`,
+`PHASE18_ACTIVATION_DECISION.md`, the Phase-18 Platform Constitution
+reference set, `AUTHORITY_DRIFT_GUARD.md`, `TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`,
+`PHASE19_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`,
+`PHASE19_POINTER_TRANSITION_DECISION.md`,
+`PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`, and
+`PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md`. In case of
+conflict, those documents prevail.
+
+**Status:** DRAFT / IMPLEMENTATION DECISION PACKAGE NOT ACCEPTED / RUNTIME SOURCE CODE NOT AUTHORIZED
+**Draft date:** 2026-06-13
+**Draft id:** `ayken.phase19.runtime_implementation_decision_package_draft.v1`
+**Authority boundary:** Draft documentation only; not an implementation
+decision package, not an implementation decision, not runtime source code, not
+a manifest parser, not a general parser, not a harness implementation, not a
+CI workflow, not a test script, not a performance threshold, not package
+installation, not package execution, not module loading, not workspace
+runtime, not workspace creation, not real mount authority, not plugin host, not
+plugin loading, not capability token minting, not capability issuance, not
+trust assignment, not registry publication, not Semantic CLI authority, not AI
+Runtime authority, not agent authority, not a syscall, not kernel ABI
+expansion, not Ring0 policy, not merge authority, and not closure authority.
+
+## Purpose
+
+This draft narrows what a later exact-SHA Phase-19 Runtime MVP implementation
+decision package would need to contain.
+
+This draft is not the implementation decision package and does not authorize
+runtime source code.
+
+It exists to keep the next package small, evidence-bound, and fail-closed
+before any runtime implementation PR can be reviewed.
+
+## Core Rule
+
+```text
+draft != implementation decision package
+implementation decision package != implementation decision
+implementation decision != runtime implementation
+runtime implementation != authority source
+```
+
+The safe default remains no runtime source code and no runtime behavior.
+
+## Draft Scope
+
+A later implementation decision package may be drafted only around these four
+questions:
+
+1. What exact minimum behavior is being considered?
+2. How will the accepted evidence matrix rows be closed?
+3. Which exact-SHA preconditions must pass?
+4. Which cases fail closed before authority can exist?
+
+This draft must not include parser design, harness design, CI workflow files,
+test scripts, performance threshold values, or runtime implementation details.
+
+## Minimum Accepted Behavior
+
+The only behavior that may be discussed by a later implementation decision
+package is:
+
+```text
+static input bundle
+  -> Phase-18 validation integration record
+  -> workspace admission record
+  -> deterministic runtime receipt
+```
+
+This chain is an inert admission/receipt boundary only.
+
+It must not install, load, mount, execute, issue, trust, publish, schedule,
+bind, grant, tokenize, instantiate, or create anything.
+
+Anything outside this chain is a non-goal for the first Phase-19 Runtime MVP
+implementation decision package.
+
+## Evidence Binding
+
+A later implementation decision package must bind every accepted
+`RUNTIME_EVIDENCE_MATRIX.md` row to a future evidence class without defining
+workflow or script implementation details.
+
+The required binding classes are:
+
+| Matrix row class | Required future evidence class | Forbidden reading |
+|---|---|---|
+| Positive input bundle | Positive transcript and input digest | Parser, installer request, loader request, execution request |
+| Positive validation integration | Validation integration record and subject digest | Authorization, trust grant, capability grant, workspace grant |
+| Positive workspace admission | Workspace admission record transcript and digest | Workspace creation, real mount, namespace, handle, access grant |
+| Positive runtime receipt | Runtime receipt transcript and digest binding | Token, capability, handle, execution right |
+| Negative denial rows | Negative transcript ending before receipt success | Partial accept, fallback validation, authority-bearing artifact |
+| Deterministic repeat rows | Repeated digest proof | Wall-clock, host timing, debug output ordering |
+| Remote exact-SHA rows | Remote proof for the decision subject SHA | Historical PASS inheritance |
+| Production-default rows | Default profile proof | Production runtime authority |
+| ABI freeze rows | ABI preservation proof | New syscall, ABI widening, Ring0 policy |
+
+The implementation decision package may name concrete checks only when those
+checks are reviewed as part of that later package. This draft does not define
+or authorize any CI workflow, test script, runtime gate, or performance
+threshold.
+
+## Exact-SHA Preconditions
+
+A later implementation decision package must require exact-SHA proof for the
+decision subject.
+
+At minimum, it must require:
+
+1. Strict `ci-freeze` PASS.
+2. Dev Loop PASS.
+3. Runtime-specific gates PASS if they are separately proposed in that later
+   package.
+4. Positive evidence PASS.
+5. Negative evidence PASS.
+6. Deterministic repeat evidence PASS.
+7. Production-default evidence PASS.
+8. ABI freeze PASS.
+9. No runtime source code bundled into the decision package.
+10. No parser, loader, installer, issuer, workspace runtime, Semantic CLI, AI
+    Runtime, registry, or agent authority bundled into the decision package.
+
+Historical PASS results are context only. Authority cannot be inherited.
+
+If the subject SHA changes, all exact-SHA evidence for that decision subject
+must be regenerated.
+
+## Fail-Closed Denials
+
+A later implementation decision package must fail closed on:
+
+1. Missing evidence.
+2. Partial evidence.
+3. Unmapped matrix rows.
+4. Nondeterministic lifecycle, admission, receipt, or denial digests.
+5. Receipt-as-token.
+6. Trust-as-capability.
+7. Plugin-as-loading.
+8. Semantic CLI output-as-authority.
+9. AI output-as-authority.
+10. Workspace-as-real-mount.
+11. Input bundle as install, load, or execute request.
+12. Kernel ABI drift.
+13. Ring0 policy.
+14. Evidence used as runtime control input.
+15. Runtime source code included in the decision package.
+16. Parser, harness, workflow, script, or threshold detail included in this
+    draft layer.
+
+Unknown authority readings fail closed.
+
+## Prohibited Draft Contents
+
+This draft must not be read to include or authorize:
+
+1. Runtime source code.
+2. Manifest parser design.
+3. General parser design.
+4. Harness implementation details.
+5. CI workflow files.
+6. Test scripts.
+7. Performance threshold values.
+8. `CURRENT_PHASE` changes.
+9. Closure language.
+10. Runtime activation beyond the already active planning/admission/receipt
+    boundary.
+11. Loader, installer, package executor, or workspace runtime.
+12. Plugin host or plugin loading.
+13. Capability issuer or token minting.
+14. Trust issuer or trust assignment.
+15. Semantic CLI authority.
+16. AI Runtime authority.
+17. Agent authority.
+18. New syscalls or kernel ABI expansion.
+
+## Relationship To Later Steps
+
+The order remains:
+
+```text
+implementation decision candidate
+  -> implementation decision package candidate
+  -> implementation decision package draft
+  -> separate exact-SHA implementation decision package
+  -> separate implementation PR
+  -> evidence package
+  -> remote PASS
+  -> acceptance review
+```
+
+No step in that chain can inherit implementation authority from this draft.
+
+## Draft Conclusion
+
+This file records a narrow draft shape for a later Phase-19 Runtime MVP
+implementation decision package.
+
+The draft is limited to minimum inert behavior, evidence binding, exact-SHA
+preconditions, and fail-closed denials.
+
+Runtime implementation remains unauthorized.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **Oluşturan:** Kenan AY
 **Düzenleyen / Geliştiren / Mimari Sorumlu:** Kenan AY *(bilgilendirme metadata'sı; runtime yetkisi değildir)*
 **Oluşturma Tarihi:** 01.01.2026
-**Son Güncelleme:** 06.06.2026
+**Son Güncelleme:** 13.06.2026
 **Closure Evidence:** `local-freeze-p10p11` + `local-phase11-closure` + `run-local-phase12c-closure-2026-03-11` + `run-local-p13-kill-switch-20260315T000051Z` + `phase15-official-closure` + `phase16-verification-layer-mvp-complete`
 **Evidence Git SHA (Phase-10/11):** `9cb2171b` | **Evidence Git SHA (Phase-12C):** `01d1cb5c` | **Evidence Git SHA (Phase-13):** `40158350` | **Evidence Git SHA (Phase-15):** `48970cd0` | **Evidence Git SHA (Phase-16):** `489868f8`
 **Closure Sync / Remote CI (Phase-10/11):** `fe9031d7` (`ci-freeze#22797401328 = success`)
@@ -25,7 +25,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **CURRENT_PHASE:** `19` (`Phase-19 ACTIVE: Platform Runtime MVP planning/admission/receipt boundary`; runtime implementation yetkisi değildir)
 **Freeze Zinciri:** `make ci-freeze` = 40 kapılı strict suite (normative spec-purity dahil) | `make ci-freeze-local` = local performance authority
 **Authority Durumu:** Issue #145 tek-maintainer authority kararıyla giderildi; PR #142, PR #144, PR #148, PR #149, PR #151, PR #150, PR #152 ve Phase-17 closure decision package birleşti. Closure exact-SHA kanıtı `main` SHA `416a5392` üzerinde yenilendi, gerekli uzak acceptance kontrolleri PASS verdi ve `phase17-official-closure` tag'i aynı SHA'ya doğrulandı
-**Yakın Hedef:** Phase-19 Platform Runtime MVP planning/admission/receipt sınırını korumak; mevcut somut girdiler `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, `PHASE19_POINTER_TRANSITION_DECISION.md`, `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` ve `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md`; `CURRENT_PHASE=19` runtime implementation, loader, installer, workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI authority veya AI Runtime authority vermez
+**Yakın Hedef:** Phase-19 Platform Runtime MVP planning/admission/receipt sınırını korumak; mevcut somut girdiler `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, `PHASE19_POINTER_TRANSITION_DECISION.md`, `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`, `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` ve `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md`; `CURRENT_PHASE=19` runtime implementation, loader, installer, workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI authority veya AI Runtime authority vermez
 **Ring0 Export Ceiling:** `193 symbols` (current enforced ceiling)
 **Performance Baseline Candidate:** `gha-ubuntu24-20260518.149.1-X64` (authorized run `26370359958` artifact'i PR'a import edildi; SHA `f129d4aa` locked acceptance PASS verdi, ancak tek basina closure authority değildir)
 **Development Status:** Phase-16 OFFICIALLY CLOSED ✅ | Phase-17 OFFICIALLY CLOSED ✅ | SINGLE-MAINTAINER AUTHORITY ALIGNED (#145 RESOLVED) ✅ | PR #142/#144/#148/#149/#151/#150/#152 + closure decision package MERGED ✅ | EXACT-SHA REMOTE EVIDENCE PASS ✅ | Phase-18 PLATFORM CONSTITUTION ACCEPTED ✅ | Phase-19 POINTER TRANSITION ACTIVE AS PLANNING BOUNDARY ✅
@@ -41,7 +41,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **Phase 16 Status:** OFFICIALLY CLOSED ✅ | Verification Layer MVP COMPLETE | Evidence chain integrity verified | Trust anchor established | `make verify-system` → 3 gates → PASS | Constitutional rule enforcement active | Fail-closed behavior confirmed
 **Phase 17 Status:** OFFICIALLY CLOSED ✅ | tag `phase17-official-closure` at `416a5392` | full `ci-freeze` (`26712333892`), locked performance (`26715068398`, `26712374737`) ve Phase-17 QEMU evidence lanes (`26712374742`, `26712374736`, `26712374727`, `26712374744`, `26712374728`) PASS | `reports/phase17_official_closure_candidate/`
 **Phase 18 Status:** ACCEPTED PLATFORM CONSTITUTION REFERENCE SET | Authority drift guard and terminology audit active | Runtime implementation, kernel expansion, new syscalls, Ring0 policy and AI authority remain forbidden unless a separate phase RFC and closure authority exists
-**Phase 19 Status:** ACTIVE AS PLATFORM RUNTIME MVP PLANNING / ADMISSION / RECEIPT BOUNDARY | `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, `PHASE19_POINTER_TRANSITION_DECISION.md`, `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`, and `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` define the planning, evidence-mapping, and future-decision-package boundary only; runtime implementation is not authorized
+**Phase 19 Status:** ACTIVE AS PLATFORM RUNTIME MVP PLANNING / ADMISSION / RECEIPT BOUNDARY | `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, `PHASE19_POINTER_TRANSITION_DECISION.md`, `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`, `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md`, and `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md` define the planning, evidence-mapping, and future-decision-package draft boundary only; runtime implementation is not authorized
 **Architecture Quick Map:** `docs/specs/phase12-trust-layer/AYKENOS_GATE_ARCHITECTURE.md`
 **Active Execution Roadmap:** `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution reference set + Phase-19 Runtime MVP planning boundary | accepted `main` SHA `416a5392` uzerinde bounded Phase-17 uzak evidence PASS; official closure tag doğrulandı; `CURRENT_PHASE=19` runtime implementation yetkisi vermez
 **Canonical Technical Definition:** AykenOS is a deterministic verification architecture that separates kernel execution, verification semantics, evidence artifacts, and distributed diagnostics into explicit layers. The kernel provides mechanism, userspace verification services produce artifact-bound verdicts and receipts, and parity/topology surfaces expose cross-node observability without elevating diagnostics into authority or consensus.
@@ -55,7 +55,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 - **Current Phase:** `19`
 - **Status:** `ACTIVE / PLATFORM RUNTIME MVP PLANNING, ADMISSION, AND RECEIPT BOUNDARY ONLY`
 - **Last Official Closure:** `17` (Execution Pipeline, 2026-05-31)
-- **Next Decision Package Action:** `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` narrows the minimum behavior, matrix-row evidence closure, exact-SHA preconditions, and fail-closed conditions for a later implementation decision package; runtime source code remains unauthorized until a separate exact-SHA decision
+- **Next Decision Package Action:** `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md` narrows the minimum behavior, evidence binding, exact-SHA preconditions, and fail-closed denials for a later implementation decision package; runtime source code remains unauthorized until a separate exact-SHA decision
 - **Verification Layer:** `COMPLETE` (MVP delivered 2026-04-25)
 - **Closure Index:** `reports/phase17_official_closure_candidate/closure_index.json`
 - **Phase-19 Authority Note:** `CURRENT_PHASE=19` activates only Runtime MVP planning, validation-integration, admission-record, and receipt-boundary authority; runtime implementation still requires a separate decision.
@@ -69,7 +69,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 - **Evidence:** A, B, C karakterleri başarıyla syscall üzerinden basıldı
 - **Result:** Ring3 infrastructure PROVEN, syscall path WORKING, instruction retirement VALIDATED
 
-**Next Focus:** `CURRENT_PHASE=19` altında Runtime MVP planning/admission/receipt sınırını korumak ve `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` ile sonraki implementation decision package yuzeyini dar tutmak. Runtime source code, loader, installer, workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI authority ve AI Runtime authority hâlâ kapalıdır.
+**Next Focus:** `CURRENT_PHASE=19` altında Runtime MVP planning/admission/receipt sınırını korumak ve `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md` ile sonraki implementation decision package draft yuzeyini dar tutmak. Runtime source code, loader, installer, workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI authority ve AI Runtime authority hâlâ kapalıdır.
 
 ## Authority Model
 
@@ -331,6 +331,7 @@ Phase 12 trust layer kapsamında tamamlananlar:
 - **Phase-19 Pointer Transition Decision:** `PHASE19_POINTER_TRANSITION_DECISION.md`
 - **Phase-19 Runtime Implementation Decision Candidate:** `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`
 - **Phase-19 Runtime Implementation Decision Package Candidate:** `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md`
+- **Phase-19 Runtime Implementation Decision Package Draft:** `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md`
 - **Documentation Index:** `docs/development/DOCUMENTATION_INDEX.md`
 - **Ring3 User-Leaf Rule:** `docs/governance/RING3_USER_LEAF_ALLOCATION_RULE.md`
 - **Ring3 Runtime Closure Note:** `docs/governance/RING3_RUNTIME_CLOSURE_NOTE.md`
@@ -381,6 +382,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 - Phase-19 pointer transition decision: `PHASE19_POINTER_TRANSITION_DECISION.md`; `CURRENT_PHASE=19` pointer'ini planning/admission/receipt sinirinda aktive eder, runtime implementation yetkisi vermez.
 - Phase-19 runtime implementation decision candidate: `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`; sonraki implementation decision sinirini daraltan candidate kaydidir, runtime source code veya implementation authority vermez.
 - Phase-19 runtime implementation decision package candidate: `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md`; sonraki implementation decision package icin minimum behavior, matrix-row evidence closure, exact-SHA precondition ve fail-closed sinirlarini daraltir, runtime source code veya implementation authority vermez.
+- Phase-19 runtime implementation decision package draft: `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md`; sonraki implementation decision package icin minimum behavior, evidence binding, exact-SHA precondition ve fail-closed denial sinirlarini daraltir, runtime source code veya implementation authority vermez.
 - Phase-19 runtime MVP icin ayri implementation RFC/evidence plan/evidence matrix/closure boundary hazirlanmadikca package installer, workspace runtime, plugin loader, capability issuer veya trust issuer yazilmaz.
 
 **Orta Vadeli:**
@@ -396,7 +398,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 
 ---
 
-**Son Güncelleme:** 12 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=19; Phase-18 Platform Constitution reference set korunur; `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, `PHASE19_POINTER_TRANSITION_DECISION.md`, `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` ve `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` Runtime MVP planning/admission/receipt, evidence-mapping ve future-decision-package sinirini tanimlar, ancak runtime implementation yetkisi yoktur.
+**Son Güncelleme:** 13 Haziran 2026 - Phase-17 resmi kapanış otoritesi `phase17-official-closure` tag'iyle `416a5392` üzerinde doğrulandı; CURRENT_PHASE=19; Phase-18 Platform Constitution reference set korunur; `PHASE19_RUNTIME_DECISION.md`, `docs/specs/phase19-platform-runtime/README.md`, `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`, `docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md`, `PHASE19_POINTER_TRANSITION_CANDIDATE.md`, `PHASE19_ACTIVATION_PRECONDITIONS_REVIEW.md`, `PHASE19_POINTER_TRANSITION_DECISION.md`, `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`, `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` ve `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md` Runtime MVP planning/admission/receipt, evidence-mapping ve future-decision-package draft sinirini tanimlar, ancak runtime implementation yetkisi yoktur.
 **Düzenleyen / Geliştiren / Oluşturan / Mimari Sorumlu:** Kenan AY *(metadata only; runtime/karar yetkisi değildir).*
 
 **© 2026 Kenan AY — AykenOS Project**

--- a/docs/development/DOCUMENTATION_INDEX.md
+++ b/docs/development/DOCUMENTATION_INDEX.md
@@ -1,7 +1,7 @@
 # AykenOS Documentation Index
 This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict, Phase 0 prevails.
 
-**Last Updated:** 2026-06-12
+**Last Updated:** 2026-06-13
 **Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu:** Kenan AY
 **Attribution Boundary:** Human-readable documentation metadata only; not runtime authority or execution evidence.
 **Current Authority Basis:** `phase17-official-closure` + `CURRENT_PHASE=19` + `PHASE19_POINTER_TRANSITION_DECISION.md` + `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md`
@@ -18,7 +18,7 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict
 - **Formal Governance Pointer:** `CURRENT_PHASE=19`
 - **Active Phase:** Phase-19 ACTIVE / Platform Runtime MVP planning, admission, and receipt boundary only
 - **Active Execution Priority:** Maintain Phase-19 planning/admission/receipt authority without runtime implementation
-- **Candidate Next Decision:** `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md`; source code remains unauthorized until a separate exact-SHA implementation decision
+- **Candidate Next Decision:** `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md`; source code remains unauthorized until a separate exact-SHA implementation decision
 - **Scope Boundary:** `CURRENT_PHASE=19` does not authorize runtime implementation; kernel expansion, new syscalls, Ring0 policy and AI Runtime authority remain forbidden
 
 ## Primary Truth Sources
@@ -55,14 +55,15 @@ Current repo truth icin once su dosyalari referans alin:
 29. `PHASE19_POINTER_TRANSITION_DECISION.md` — **Phase-19 pointer transition decision; `CURRENT_PHASE=19`, runtime implementation not authorized**
 30. `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` — **Phase-19 implementation decision candidate; runtime source code not authorized**
 31. `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` — **Phase-19 implementation decision package candidate; runtime source code not authorized**
-32. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
-33. `reports/phase15_official_closure/closure_index.json`
-34. `reports/phase13_official_closure_candidate/closure_index.json`
-35. `reports/phase12_official_closure_candidate/closure_manifest.json`
-36. `reports/phase10_phase11_official_closure_index.json`
-37. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
-38. `Makefile`
-39. `.github/workflows/ci-freeze.yml`
+32. `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md` — **Phase-19 implementation decision package draft; runtime source code not authorized**
+33. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
+34. `reports/phase15_official_closure/closure_index.json`
+35. `reports/phase13_official_closure_candidate/closure_index.json`
+36. `reports/phase12_official_closure_candidate/closure_manifest.json`
+37. `reports/phase10_phase11_official_closure_index.json`
+38. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
+39. `Makefile`
+40. `.github/workflows/ci-freeze.yml`
 
 Phase-14 workstream numbering ve aktif durum yorumu icin canonical truth source:
 
@@ -116,13 +117,14 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 25. `PHASE19_POINTER_TRANSITION_DECISION.md` — Phase-19 pointer transition decision; not implementation authority
 26. `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` — Phase-19 implementation decision candidate; not implementation authority
 27. `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` — Phase-19 implementation decision package candidate; not implementation authority
-28. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
-29. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
-30. `docs/specs/phase16-ayken-orchestration/README.md`
-31. `docs/specs/authority-lineage-v1/README.md`
-32. `docs/specs/phase14-distributed-observability/README.md`
-33. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
-34. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
+28. `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md` — Phase-19 implementation decision package draft; not implementation authority
+29. `PHASE18_ROADMAP.md` — historical pre-closure runtime-validation roadmap
+30. `docs/roadmap/overview.md` — historical 2026-04-24 snapshot only
+31. `docs/specs/phase16-ayken-orchestration/README.md`
+32. `docs/specs/authority-lineage-v1/README.md`
+33. `docs/specs/phase14-distributed-observability/README.md`
+34. `docs/specs/phase14-distributed-observability/PHASE14_ARCHITECTURE_MAP.md`
+35. `docs/specs/phase14-distributed-observability/PHASE14_DEVELOPMENT_TRACKER.md`
 
 ## Phase-18 Reference Set
 1. `PHASE18_TRANSITION_DECISION.md`
@@ -167,6 +169,9 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
     does not authorize runtime source code.
 16. `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` —
     implementation decision package candidate; narrows the package contents
+    for a later exact-SHA decision and does not authorize runtime source code.
+17. `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md` —
+    implementation decision package draft; narrows the package draft contents
     for a later exact-SHA decision and does not authorize runtime source code.
 
 ## Phase-14 Reference Set

--- a/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
+++ b/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
@@ -434,6 +434,13 @@ olarak kaydeder. Bu candidate implementation decision, runtime source code,
 parser, loader, installer, workspace runtime, issuer, Semantic CLI authority
 veya AI Runtime authority kurmaz.
 
+`PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md`, sonraki exact-SHA
+implementation decision package icin minimum behavior, evidence binding,
+exact-SHA precondition ve fail-closed denial kosullarini draft olarak
+kaydeder. Bu draft implementation decision package, implementation decision,
+runtime source code, parser, loader, installer, workspace runtime, issuer,
+Semantic CLI authority veya AI Runtime authority kurmaz.
+
 Phase-19 karar siniri su kurallari korur:
 
 1. Runtime decision runtime implementation degildir.
@@ -467,6 +474,10 @@ Phase-19 karar siniri su kurallari korur:
 14. Implementation decision package candidate, implementation decision package
     degildir; minimum behavior, evidence-row closure ve fail-closed kosullari
     yalniz sonraki exact-SHA karar paketini daraltir.
+15. Implementation decision package draft, implementation decision package
+    degildir; minimum behavior, evidence binding, exact-SHA precondition ve
+    fail-closed denial kosullari yalniz sonraki exact-SHA karar paketini
+    daraltir.
 
 ## 7. PR Sequence and Coordination Matrix
 
@@ -509,6 +520,7 @@ Phase-19 karar siniri su kurallari korur:
 | Phase-19 Runtime Implementation Decision Candidate | CANDIDATE / IMPLEMENTATION NOT AUTHORIZED | Sonraki exact-SHA implementation decision icin minimal userspace admission/receipt harness sinirini ve evidence precondition'larini docs-only kaydetmek | `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md` | Candidate runtime source code, implementation decision, parser, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
 | Phase-19 Runtime Evidence Matrix | ACTIVE RFC / IMPLEMENTATION NOT AUTHORIZED | Sonraki implementation decision icin artifact, positive, negative, determinism, remote, production-default ve performance-boundary evidence satirlarini map etmek | `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md` | Matrix CI gate, evidence PASS, implementation decision, parser, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
 | Phase-19 Runtime Implementation Decision Package Candidate | CANDIDATE / IMPLEMENTATION NOT AUTHORIZED | Sonraki exact-SHA implementation decision package icin minimum behavior, evidence-row closure, exact-SHA precondition ve fail-closed kosullarini docs-only kaydetmek | `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` | Candidate implementation decision package, runtime source code, parser, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
+| Phase-19 Runtime Implementation Decision Package Draft | DRAFT / IMPLEMENTATION NOT AUTHORIZED | Sonraki exact-SHA implementation decision package icin minimum behavior, evidence binding, exact-SHA precondition ve fail-closed denial kosullarini docs-only daraltmak | `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md` | Draft implementation decision package, implementation decision, runtime source code, parser, loader, installer, workspace runtime, issuer, trust, Semantic CLI veya AI Runtime authority grant degildir |
 
 PR koordinasyon kurallari:
 
@@ -1208,7 +1220,8 @@ Bu roadmap su olaylarda guncellenir:
 36. Phase-19 Runtime Implementation Decision Candidate sonucu.
 37. Phase-19 Runtime Evidence Matrix sonucu.
 38. Phase-19 Runtime Implementation Decision Package Candidate sonucu.
-39. Yeni feature/ABI/authority surface onerisinin incelenmesi.
+39. Phase-19 Runtime Implementation Decision Package Draft sonucu.
+40. Yeni feature/ABI/authority surface onerisinin incelenmesi.
 
 ## References
 
@@ -1255,6 +1268,7 @@ Bu roadmap su olaylarda guncellenir:
 - `PHASE19_POINTER_TRANSITION_DECISION.md`
 - `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_CANDIDATE.md`
 - `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md`
+- `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md`
 - `PHASE18_ROADMAP.md`
 - `shared/abi/syscall_v2.h`
 - `shared/abi/ayken_abi.h`

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -2,7 +2,7 @@
 This document is subordinate to `ARCHITECTURE_FREEZE.md`. In case of conflict,
 the freeze contract prevails.
 
-**Last authority sync:** 2026-06-12 (Phase-19 Runtime Implementation Decision Package Candidate)
+**Last authority sync:** 2026-06-13 (Phase-19 Runtime Implementation Decision Package Draft)
 **Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu:** Kenan AY
 **Attribution boundary:** Documentation metadata only; not runtime or merge authority.
 
@@ -79,7 +79,11 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
    implementation decision package candidate; sonraki exact-SHA decision
    package sinirini daraltir, runtime source code veya implementation
    authority kurmaz.
-27. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
+27. `../../PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md`:
+   implementation decision package draft; sonraki exact-SHA decision package
+   draft sinirini daraltir, runtime source code veya implementation authority
+   kurmaz.
+28. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
    planlamasi; aktif Phase-18 otoritesi degildir.
 
 ## Current Status
@@ -89,7 +93,7 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 | Son resmi kapanis | Phase-17 OFFICIALLY CLOSED (`phase17-official-closure` at `416a5392`) |
 | Aktif faz | Phase-19 ACTIVE / Platform Runtime MVP planning, admission, and receipt boundary only |
 | Aktif odak | Phase-19 planning/admission/receipt authority maintenance; runtime implementation remains out of scope |
-| Siradaki docs-only odak | `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md` sonraki implementation decision package icin minimum behavior, evidence-row closure, exact-SHA precondition ve fail-closed kosullarini daraltir; source code remains unauthorized until a separate exact-SHA implementation decision |
+| Siradaki docs-only odak | `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md` sonraki implementation decision package draft'i icin minimum behavior, evidence binding, exact-SHA precondition ve fail-closed denial kosullarini daraltir; source code remains unauthorized until a separate exact-SHA implementation decision |
 | ABI | Canonical `1000-1011` / 12 syscall, ABI version `0x00010001` |
 | Phase-18 | ACCEPTED PLATFORM CONSTITUTION REFERENCE SET; kernel expansion, runtime implementation and new syscalls forbidden unless a separate phase RFC/closure authority exists |
 | Phase-19 | ACTIVE AS PLANNING / VALIDATION-INTEGRATION / ADMISSION-RECORD / RECEIPT BOUNDARY; implementation forbidden until a separate decision |
@@ -126,11 +130,11 @@ current execution priority otoritesi degildir:
 
 ---
 
-**Next action:** `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_CANDIDATE.md`
-sonraki implementation decision package icin minimum behavior, matrix-row
-evidence closure, exact-SHA precondition ve fail-closed kosullarini docs-only
-olarak daraltir. Gercek Phase-19 runtime implementation karar paketi ancak
-ayri exact-SHA PR ve evidence package ile degerlendirilebilir.
+**Next action:** `PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md`
+sonraki implementation decision package draft'i icin minimum behavior,
+evidence binding, exact-SHA precondition ve fail-closed denial kosullarini
+docs-only olarak daraltir. Gercek Phase-19 runtime implementation karar
+paketi ancak ayri exact-SHA PR ve evidence package ile degerlendirilebilir.
 `CURRENT_PHASE=19` runtime source code, loader, installer, workspace runtime,
 plugin host, capability issuer, trust issuer, Semantic CLI authority veya AI
 Runtime authority vermez. High-risk vocabulary `TERMINOLOGY_AUDIT.md` kaydina

--- a/docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md
+++ b/docs/specs/phase19-platform-runtime/CROSS_CONSISTENCY_REVIEW.md
@@ -12,14 +12,16 @@ documents prevail.
 **Review date:** 2026-06-05
 **Evidence matrix sync:** 2026-06-11
 **Decision package candidate sync:** 2026-06-12
+**Decision package draft sync:** 2026-06-13
 **Review id:** `ayken.phase19.runtime.cross_consistency.review.v1`
 **Authority boundary:** Documentation/review record only; not
 `CURRENT_PHASE=19`, not runtime implementation, not a parser, not a package
 installer, not a module loader, not workspace runtime, not real mount
 authority, not plugin loading, not capability issuance, not trust assignment,
 not Semantic CLI authority, not AI Runtime authority, not a syscall, not
-kernel ABI expansion, not an implementation decision package, not merge
-authority, and not closure authority.
+kernel ABI expansion, not an implementation decision package, not an
+implementation decision package draft authority, not merge authority, and not
+closure authority.
 
 ## Purpose
 
@@ -47,6 +49,11 @@ authority.
 review as background consistency evidence for a later decision package
 candidate. That candidate remains separate from an implementation decision
 and from runtime source code.
+
+`PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md` may use this review
+as background consistency evidence for a later decision package draft. That
+draft remains separate from an implementation decision package, an
+implementation decision, and runtime source code.
 
 ## Reviewed Inputs
 
@@ -88,6 +95,7 @@ receipt != token
 evidence plan != evidence PASS
 evidence matrix != evidence PASS
 decision package candidate != implementation decision
+decision package draft != implementation decision package
 MVP boundary denial is mandatory
 ```
 
@@ -274,6 +282,30 @@ The unacceptable reading is:
 2. Parser design.
 3. Harness implementation details.
 4. CI workflow or test script implementation.
+5. Loader, installer, workspace runtime, issuer, Semantic CLI, AI Runtime, or
+   agent authority.
+
+**Result:** PASS
+
+## Implementation Decision Package Draft Boundary
+
+`PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md` is outside the
+reviewed Runtime RFC set. It is consistent with this review only if it remains
+a draft boundary and does not become an implementation decision package.
+
+The acceptable draft reading is:
+
+1. Minimum inert behavior boundary only.
+2. Evidence binding only.
+3. Exact-SHA preconditions only.
+4. Fail-closed denials only.
+
+The unacceptable reading is:
+
+1. Runtime source code.
+2. Parser or harness design.
+3. CI workflow or test script implementation.
+4. Performance threshold definition.
 5. Loader, installer, workspace runtime, issuer, Semantic CLI, AI Runtime, or
    agent authority.
 

--- a/docs/specs/phase19-platform-runtime/README.md
+++ b/docs/specs/phase19-platform-runtime/README.md
@@ -75,6 +75,10 @@ runtime source code or implementation.
 records the later implementation decision package candidate boundary. It is
 not an implementation decision and does not authorize runtime source code.
 
+`../../../PHASE19_RUNTIME_IMPLEMENTATION_DECISION_PACKAGE_DRAFT.md` records
+the later implementation decision package draft boundary. It is not the
+implementation decision package and does not authorize runtime source code.
+
 `RUNTIME_EVIDENCE_MATRIX.md` maps accepted evidence obligations to future
 proof rows. It is not a CI gate, evidence PASS, implementation decision, or
 runtime authority.
@@ -86,14 +90,16 @@ Runtime RFC set != runtime implementation
 CURRENT_PHASE=19 != runtime implementation
 evidence matrix != evidence PASS
 decision package candidate != implementation decision
+decision package draft != implementation decision package
 ```
 
 The existence of these RFCs and the `CURRENT_PHASE=19` pointer means only that
 the Phase-19 Runtime MVP boundary is active as planning authority. A separate
 implementation decision, implementation RFC acceptance, runtime evidence
 implementation, and remote CI authority remain required before any runtime
-code can be accepted. The implementation decision candidate narrows that
-future decision, but is not itself implementation authority.
+code can be accepted. The implementation decision candidate, package
+candidate, and package draft narrow that future decision path, but none is
+itself implementation authority.
 
 ## MVP Boundary
 


### PR DESCRIPTION
Adds a docs-only Phase-19 Runtime Implementation Decision Package Draft. The draft narrows the later exact-SHA decision package shape to minimum inert behavior, evidence binding, exact-SHA preconditions, and fail-closed denials. It does not authorize runtime source code, parser design, harness implementation, CI workflow changes, test scripts, performance thresholds, loader, installer, workspace runtime, issuer behavior, Semantic CLI authority, AI Runtime authority, syscall changes, ABI changes, workflow changes, or baseline changes.\n\nValidation run locally:\n- git diff --check\n- make ci-gate-spec-purity RUN_ID=local-phase19-runtime-decision-package-draft-spec-purity-20260613 EVIDENCE_ROOT=evidence\n- make ci-gate-governance RUN_ID=local-phase19-runtime-decision-package-draft-governance-20260613 EVIDENCE_ROOT=evidence