### PR TITLE
ci: migrate GitHub Actions to Node 24 actions

### DIFF
--- a/.github/workflows/_shared-setup.yml
+++ b/.github/workflows/_shared-setup.yml
@@ -14,7 +14,7 @@ jobs:
       cache-hit: ${{ steps.cache.outputs.cache-hit }}
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Install dependencies
         run: |
@@ -31,7 +31,7 @@ jobs:
       
       - name: Cache build artifacts
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             out/build

--- a/.github/workflows/ci-freeze.yml
+++ b/.github/workflows/ci-freeze.yml
@@ -90,7 +90,7 @@ jobs:
       SYSCALL_OVMF_VARS: "/usr/share/OVMF/OVMF_VARS_4M.fd"
       SYSCALL_V2_RUNTIME_TIMEOUT: "60"  # Hosted runner needs more time for userspace boot
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Load performance baseline authority
@@ -169,7 +169,7 @@ jobs:
           echo "authority_hash=${AUTHORITY_HASH}" >> "$GITHUB_OUTPUT"
           echo "Drift authority hash: ${AUTHORITY_HASH}"
       - name: Restore drift state cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .ci-state
           key: drift-state-${{ steps.drift_auth.outputs.authority_hash }}
@@ -183,7 +183,7 @@ jobs:
           python3 tools/ci/phase17_spec_validation_gate.py
       - name: Upload Spec Validation Evidence
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: spec-validation-evidence-${{ github.run_id }}
           path: |
@@ -193,7 +193,7 @@ jobs:
           if-no-files-found: warn
       - name: Save drift state cache
         if: ${{ always() && hashFiles('.ci-state/**') != '' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: .ci-state
           key: drift-state-${{ steps.drift_auth.outputs.authority_hash }}
@@ -278,7 +278,7 @@ jobs:
         if: ${{ always() && github.event_name == 'pull_request' }}
         id: ayken_comment
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -352,7 +352,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Upload performance evidence on success
         if: ${{ success() && github.event_name != 'pull_request' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: performance-evidence-${{ github.run_id }}-${{ github.run_attempt }}
           if-no-files-found: error
@@ -396,7 +396,7 @@ jobs:
           done || true
       - name: Upload freeze evidence on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: freeze-evidence-${{ github.run_id }}-${{ github.run_attempt }}
           if-no-files-found: warn
@@ -418,7 +418,7 @@ jobs:
       PERF_ENV_MISMATCH_POLICY: "fail"
       GOVERNANCE_POLICY_KERNEL_PROFILE: "validation"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Load performance baseline authority
@@ -501,7 +501,7 @@ jobs:
           find evidence -maxdepth 4 -type f 2>/dev/null | head -20 || echo "MISSING: evidence directory"
       - name: Upload performance evidence
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: perf-baseline-evidence
           if-no-files-found: error

--- a/.github/workflows/ci-gate-ai-runtime-boundary.yml
+++ b/.github/workflows/ci-gate-ai-runtime-boundary.yml
@@ -23,13 +23,13 @@ jobs:
     env:
       CI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upload gate evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-gate-ai-runtime-boundary-${{ github.run_id }}
           path: evidence/gates/ai-runtime-boundary/

--- a/.github/workflows/ci-gate-bcib-v3-core.yml
+++ b/.github/workflows/ci-gate-bcib-v3-core.yml
@@ -34,13 +34,13 @@ jobs:
     env:
       CI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -71,7 +71,7 @@ jobs:
 
       - name: Upload gate evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-gate-bcib-v3-core-${{ github.run_id }}
           path: evidence/gates/bcib-v3-core/

--- a/.github/workflows/ci-gate-capability-manager.yml
+++ b/.github/workflows/ci-gate-capability-manager.yml
@@ -26,13 +26,13 @@ jobs:
     env:
       CI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -63,7 +63,7 @@ jobs:
 
       - name: Upload gate evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-gate-capability-manager-${{ github.run_id }}
           path: evidence/gates/capability-manager/

--- a/.github/workflows/ci-gate-data-runtime-bcib.yml
+++ b/.github/workflows/ci-gate-data-runtime-bcib.yml
@@ -25,13 +25,13 @@ jobs:
     env:
       CI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload gate evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-gate-data-runtime-bcib-${{ github.run_id }}
           path: evidence/gates/data-runtime-bcib/

--- a/.github/workflows/ci-gate-dsl-bcib-contract.yml
+++ b/.github/workflows/ci-gate-dsl-bcib-contract.yml
@@ -24,13 +24,13 @@ jobs:
     env:
       CI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload gate evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-gate-dsl-bcib-contract-${{ github.run_id }}
           path: evidence/gates/dsl-bcib-contract/

--- a/.github/workflows/ci-gate-execution-marker-determinism.yml
+++ b/.github/workflows/ci-gate-execution-marker-determinism.yml
@@ -23,7 +23,7 @@ jobs:
       EXECUTION_MARKER_DETERMINISM_QEMU_TIMEOUT: "45"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install QEMU and kernel toolchain
         run: |
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upload determinism evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-gate-execution-marker-determinism-${{ github.run_id }}
           path: |

--- a/.github/workflows/ci-gate-execution-marker-lifecycle.yml
+++ b/.github/workflows/ci-gate-execution-marker-lifecycle.yml
@@ -23,7 +23,7 @@ jobs:
       EXECUTION_MARKER_LIFECYCLE_QEMU_TIMEOUT: "45"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install QEMU and kernel toolchain
         run: |
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upload lifecycle evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-gate-execution-marker-lifecycle-${{ github.run_id }}
           path: |

--- a/.github/workflows/ci-gate-execution-public-e2e.yml
+++ b/.github/workflows/ci-gate-execution-public-e2e.yml
@@ -23,7 +23,7 @@ jobs:
       EXECUTION_PUBLIC_E2E_QEMU_TIMEOUT: "45"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install QEMU and kernel toolchain
         run: |
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upload public E2E evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-gate-execution-public-e2e-${{ github.run_id }}
           path: |

--- a/.github/workflows/ci-gate-execution-timeout-race.yml
+++ b/.github/workflows/ci-gate-execution-timeout-race.yml
@@ -24,7 +24,7 @@ jobs:
       EXECUTION_TIMEOUT_RACE_QEMU_TIMEOUT: "45"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install QEMU and kernel toolchain
         run: |
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload IRQ timeout race evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-gate-execution-timeout-race-${{ github.run_id }}
           path: |

--- a/.github/workflows/ci-gate-execution-worker-completion.yml
+++ b/.github/workflows/ci-gate-execution-worker-completion.yml
@@ -23,7 +23,7 @@ jobs:
       EXECUTION_WORKER_COMPLETION_QEMU_TIMEOUT: "45"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install QEMU and kernel toolchain
         run: |
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upload Ring3 worker completion evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-gate-execution-worker-completion-${{ github.run_id }}
           path: |

--- a/.github/workflows/ci-gate-phase17-performance-acceptance.yml
+++ b/.github/workflows/ci-gate-phase17-performance-acceptance.yml
@@ -35,7 +35,7 @@ jobs:
       SYSCALL_OVMF_VARS: "/usr/share/OVMF/OVMF_VARS_4M.fd"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload Phase-17 performance acceptance evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-gate-phase17-performance-acceptance-${{ github.run_id }}
           path: |

--- a/.github/workflows/ci-gate-proofd-observability-boundary.yml
+++ b/.github/workflows/ci-gate-proofd-observability-boundary.yml
@@ -24,13 +24,13 @@ jobs:
     env:
       CI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload gate evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-gate-proofd-observability-boundary-${{ github.run_id }}
           path: evidence/gates/proofd-observability-boundary/

--- a/.github/workflows/ci-gate-semantic-cli-contract.yml
+++ b/.github/workflows/ci-gate-semantic-cli-contract.yml
@@ -25,13 +25,13 @@ jobs:
     env:
       CI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload gate evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-gate-semantic-cli-contract-${{ github.run_id }}
           path: evidence/gates/semantic-cli-contract/

--- a/.github/workflows/ci-gate-toolchain-opcode-registry.yml
+++ b/.github/workflows/ci-gate-toolchain-opcode-registry.yml
@@ -24,13 +24,13 @@ jobs:
     env:
       CI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -68,7 +68,7 @@ jobs:
 
       - name: Upload gate evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-gate-toolchain-opcode-registry-${{ github.run_id }}
           path: evidence/gates/toolchain-opcode-registry/

--- a/.github/workflows/ci-gate-workspace.yml
+++ b/.github/workflows/ci-gate-workspace.yml
@@ -27,7 +27,7 @@ jobs:
       EVIDENCE_ROOT: "evidence"
       WORKSPACE_STRICT: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install toolchain dependencies
         run: |
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload gate evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-gate-workspace-${{ github.run_id }}
           path: evidence/run-${{ env.RUN_ID }}/gates/workspace/

--- a/.github/workflows/dev-loop-optimized.yml
+++ b/.github/workflows/dev-loop-optimized.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 10
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Install dependencies
         run: |
@@ -28,7 +28,7 @@ jobs:
             jq
       
       - name: Cache build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             out/build
@@ -54,7 +54,7 @@ jobs:
       
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dev-loop-optimized
           path: |

--- a/.github/workflows/dev-loop.yml
+++ b/.github/workflows/dev-loop.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 15
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Install dependencies
         run: |
@@ -36,7 +36,7 @@ jobs:
       
       - name: Upload dev loop artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dev-loop-artifacts
           path: |

--- a/.github/workflows/devloop-ci.yml
+++ b/.github/workflows/devloop-ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Install dependencies
         run: |
@@ -34,7 +34,7 @@ jobs:
       
       - name: Upload smoke logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: smoke-logs
           path: out/logs/
@@ -45,7 +45,7 @@ jobs:
     needs: smoke
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Install dependencies
         run: |
@@ -59,7 +59,7 @@ jobs:
       
       - name: Upload contract logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: contract-logs
           path: out/logs/
@@ -70,7 +70,7 @@ jobs:
     needs: contract
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Install dependencies
         run: |
@@ -84,7 +84,7 @@ jobs:
       
       - name: Upload full logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: full-logs
           path: out/logs/
@@ -99,7 +99,7 @@ jobs:
     timeout-minutes: 30
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Full history required for bisect
       
@@ -188,7 +188,7 @@ jobs:
       
       - name: Upload bisect logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bisect-logs
           path: out/logs/bisect/
@@ -196,7 +196,7 @@ jobs:
       
       - name: Comment on PR with bisect result
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -241,7 +241,7 @@ jobs:
     needs: full
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Install dependencies
         run: |
@@ -255,7 +255,7 @@ jobs:
       
       - name: Upload isolation logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: isolation-logs
           path: out/logs/
@@ -267,7 +267,7 @@ jobs:
     needs: isolation
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Install dependencies
         run: |
@@ -287,7 +287,7 @@ jobs:
       
       - name: Upload performance logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: performance-logs
           path: out/logs/

--- a/.github/workflows/evidence.yml
+++ b/.github/workflows/evidence.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Run evidence isolation check
         run: |
@@ -20,7 +20,7 @@ jobs:
       
       - name: Upload evidence report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: evidence-report
           path: out/evidence/**/reports/evidence_*.json

--- a/.github/workflows/governance-evidence-isolation.yml
+++ b/.github/workflows/governance-evidence-isolation.yml
@@ -13,7 +13,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       
@@ -24,7 +24,7 @@ jobs:
       
       - name: Upload check results (on failure)
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: evidence-isolation-failure
           path: |

--- a/.github/workflows/governance-naming-compliance.yml
+++ b/.github/workflows/governance-naming-compliance.yml
@@ -13,7 +13,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       
@@ -29,7 +29,7 @@ jobs:
       
       - name: Upload check results (on failure)
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: naming-compliance-failure
           path: |

--- a/.github/workflows/governance-observation-boundary.yml
+++ b/.github/workflows/governance-observation-boundary.yml
@@ -13,7 +13,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       
@@ -24,7 +24,7 @@ jobs:
       
       - name: Upload check results (on failure)
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: observation-boundary-failure
           path: |

--- a/.github/workflows/governance-spec-purity.yml
+++ b/.github/workflows/governance-spec-purity.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run normative spec purity check
         run: |
@@ -26,7 +26,7 @@ jobs:
 
       - name: Upload check script on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: spec-purity-failure
           path: |

--- a/.github/workflows/governance-summary.yml
+++ b/.github/workflows/governance-summary.yml
@@ -18,7 +18,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Display governance status
         run: |

--- a/.github/workflows/naming.yml
+++ b/.github/workflows/naming.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Run naming compliance check
         run: |
@@ -20,7 +20,7 @@ jobs:
       
       - name: Upload naming report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: naming-report
           path: out/evidence/**/reports/naming_*.json

--- a/.github/workflows/perf-baseline-init.yml
+++ b/.github/workflows/perf-baseline-init.yml
@@ -22,7 +22,7 @@ jobs:
       PERF_ENV_MISMATCH_POLICY: "fail"
       PERF_ALLOW_BASELINE_LOCK_MUTATION: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Load performance baseline authority
         run: |
@@ -142,7 +142,7 @@ jobs:
       
       - name: Upload performance evidence
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: perf-baseline-evidence
           if-no-files-found: error

--- a/.github/workflows/perf-learning-comment.yml
+++ b/.github/workflows/perf-learning-comment.yml
@@ -25,7 +25,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -77,7 +77,7 @@ jobs:
             --created-at-utc "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
       - name: Upload outputs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: perf-learning-outputs-${{ github.run_id }}-${{ github.run_attempt }}
           if-no-files-found: error
@@ -89,7 +89,7 @@ jobs:
 
       - name: Post PR comment
         if: ${{ github.event.inputs.post_pr_comment == 'true' && github.event.inputs.pr_number != '' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -46,7 +46,7 @@ jobs:
       SYSCALL_OVMF_VARS: "/usr/share/OVMF/OVMF_VARS_4M.fd"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload performance evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: performance-gate-${{ github.run_id }}
           path: |


### PR DESCRIPTION
## Summary
- Updates GitHub-maintained workflow actions to Node 24 compatible major versions.
- Keeps the change limited to workflow maintenance: checkout v6, upload-artifact v7, cache v5, and github-script v9.
- Does not change Phase-19 documents, runtime source, kernel code, ABI, baselines, or workflow authority semantics.

## Validation
- Verified latest official action metadata uses node24.
- Confirmed no old actions/*@v4 or github-script@v7 references remain in .github/workflows.
- git diff --check: PASS.
- make ci-gate-governance RUN_ID=local-node20-migration-governance-20260613 EVIDENCE_ROOT=evidence: PASS.