### PR TITLE
ci(perf): renew baseline for runner image

### DIFF
--- a/scripts/ci/perf-baseline.lock.json
+++ b/scripts/ci/perf-baseline.lock.json
@@ -1,10 +1,10 @@
 {
-  "created_at_utc": "2026-06-11T16:36:06Z",
+  "created_at_utc": "2026-06-20T00:32:16Z",
   "env": {
     "baseline_authority": "github-hosted-ubuntu-24.04-x64",
-    "ci_image_digest": "gha-ubuntu24-20260607.184.1-X64",
+    "ci_image_digest": "gha-ubuntu24-20260615.205.1-X64",
     "clang_version": "Ubuntu clang version 18.1.3 (1ubuntu1)",
-    "env_hash": "edbe5bed0e83075ace80b5d9aa09588613afceedd8304e30891a20aae2dc4a67",
+    "env_hash": "79424490b83a96fff8ddaf716a9420b9dfc7a9590c9c109085c18ea824b1208b",
     "host_arch": "x86_64",
     "host_os": "Linux",
     "kernel_profile": "validation",
@@ -23,14 +23,14 @@
     },
     "nasm_version": "NASM version 2.16.01",
     "qemu_timeout_seconds": 30,
-    "qemu_version": "QEMU emulator version 8.2.2 (Debian 1:8.2.2+ds-0ubuntu1.16)",
+    "qemu_version": "QEMU emulator version 8.2.2 (Debian 1:8.2.2+ds-0ubuntu1.17)",
     "target_triple": "x86_64-elf"
   },
-  "git_sha": "0f956c672075773aeed2d2e718d5c794ae716b9e",
+  "git_sha": "475bc5862b6dc98dc5951efe0c3b647327463c0d",
   "metrics": {
-    "boot_time_ms": 10696,
-    "context_switch_latency_ms_proxy": 172.344262,
-    "syscall_latency_ms_proxy": 172.344262
+    "boot_time_ms": 10690,
+    "context_switch_latency_ms_proxy": 172.229508,
+    "syscall_latency_ms_proxy": 172.229508
   },
   "policy": {
     "baseline_authority": "github-hosted-ubuntu-24.04-x64",
@@ -54,30 +54,30 @@
     }
   },
   "raw_metrics": {
-    "boot_time_ms": 10696,
-    "context_switch_latency_ms_proxy": 172.344262,
+    "boot_time_ms": 10690,
+    "context_switch_latency_ms_proxy": 172.229508,
     "entry_latency_ticks": {
       "available": true,
-      "ticks": 22563838
+      "ticks": 24118780
     },
     "mailbox_phase_breakdown_ticks": {
       "consume_trace": {
-        "count": 22,
+        "count": 16,
         "latest": {
-          "candidate_epoch": 538,
-          "new_last_epoch": 538,
-          "old_last_epoch": 102,
+          "candidate_epoch": 20,
+          "new_last_epoch": 20,
+          "old_last_epoch": 19,
           "reason": "timer_validate_accept_consume",
           "site": "timer_validate_irq",
           "tick_valid": 2,
-          "ticks": 25550440141
+          "ticks": 25533179166
         },
         "reason_counts": {
           "gate45_self_keep_running_bypass": 0,
           "gate4_epoch1_pending_bypass": 0,
           "scheduler_keep_running_consume": 0,
           "scheduler_switch_consume": 1,
-          "timer_validate_accept_consume": 21,
+          "timer_validate_accept_consume": 15,
           "timer_validate_accept_deferred": 0
         },
         "site_counts": {
@@ -85,41 +85,41 @@
           "IRQ": 0,
           "START": 0,
           "YIELD": 0,
-          "timer_validate_irq": 21
+          "timer_validate_irq": 15
         }
       },
       "durations": {
         "arbiter": {
           "available": true,
-          "ticks": 8948209
+          "ticks": 10399589
         },
         "arbiter_candidate_lookup": {
           "available": true,
-          "ticks": 431078
+          "ticks": 456116
         },
         "arbiter_decision": {
           "available": true,
-          "ticks": 4323834
+          "ticks": 4732616
         },
         "arbiter_owner_lookup": {
           "available": true,
-          "ticks": 485467
+          "ticks": 753032
         },
         "extract": {
           "available": true,
-          "ticks": 2342347
+          "ticks": 2613684
         },
         "handoff": {
           "available": true,
-          "ticks": 379530
+          "ticks": 384577
         },
         "snapshot": {
           "available": true,
-          "ticks": 440828
+          "ticks": 552157
         },
         "validate": {
           "available": true,
-          "ticks": 1069107
+          "ticks": 1197217
         }
       },
       "events": {
@@ -129,7 +129,7 @@
         },
         "arbiter_candidate_accept_switch": {
           "available": true,
-          "ticks": 25368747455
+          "ticks": 25344426756
         },
         "arbiter_candidate_reject": {
           "available": false,
@@ -137,7 +137,7 @@
         },
         "arbiter_decision_path_fallback": {
           "available": true,
-          "ticks": 25407808393
+          "ticks": 25386356301
         },
         "arbiter_decision_path_keep_running": {
           "available": false,
@@ -149,11 +149,11 @@
         },
         "arbiter_decision_path_switch": {
           "available": true,
-          "ticks": 25368401858
+          "ticks": 25343961060
         },
         "arbiter_keep_running_fallback": {
           "available": true,
-          "ticks": 25408165064
+          "ticks": 25386702437
         },
         "arbiter_ready_head_fallback": {
           "available": false,
@@ -187,8 +187,8 @@
           "epoch_lte_owner_last_epoch_count": 61,
           "epoch_zero_count": 0,
           "latest_candidate_pid": 2,
-          "latest_epoch": 538,
-          "latest_owner_last_epoch": 538
+          "latest_epoch": 20,
+          "latest_owner_last_epoch": 20
         }
       },
       "fallback_reasons": {
@@ -215,10 +215,10 @@
           "count": 61,
           "enter_count": 61,
           "exit_count": 61,
-          "max_ticks": 1187050,
-          "mean_ticks": 317476,
-          "min_ticks": 278590,
-          "total_ticks": 19366052
+          "max_ticks": 1251166,
+          "mean_ticks": 353965,
+          "min_ticks": 273959,
+          "total_ticks": 21591898
         },
         "keep_running": {
           "available": false,
@@ -245,10 +245,10 @@
           "count": 1,
           "enter_count": 1,
           "exit_count": 1,
-          "max_ticks": 2270782,
-          "mean_ticks": 2270782,
-          "min_ticks": 2270782,
-          "total_ticks": 2270782
+          "max_ticks": 2477905,
+          "mean_ticks": 2477905,
+          "min_ticks": 2477905,
+          "total_ticks": 2477905
         }
       },
       "raw_markers": {
@@ -258,15 +258,15 @@
         },
         "arbiter_candidate_accept_switch": {
           "tick_valid": true,
-          "ticks": 25368747455
+          "ticks": 25344426756
         },
         "arbiter_candidate_lookup_enter": {
           "tick_valid": true,
-          "ticks": 25365541777
+          "ticks": 25340908140
         },
         "arbiter_candidate_lookup_exit": {
           "tick_valid": true,
-          "ticks": 25365972855
+          "ticks": 25341364256
         },
         "arbiter_candidate_reject": {
           "tick_valid": false,
@@ -274,15 +274,15 @@
         },
         "arbiter_decision_enter": {
           "tick_valid": true,
-          "ticks": 25365183685
+          "ticks": 25340408217
         },
         "arbiter_decision_exit": {
           "tick_valid": true,
-          "ticks": 25369507519
+          "ticks": 25345140833
         },
         "arbiter_decision_path_fallback": {
           "tick_valid": true,
-          "ticks": 25407808393
+          "ticks": 25386356301
         },
         "arbiter_decision_path_keep_running": {
           "tick_valid": false,
@@ -294,27 +294,27 @@
         },
         "arbiter_decision_path_switch": {
           "tick_valid": true,
-          "ticks": 25368401858
+          "ticks": 25343961060
         },
         "arbiter_enter": {
           "tick_valid": true,
-          "ticks": 25360944744
+          "ticks": 25335145372
         },
         "arbiter_exit": {
           "tick_valid": true,
-          "ticks": 25369892953
+          "ticks": 25345544961
         },
         "arbiter_keep_running_fallback": {
           "tick_valid": true,
-          "ticks": 25408165064
+          "ticks": 25386702437
         },
         "arbiter_owner_lookup_enter": {
           "tick_valid": true,
-          "ticks": 25361446039
+          "ticks": 25336064980
         },
         "arbiter_owner_lookup_exit": {
           "tick_valid": true,
-          "ticks": 25361931506
+          "ticks": 25336818012
         },
         "arbiter_ready_head_fallback": {
           "tick_valid": false,
@@ -326,35 +326,35 @@
         },
         "extract_enter": {
           "tick_valid": true,
-          "ticks": 25362496672
+          "ticks": 25337465743
         },
         "extract_exit": {
           "tick_valid": true,
-          "ticks": 25364839019
+          "ticks": 25340079427
         },
         "handoff_enter": {
           "tick_valid": true,
-          "ticks": 25370368865
+          "ticks": 25346028174
         },
         "handoff_exit": {
           "tick_valid": true,
-          "ticks": 25370748395
+          "ticks": 25346412751
         },
         "snapshot_enter": {
           "tick_valid": true,
-          "ticks": 25362885120
+          "ticks": 25337843067
         },
         "snapshot_exit": {
           "tick_valid": true,
-          "ticks": 25363325948
+          "ticks": 25338395224
         },
         "validate_enter": {
           "tick_valid": true,
-          "ticks": 25394962063
+          "ticks": 25372379713
         },
         "validate_exit": {
           "tick_valid": true,
-          "ticks": 25396031170
+          "ticks": 25373576930
         }
       }
     },
@@ -395,89 +395,89 @@
       "durations": {
         "boot_start_to_core_ready": {
           "available": true,
-          "ticks": 122483463
+          "ticks": 129218047
         },
         "core_ready_to_first_sched_activity": {
           "available": true,
-          "ticks": 933719
+          "ticks": 1388096
         },
         "first_sched_activity_to_first_user_entry": {
           "available": true,
-          "ticks": 19679846
+          "ticks": 25464516
         },
         "first_syscall_gate_entry_to_first_syscall_entry": {
           "available": true,
-          "ticks": 1968134
+          "ticks": 2065326
         },
         "first_syscall_gate_entry_to_first_syscall_exit": {
           "available": true,
-          "ticks": 2956513
+          "ticks": 3218222
         },
         "first_syscall_gate_entry_to_first_syscall_gate_return": {
           "available": true,
-          "ticks": 3552721
+          "ticks": 3705993
         },
         "first_user_entry_to_first_syscall_entry": {
           "available": true,
-          "ticks": 24531972
+          "ticks": 26184106
         },
         "first_user_entry_to_first_syscall_exit": {
           "available": true,
-          "ticks": 25520351
+          "ticks": 27337002
         },
         "first_user_entry_to_first_syscall_gate_entry": {
           "available": true,
-          "ticks": 22563838
+          "ticks": 24118780
         }
       },
       "raw_markers": {
         "boot_start": {
           "tick_valid": true,
-          "ticks": 25232445625
+          "ticks": 25195628481
         },
         "core_ready": {
           "tick_valid": true,
-          "ticks": 25354929088
+          "ticks": 25324846528
         },
         "first_sched_activity": {
           "tick_valid": true,
-          "ticks": 25355862807
+          "ticks": 25326234624
         },
         "first_syscall_entry": {
           "tick_valid": true,
-          "ticks": 25400074625
+          "ticks": 25377883246
         },
         "first_syscall_exit": {
           "tick_valid": true,
-          "ticks": 25401063004
+          "ticks": 25379036142
         },
         "first_syscall_gate_entry": {
           "tick_valid": true,
-          "ticks": 25398106491
+          "ticks": 25375817920
         },
         "first_syscall_gate_return": {
           "tick_valid": true,
-          "ticks": 25401659212
+          "ticks": 25379523913
         },
         "first_user_entry": {
           "tick_valid": true,
-          "ticks": 25375542653
+          "ticks": 25351699140
         }
       }
     },
     "preempt_iret_count": 61,
-    "preempt_qemu_run_time_ms": 10513,
-    "preempt_run_time_ms": 10513,
+    "preempt_qemu_run_time_ms": 10506,
+    "preempt_run_time_ms": 10506,
     "preempt_sw_count": 61,
-    "preempt_wall_time_ms": 10679,
+    "preempt_wall_time_ms": 10669,
     "syscall_gate_return_latency_ticks": {
       "available": true,
-      "ticks": 3552721
+      "ticks": 3705993
     },
-    "syscall_latency_ms_proxy": 172.344262,
+    "syscall_latency_ms_proxy": 172.229508,
     "syscall_latency_ticks_pure": {
       "available": true,
-      "ticks": 2956513
+      "ticks": 3218222
     }
   },
   "schema_version": 1


### PR DESCRIPTION
## Summary

Renew the constitutional performance baseline lock for GitHub-hosted Ubuntu runner image drift.

## Renewal Condition

- Trigger: runner image update
- Old runner digest: gha-ubuntu24-20260607.184.1-X64
- New runner digest: gha-ubuntu24-20260615.205.1-X64
- Old env hash: edbe5bed0e83075ace80b5d9aa09588613afceedd8304e30891a20aae2dc4a67
- New env hash: 79424490b83a96fff8ddaf716a9420b9dfc7a9590c9c109085c18ea824b1208b

## Generated Artifact

- Workflow: perf-baseline-init
- Run: 27854722922
- Source subject: 475bc5862b6dc98dc5951efe0c3b647327463c0d
- Imported file: scripts/ci/perf-baseline.lock.json
- Runtime counters: preempt_sw_count=61, preempt_iret_count=61

## Authority Boundary

This PR is a governed baseline-renewal PR only. It is not Phase-19 implementation, merge authority for PR #181, runtime activation, general runtime authority, Phase-19 closure, or a baseline threshold relaxation.

## Local Checks

- git diff --check: PASS
- generated lock field validation: PASS