### PR TITLE
[codex] decide Phase-19 reference integrity implementation

### DIFF
--- a/AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md
+++ b/AYKENOS_GUNCEL_DURUM_RAPORU_2026_05_23.md
@@ -111,6 +111,11 @@
 > contract/schema/subject binding, typed test-owned SHA-256 content binding,
 > and exact validation stage order. It does not authorize implementation,
 > parsing, loading, installation, execution, runtime activation, or closure.
+> `PHASE19_REFERENCE_INTEGRITY_VALIDATION_IMPLEMENTATION_DECISION.md`
+> accepts only one later separate draft source PR within the frozen one-file
+> typed test-owned boundary. It contains no source code and does not grant
+> evidence PASS, acceptance, merge, parsing, loading, execution, runtime
+> activation, general runtime authority, or closure.
 > `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md` maps
 > future artifact/evidence rows for a later implementation decision; it is
 > not evidence PASS, a CI gate, or implementation authority.
@@ -135,6 +140,7 @@
 | Phase-19 review-fix update | `PHASE19_RUNTIME_IMPLEMENTATION_REVIEW_FINDINGS_UPDATE.md` + `PHASE19_RUNTIME_IMPLEMENTATION_REVIEW_FINDINGS_EVIDENCE_REBIND.md` + `PHASE19_RUNTIME_IMPLEMENTATION_ACCEPTANCE_REVIEW_POST_REVIEW.md` + `PHASE19_RUNTIME_IMPLEMENTATION_MERGE_DECISION_UPDATE.md` + `PHASE19_RUNTIME_IMPLEMENTATION_MAIN_EXACT_SHA_EVIDENCE_SYNC.md` | Subject `0a067dba` bounded accepted; PR #181 main SHA `ed7e2798` uzerinde merge edildi; post-merge strict freeze ve full Dev Loop PASS exact-SHA baglandi |
 | Phase-19 post-merge consistency | `PHASE19_RUNTIME_IMPLEMENTATION_POST_MERGE_CONSISTENCY_REVIEW.md` | Bounded contract/authority-drift PASS; general parser, full reference-integrity validation, general RFC conformance ve yeni implementation authority yoktur |
 | Phase-19 reference-integrity candidate | `PHASE19_REFERENCE_INTEGRITY_VALIDATION_DECISION_CANDIDATE.md` | Typed test-owned canonical reference binding, SHA-256 recomputation ve exact stage-order evidence adayi; implementation authority, parser, loader, installer veya execution yoktur |
+| Phase-19 reference-integrity implementation decision | `PHASE19_REFERENCE_INTEGRITY_VALIDATION_IMPLEMENTATION_DECISION.md` | Yalniz ayri draft one-file source PR siniri; source acceptance, evidence, acceptance review, merge, parser, loader, execution veya runtime activation yoktur |
 | Aktif execution roadmap | `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution reference set + Phase-19 Runtime MVP planning boundary | Review-fixed subject `0a067dba` PR #181 ile merge ve post-merge verified; runtime activation, general runtime authority, authority drift review guard ve terminology audit ayrik kalir |
 | Canonical performance baseline | `scripts/ci/perf-baseline.lock.json` | Governed PR #182 baseline renewal `bb712923` ile `main`e kabul edildi; refreshed PR #181 head `d42c1d18` icin locked performance run `27855137608` ve `ci-freeze` run `27855137588` PASS |
 | Review enforcement | Issue #145 tek-maintainer ADR'i, `@kenanay` CODEOWNERS accountability metadata'si ve canli `main` `freeze` protection paritesi ile kapatildi | Bagimsiz self-review iddiasi yoktur; remote CI ve kayitli maintainer karari merge siniridir |
@@ -340,9 +346,10 @@ reference set olarak korunur; Phase-19 pointer transition yalnız
 planning/admission/receipt boundary kurar; review-fixed subject `0a067dba`
 PR #181 ile main SHA `ed7e2798` uzerinde merge ve post-merge verified;
 post-merge bounded consistency PASS kaydedildi. General reference-integrity
-validation icin typed test-owned decision candidate ve candidate matrix delta
-acildi; source code authority, runtime activation, general runtime authority
-ve Phase-19 closure ayri ve kapali kalir.
+validation candidate PR #185 ile main SHA `194d5e3e` uzerinde kabul edildi.
+Implementation decision yalniz ayri draft one-file source PR sinirini acar;
+source acceptance, evidence, merge, runtime activation, general runtime
+authority ve Phase-19 closure ayri ve kapali kalir.
 
 ---
 

--- a/PHASE19_REFERENCE_INTEGRITY_VALIDATION_IMPLEMENTATION_DECISION.md
+++ b/PHASE19_REFERENCE_INTEGRITY_VALIDATION_IMPLEMENTATION_DECISION.md
@@ -1,0 +1,345 @@
+# Phase-19 Reference Integrity Validation Implementation Decision
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_RUNTIME_IMPLEMENTATION_POST_MERGE_CONSISTENCY_REVIEW.md`, and
+`PHASE19_REFERENCE_INTEGRITY_VALIDATION_DECISION_CANDIDATE.md`.
+
+**Status:** IMPLEMENTATION DECISION / SEPARATE SOURCE PR AUTHORIZED WITHIN BOUNDED SCOPE / SOURCE NOT INCLUDED / EVIDENCE AND ACCEPTANCE PENDING / NO RUNTIME ACTIVATION
+**Decision date:** 2026-06-21
+**Decision id:** `ayken.phase19.reference_integrity_validation_implementation_decision.v1`
+**Candidate subject SHA:** `8d0a17c266ca988ecc5b31859ab319ccf9220c08`
+**Candidate merge/main SHA:** `194d5e3e102ebb93cc9f04cc2798b22f466b3baa`
+**Prior bounded implementation subject SHA:** `0a067dbaa230838e2c14e1e1f0bd91494092713e`
+**Authority boundary:** Documentation decision authorizing one separate draft
+source PR within the exact limits below; not source code, not evidence PASS,
+not acceptance, not merge authority, not general parsing, not loader or
+installer authority, not execution, not runtime activation, not general
+runtime authority, and not Phase-19 closure.
+
+## Decision
+
+The reference-integrity validation candidate is accepted as the boundary for
+one later, separate implementation PR.
+
+That PR may extend only the existing typed, test-owned admission/receipt
+harness. It may not include this decision document as new source authority and
+must receive a new exact implementation subject SHA.
+
+This decision does not accept an implementation, evidence package,
+acceptance review, or merge decision.
+
+## Core Rule
+
+```text
+implementation decision != implementation
+reference integrity != parser
+digest recomputation != authenticity or signature validation
+stage-order verification != Platform ABI validator implementation
+source PR PASS != acceptance or merge authority
+```
+
+The safe default remains the already merged inert admission/receipt harness.
+
+## Accepted Implementation Behavior
+
+The separate source PR may implement only:
+
+```text
+typed static test bundle
+  -> canonical typed reference validation
+  -> explicit test-owned content binding
+  -> SHA-256 content digest recomputation
+  -> exact Phase-18 validation stage-reference order verification
+  -> existing validation-integration record
+  -> existing inert workspace admission record
+  -> existing deterministic runtime receipt
+```
+
+Every new check must fail closed before validation-integration success,
+workspace admission record emission, or runtime receipt emission.
+
+## Exact Source Boundary
+
+The implementation PR may change only:
+
+```text
+userspace/phase19-admission-receipt/src/lib.rs
+```
+
+Tests must remain inline in that file. The PR must not change:
+
+1. `Cargo.toml` or `Cargo.lock`.
+2. CI workflows, Make targets, baselines, or thresholds.
+3. Kernel, syscall, ABI, scheduler, loader, workspace, Semantic CLI, or AI
+   source.
+4. Phase pointer or closure records.
+
+The crate must retain only its existing `serde`, `serde_json`, and `sha2`
+dependencies and must remain unwired from production runtime paths.
+
+## Accepted Typed Data Shape
+
+The source PR must add one closed reference classification enum with exactly:
+
+1. `ModuleManifest`
+2. `PackageMetadata`
+3. `PlatformValidationPolicy`
+4. `WorkspaceDeclaration`
+5. `RuntimeEvidenceMatrix`
+
+It must add a test-owned content entry containing only:
+
+1. Stable `path_or_uri` reference key.
+2. One reference classification value.
+3. Required subject equal to the bundle subject.
+4. Exact test-owned bytes used for digest recomputation.
+
+The harness entrypoint may accept an immutable slice of these entries. It
+must not resolve paths, open files, fetch URIs, read environment state, or
+deserialize untrusted input.
+
+The validation evidence must replace its unstructured stage digest vector with
+typed stage references containing only:
+
+1. `stage_id`
+2. `stage_index`
+3. `digest_algorithm`
+4. `digest_value`
+5. Exact test-owned stage record bytes
+
+No stage semantic evaluator, policy interpreter, or Phase-18 validator may be
+implemented.
+
+## Canonical Reference Map
+
+The implementation must use this closed map:
+
+| Reference class | Canonical contract id | Local typed-envelope version |
+|---|---|---|
+| Module manifest | `ayken.platform.module.manifest.v1` | `1` |
+| Package metadata | `ayken.platform.package.metadata.v1` | `1` |
+| Platform validation policy | `ayken.platform.abi.validation.gate.v1` | `1` |
+| Workspace declaration | `ayken.platform.workspace.lifecycle.v1` | `1` |
+| Runtime evidence matrix | `ayken.phase19.runtime.evidence_matrix.v1` | `1` |
+
+The Platform validation receipt contract must also be
+`ayken.platform.abi.validation.gate.v1`. Its Phase-19 typed-envelope version
+must be `1` and must not be represented as a new Phase-18 receipt field.
+
+Any legacy alias, unknown id, or unknown local envelope version must deny.
+
+## Digest And Content Rules
+
+The source PR must enforce:
+
+1. `digest_algorithm == "sha256"`.
+2. `digest_value` is `sha256:` followed by exactly 64 lower-case hexadecimal
+   digits.
+3. Exactly one test-owned content entry exists for every declared reference.
+4. No duplicate or undeclared content entry exists.
+5. Every content entry carries the bundle subject.
+6. SHA-256 over the exact supplied bytes equals the declared digest.
+7. Stage reference digests follow the same algorithm, shape, and content
+   recomputation rules.
+
+Digest equality proves only byte binding for the supplied test fixture. It
+does not prove publisher identity, signature validity, package authenticity,
+trust, capability, installability, loadability, or executability.
+
+## Exact Validation Stage Order
+
+Validation evidence must contain exactly ten stage references in this order:
+
+```text
+0 kernel_freeze_guard
+1 manifest_validation
+2 package_metadata_validation
+3 package_manifest_binding
+4 trust_classification_validation
+5 capability_contract_validation
+6 workspace_lifecycle_validation
+7 plugin_boundary_validation
+8 cross_contract_separation
+9 validation_receipt_emission
+```
+
+Count, id, index, order, digest format, and test-owned byte binding must be
+checked. Stage status, reason semantics, input semantics, and policy behavior
+remain external and unimplemented.
+
+The stage denial classes are distinct:
+
+1. `unknown_validation_stage_id` means a stage id is outside the closed list.
+2. `validation_stage_index_mismatch` means a known stage id declares an index
+   other than its canonical index.
+3. `validation_stage_order_mismatch` means all ids and declared indices are
+   individually valid but list position does not match canonical order.
+
+## Stable Denial Reasons
+
+The separate source PR must add distinct stable denial reasons for:
+
+1. `unknown_reference_contract`
+2. `unknown_reference_schema_version`
+3. `missing_reference_subject`
+4. `reference_subject_mismatch`
+5. `unsupported_reference_digest_algorithm`
+6. `malformed_reference_digest`
+7. `missing_reference_content`
+8. `duplicate_reference_content`
+9. `unexpected_reference_content`
+10. `reference_digest_mismatch`
+11. `validation_contract_mismatch`
+12. `validation_stage_count_mismatch`
+13. `unknown_validation_stage_id`
+14. `validation_stage_index_mismatch`
+15. `validation_stage_order_mismatch`
+16. `validation_stage_digest_mismatch`
+
+Existing denial reasons must retain their meanings. Distinct failures must
+not be collapsed into `subject_mismatch`, `stale_manifest_digest`, or another
+generic class.
+
+## Denial Precedence
+
+When multiple defects are present, the first denial must follow this order:
+
+1. Existing input schema, unknown-field, duplicate-key, and kernel ABI guards.
+2. Existing required-reference presence guards.
+3. Reference classification and canonical contract id.
+4. Local typed-envelope version.
+5. Required reference subject presence.
+6. Reference subject equality.
+7. Digest algorithm.
+8. Digest textual shape.
+9. Missing, duplicate, then unexpected content cardinality.
+10. Reference content digest recomputation.
+11. Existing input-bundle binding.
+12. Platform validation evidence presence.
+13. Validation receipt contract, local version, and subject binding.
+14. Validation stage count.
+15. Stage id.
+16. Stage index.
+17. Stage order.
+18. Stage digest algorithm and shape.
+19. Stage content digest recomputation.
+20. Existing validation stale, authority, status, and admission authority
+    guards.
+
+Reference-integrity failures before input binding must not publish an input
+bundle digest. Later failures must not publish validation-integration,
+admission, or receipt success records.
+
+## Accepted Evidence Matrix Binding
+
+The separate implementation and evidence package must close every candidate
+row from `PHASE19_REFERENCE_INTEGRITY_VALIDATION_DECISION_CANDIDATE.md`:
+
+| Row group | Required evidence |
+|---|---|
+| `P19-RI-A1..A3` | Exact canonical map, content-table cardinality, and ten-stage structure |
+| `P19-RI-P1..P2` | Positive inert receipt and exact ordered stage transcript |
+| `P19-RI-N1..N9` | One focused denial fixture and stable reason for each negative row |
+| `P19-RI-D1..D2` | Positive and denial repeat digest parity |
+| `P19-RI-R1..R2` | Local and remote exact-SHA evidence |
+| `P19-RI-B1` | Production unwired, dependency/ABI/workflow/baseline unchanged proof |
+
+Required targeted test clusters are:
+
+1. Canonical reference map and positive content-binding success.
+2. Contract and envelope-version denial.
+3. Subject-presence and subject-mismatch denial.
+4. Digest algorithm, format, and recomputation denial.
+5. Missing, duplicate, and unexpected content denial.
+6. Validation contract and exact stage count/id/index/order denial.
+7. Stage digest recomputation denial.
+8. Positive and denial determinism repeat proof.
+9. Existing admission/receipt and authority-denial regression suite.
+
+Tests are evidence inputs only. They are not acceptance or merge authority.
+
+## Exact-SHA Evidence Requirements
+
+The later implementation subject must receive:
+
+1. Targeted crate test PASS.
+2. Positive and negative transcript evidence bound to the implementation SHA.
+3. Deterministic repeat evidence for positive and denial paths.
+4. Strict `ci-freeze` PASS.
+5. Full Dev Loop PASS.
+6. ABI, governance, spec-purity, isolation, and locked performance PASS.
+7. Proof that production wiring, dependencies, workflows, baseline, syscall
+   surface, and ABI metadata are unchanged.
+
+Historical candidate or prior implementation PASS results cannot be inherited.
+Any implementation subject change requires evidence regeneration.
+
+## Decision Record Evidence
+
+This documentation decision is based on:
+
+| Input | Result |
+|---|---|
+| Candidate subject | `8d0a17c266ca988ecc5b31859ab319ccf9220c08` |
+| Candidate merge/main subject | `194d5e3e102ebb93cc9f04cc2798b22f466b3baa` |
+| Candidate PR | PR #185, merged |
+| Candidate PR strict freeze | Run `27877760939`, PASS |
+| Candidate PR full Dev Loop | Run `27877760951`, PASS |
+| Candidate main strict freeze | Run `27878009714`, PASS |
+| Candidate main full Dev Loop | Run `27878009710`, PASS |
+
+This decision record itself must also receive exact-head strict freeze and full
+Dev Loop PASS before it can authorize opening the separate source PR.
+
+## Prohibited Readings
+
+This decision does not authorize:
+
+1. General parsing or `Deserialize`-driven input acceptance.
+2. Filesystem, URI, package, registry, or network resolution.
+3. Signature, publisher, dependency, trust, capability, plugin, or module
+   semantics.
+4. Package installation or execution.
+5. Module or plugin loading.
+6. Workspace creation, runtime, or real mounts.
+7. Capability or trust issuance.
+8. Semantic CLI, AI Runtime, or agent authority.
+9. New syscalls, kernel ABI expansion, or Ring0 policy.
+10. Runtime activation, general runtime authority, or Phase-19 closure.
+
+Unknown authority readings fail closed.
+
+## Governance Bound
+
+After this decision is accepted, the normal chain for one implementation
+subject is limited to:
+
+```text
+separate implementation PR
+  -> evidence package
+  -> acceptance review
+  -> merge decision
+  -> main exact-SHA sync
+```
+
+Status synchronization is index maintenance, not a new authority layer.
+Evidence re-binding is required only when source changes produce a new subject.
+Post-merge review requires a new technical finding, claim drift, or explicit
+contract-consistency question.
+
+## Decision Conclusion
+
+One separate draft source PR may be opened after this decision record receives
+its own exact-head remote PASS.
+
+That PR is limited to typed test-owned reference integrity in
+`userspace/phase19-admission-receipt/src/lib.rs`. It remains subject to a new
+evidence package, acceptance review, merge decision, and main exact-SHA sync.
+
+Runtime activation, general parsing, loading, installation, execution,
+general runtime authority, and Phase-19 closure remain unauthorized.

--- a/PHASE19_RUNTIME_DECISION.md
+++ b/PHASE19_RUNTIME_DECISION.md
@@ -270,6 +270,14 @@ an implementation decision, source code authority, evidence PASS, acceptance,
 merge authority, runtime activation, general RFC conformance, or Phase-19
 closure.
 
+`PHASE19_REFERENCE_INTEGRITY_VALIDATION_IMPLEMENTATION_DECISION.md` accepts
+that candidate only as the boundary for one separate draft source PR. It
+freezes the one-file source scope, typed data shape, canonical contract map,
+digest rules, exact stage sequence, denial classes and precedence, and
+evidence obligations. It contains no source code and does not grant evidence
+PASS, acceptance, merge authority, general parsing, runtime activation,
+general runtime authority, or Phase-19 closure.
+
 `MODULE_LOADING_MODEL.md`, `PLUGIN_INSTANTIATION_MODEL.md`, package
 execution, real workspace mounts, capability issuance, trust assignment,
 Semantic CLI authority, AI Runtime authority, and agent behavior are not part

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **Oluşturan:** Kenan AY
 **Düzenleyen / Geliştiren / Mimari Sorumlu:** Kenan AY *(bilgilendirme metadata'sı; runtime yetkisi değildir)*
 **Oluşturma Tarihi:** 01.01.2026
-**Son Güncelleme:** 20.06.2026
+**Son Güncelleme:** 21.06.2026
 **Closure Evidence:** `local-freeze-p10p11` + `local-phase11-closure` + `run-local-phase12c-closure-2026-03-11` + `run-local-p13-kill-switch-20260315T000051Z` + `phase15-official-closure` + `phase16-verification-layer-mvp-complete`
 **Evidence Git SHA (Phase-10/11):** `9cb2171b` | **Evidence Git SHA (Phase-12C):** `01d1cb5c` | **Evidence Git SHA (Phase-13):** `40158350` | **Evidence Git SHA (Phase-15):** `48970cd0` | **Evidence Git SHA (Phase-16):** `489868f8`
 **Closure Sync / Remote CI (Phase-10/11):** `fe9031d7` (`ci-freeze#22797401328 = success`)
@@ -46,6 +46,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 **Phase 19 Review-Fix Status:** Review findings produced bounded implementation subject `0a067dba`; `PHASE19_RUNTIME_IMPLEMENTATION_REVIEW_FINDINGS_UPDATE.md`, `PHASE19_RUNTIME_IMPLEMENTATION_REVIEW_FINDINGS_EVIDENCE_REBIND.md`, `PHASE19_RUNTIME_IMPLEMENTATION_ACCEPTANCE_REVIEW_POST_REVIEW.md`, and `PHASE19_RUNTIME_IMPLEMENTATION_MERGE_DECISION_UPDATE.md` superseded inherited merge authority for the changed subject. PR #181 merged at main SHA `ed7e2798`; `PHASE19_RUNTIME_IMPLEMENTATION_MAIN_EXACT_SHA_EVIDENCE_SYNC.md` records post-merge strict freeze `27869414821` and full Dev Loop `27869414805` PASS. Runtime activation, general runtime authority, and Phase-19 closure remain unauthorized.
 **Phase 19 Post-Merge Consistency:** `PHASE19_RUNTIME_IMPLEMENTATION_POST_MERGE_CONSISTENCY_REVIEW.md` records bounded contract and authority-drift PASS. General parsing, independent reference-content digest verification, complete reference contract/schema binding, validation-stage-order verification, general RFC conformance, and new implementation authority remain ungranted.
 **Phase 19 Next Decision Candidate:** `PHASE19_REFERENCE_INTEGRITY_VALIDATION_DECISION_CANDIDATE.md` records a docs-only candidate and candidate evidence-matrix delta for typed test-owned reference integrity. Implementation, parser, loader, installer, execution, runtime activation, general RFC conformance, and Phase-19 closure remain unauthorized.
+**Phase 19 Reference Integrity Implementation Decision:** `PHASE19_REFERENCE_INTEGRITY_VALIDATION_IMPLEMENTATION_DECISION.md` authorizes only one later separate draft source PR within a one-file typed test-owned boundary. Source is not included; evidence, acceptance, merge, parser, loader, execution, runtime activation, and closure remain separate.
 **Architecture Quick Map:** `docs/specs/phase12-trust-layer/AYKENOS_GATE_ARCHITECTURE.md`
 **Active Execution Roadmap:** `docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md` + Phase-18 Platform Constitution reference set + Phase-19 Runtime MVP planning boundary | accepted `main` SHA `416a5392` uzerinde bounded Phase-17 uzak evidence PASS; official closure tag doğrulandı; `CURRENT_PHASE=19` runtime implementation yetkisi vermez
 **Canonical Technical Definition:** AykenOS is a deterministic verification architecture that separates kernel execution, verification semantics, evidence artifacts, and distributed diagnostics into explicit layers. The kernel provides mechanism, userspace verification services produce artifact-bound verdicts and receipts, and parity/topology surfaces expose cross-node observability without elevating diagnostics into authority or consensus.
@@ -63,6 +64,7 @@ This document is subordinate to PHASE 0 – FOUNDATIONAL OATH. In case of confli
 - **Current Main Evidence Boundary:** `PHASE19_RUNTIME_IMPLEMENTATION_MAIN_EXACT_SHA_EVIDENCE_SYNC.md` records PR #181 merged at main SHA `ed7e2798` and post-merge strict freeze/full Dev Loop PASS; it does not activate runtime behavior, grant general runtime authority, or close Phase-19
 - **Current Consistency Review Boundary:** `PHASE19_RUNTIME_IMPLEMENTATION_POST_MERGE_CONSISTENCY_REVIEW.md` records bounded post-merge consistency and authority-drift PASS; it does not grant general RFC conformance or authorize the next implementation slice
 - **Current Reference Integrity Candidate Boundary:** `PHASE19_REFERENCE_INTEGRITY_VALIDATION_DECISION_CANDIDATE.md` defines canonical contract/schema/subject binding, SHA-256 recomputation, and exact stage-order evidence requirements without authorizing implementation
+- **Current Reference Integrity Implementation Decision Boundary:** `PHASE19_REFERENCE_INTEGRITY_VALIDATION_IMPLEMENTATION_DECISION.md` permits one later separate draft source PR after decision-record remote PASS; it does not accept source, evidence, merge, or runtime activation
 - **Verification Layer:** `COMPLETE` (MVP delivered 2026-04-25)
 - **Closure Index:** `reports/phase17_official_closure_candidate/closure_index.json`
 - **Phase-19 Authority Note:** `CURRENT_PHASE=19` activates only Runtime MVP planning, validation-integration, admission-record, and receipt-boundary authority; runtime implementation still requires a separate decision.
@@ -361,6 +363,7 @@ Phase 12 trust layer kapsamında tamamlananlar:
 - **Phase-19 Runtime Implementation Main Exact-SHA Evidence Sync:** `PHASE19_RUNTIME_IMPLEMENTATION_MAIN_EXACT_SHA_EVIDENCE_SYNC.md`
 - **Phase-19 Runtime Implementation Post-Merge Consistency Review:** `PHASE19_RUNTIME_IMPLEMENTATION_POST_MERGE_CONSISTENCY_REVIEW.md`
 - **Phase-19 Reference Integrity Validation Decision Candidate:** `PHASE19_REFERENCE_INTEGRITY_VALIDATION_DECISION_CANDIDATE.md`
+- **Phase-19 Reference Integrity Validation Implementation Decision:** `PHASE19_REFERENCE_INTEGRITY_VALIDATION_IMPLEMENTATION_DECISION.md`
 - **Documentation Index:** `docs/development/DOCUMENTATION_INDEX.md`
 - **Ring3 User-Leaf Rule:** `docs/governance/RING3_USER_LEAF_ALLOCATION_RULE.md`
 - **Ring3 Runtime Closure Note:** `docs/governance/RING3_RUNTIME_CLOSURE_NOTE.md`
@@ -429,6 +432,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 - Phase-19 main exact-SHA evidence sync: `PHASE19_RUNTIME_IMPLEMENTATION_MAIN_EXACT_SHA_EVIDENCE_SYNC.md`; PR #181 merge commit/main SHA `ed7e2798` icin post-merge `ci-freeze` ve full Dev Loop PASS'i baglar, runtime activation veya Phase-19 closure vermez.
 - Phase-19 post-merge consistency review: `PHASE19_RUNTIME_IMPLEMENTATION_POST_MERGE_CONSISTENCY_REVIEW.md`; bounded subject icin contract/authority-drift PASS kaydeder, ancak general RFC conformance veya yeni implementation authority vermez.
 - Phase-19 reference integrity validation decision candidate: `PHASE19_REFERENCE_INTEGRITY_VALIDATION_DECISION_CANDIDATE.md`; typed test-owned reference content, canonical contract/schema/subject binding, SHA-256 recomputation ve exact stage-order evidence sinirini aday olarak kaydeder, implementation authority vermez.
+- Phase-19 reference integrity validation implementation decision: `PHASE19_REFERENCE_INTEGRITY_VALIDATION_IMPLEMENTATION_DECISION.md`; yalnız ayrı bir draft source PR icin tek-dosya typed test-owned implementation sinirini kabul eder, source/evidence/acceptance/merge veya runtime activation vermez.
 - Phase-19 runtime MVP icin ayri implementation RFC/evidence plan/evidence matrix/closure boundary hazirlanmadikca package installer, workspace runtime, plugin loader, capability issuer veya trust issuer yazilmaz.
 
 **Orta Vadeli:**
@@ -444,7 +448,7 @@ AykenOS iki lisans modeli ile dağıtılır:
 
 ---
 
-**Son Güncelleme:** 20 Haziran 2026 - CURRENT_PHASE=19 planning/admission/receipt boundary olarak korunur. Bounded implementation subject `0a067dba`, PR #181 ile main SHA `ed7e2798` üzerinde merge edildi; post-merge `ci-freeze` run `27869414821` ve full Dev Loop run `27869414805` PASS sonucu `PHASE19_RUNTIME_IMPLEMENTATION_MAIN_EXACT_SHA_EVIDENCE_SYNC.md` ile bağlandı. `PHASE19_RUNTIME_IMPLEMENTATION_POST_MERGE_CONSISTENCY_REVIEW.md` bounded consistency/authority-drift PASS ve deferred general reference-integrity obligations kaydını ekledi. `PHASE19_REFERENCE_INTEGRITY_VALIDATION_DECISION_CANDIDATE.md` sonraki dar typed test-owned reference-integrity karar adayini ve candidate matrix delta'sini kaydeder; implementation authority vermez. Runtime activation, general runtime authority ve Phase-19 closure verilmedi.
+**Son Güncelleme:** 21 Haziran 2026 - CURRENT_PHASE=19 planning/admission/receipt boundary olarak korunur. Bounded implementation subject `0a067dba`, PR #181 ile main SHA `ed7e2798` üzerinde merge edildi; post-merge evidence sync ve consistency review tamamlandı. Reference-integrity candidate PR #185 ile main SHA `194d5e3e` üzerinde kabul edildi ve post-merge remote PASS aldı. `PHASE19_REFERENCE_INTEGRITY_VALIDATION_IMPLEMENTATION_DECISION.md` yalnız ayrı bir draft one-file source PR sinirini karar altina alir; source, evidence, acceptance, merge, runtime activation, general runtime authority ve Phase-19 closure verilmedi.
 **Düzenleyen / Geliştiren / Oluşturan / Mimari Sorumlu:** Kenan AY *(metadata only; runtime/karar yetkisi değildir).*
 
 **© 2026 Kenan AY — AykenOS Project**

--- a/docs/development/DOCUMENTATION_INDEX.md
+++ b/docs/development/DOCUMENTATION_INDEX.md
@@ -35,6 +35,7 @@ This document is subordinate to PHASE 0 - FOUNDATIONAL OATH. In case of conflict
 - **Current Main Exact-SHA Evidence Boundary:** `PHASE19_RUNTIME_IMPLEMENTATION_MAIN_EXACT_SHA_EVIDENCE_SYNC.md`; records PR #181 merged at main SHA `ed7e2798` with post-merge strict freeze and full Dev Loop PASS, without runtime activation or Phase-19 closure
 - **Current Post-Merge Consistency Boundary:** `PHASE19_RUNTIME_IMPLEMENTATION_POST_MERGE_CONSISTENCY_REVIEW.md`; records bounded consistency and authority-drift PASS while denying general RFC conformance and new implementation authority
 - **Current Reference Integrity Candidate Boundary:** `PHASE19_REFERENCE_INTEGRITY_VALIDATION_DECISION_CANDIDATE.md`; records a candidate plus candidate evidence-matrix delta without implementation authority
+- **Current Reference Integrity Implementation Decision Boundary:** `PHASE19_REFERENCE_INTEGRITY_VALIDATION_IMPLEMENTATION_DECISION.md`; authorizes one later separate draft source PR within the one-file typed test-owned boundary, without source acceptance or merge authority
 - **Scope Boundary:** `CURRENT_PHASE=19` does not authorize general runtime behavior; kernel expansion, new syscalls, Ring0 policy and AI Runtime authority remain forbidden
 
 ## Primary Truth Sources
@@ -89,14 +90,15 @@ Current repo truth icin once su dosyalari referans alin:
 47. `PHASE19_RUNTIME_IMPLEMENTATION_MAIN_EXACT_SHA_EVIDENCE_SYNC.md` — **Phase-19 PR #181 merged main exact-SHA evidence sync; runtime not activated**
 48. `PHASE19_RUNTIME_IMPLEMENTATION_POST_MERGE_CONSISTENCY_REVIEW.md` — **Phase-19 bounded post-merge consistency review; general RFC conformance not granted**
 49. `PHASE19_REFERENCE_INTEGRITY_VALIDATION_DECISION_CANDIDATE.md` — **Phase-19 typed reference-integrity validation decision candidate; implementation not authorized**
-50. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
-51. `reports/phase15_official_closure/closure_index.json`
-52. `reports/phase13_official_closure_candidate/closure_index.json`
-53. `reports/phase12_official_closure_candidate/closure_manifest.json`
-54. `reports/phase10_phase11_official_closure_index.json`
-55. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
-56. `Makefile`
-57. `.github/workflows/ci-freeze.yml`
+50. `PHASE19_REFERENCE_INTEGRITY_VALIDATION_IMPLEMENTATION_DECISION.md` — **Phase-19 bounded reference-integrity implementation decision; separate source PR only**
+51. `reports/phase15_official_closure/PHASE15_CLOSURE_REPORT.md`
+52. `reports/phase15_official_closure/closure_index.json`
+53. `reports/phase13_official_closure_candidate/closure_index.json`
+54. `reports/phase12_official_closure_candidate/closure_manifest.json`
+55. `reports/phase10_phase11_official_closure_index.json`
+56. `userspace/minimal/minimal_bcib_first_retire_probe.S` — **historical Ring3 breakthrough evidence**
+57. `Makefile`
+58. `.github/workflows/ci-freeze.yml`
 
 Phase-14 workstream numbering ve aktif durum yorumu icin canonical truth source:
 
@@ -271,6 +273,9 @@ README/spec dili ve architecture map bu tracker ile hizali okunmalidir.
 34. `PHASE19_REFERENCE_INTEGRITY_VALIDATION_DECISION_CANDIDATE.md` —
     records the typed test-owned reference-integrity decision candidate and
     its candidate evidence-matrix delta without implementation authority.
+35. `PHASE19_REFERENCE_INTEGRITY_VALIDATION_IMPLEMENTATION_DECISION.md` —
+    accepts one later separate draft source PR within the frozen one-file
+    boundary without source acceptance, merge, or runtime activation.
 
 ## Phase-14 Reference Set
 ### Architecture and Observability Surfaces

--- a/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
+++ b/docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
@@ -555,6 +555,13 @@ Phase-18 stage-order verification karar adayini ve candidate evidence matrix
 delta'sini kaydeder. Source code, implementation decision, evidence PASS,
 runtime activation, general runtime authority veya Phase-19 closure kurmaz.
 
+`PHASE19_REFERENCE_INTEGRITY_VALIDATION_IMPLEMENTATION_DECISION.md`, candidate
+sinirini yalniz bir sonraki ayri draft source PR icin tek dosya, mevcut
+dependency seti, typed test-owned content, canonical contract map, SHA-256
+recomputation, exact stage order, denial precedence ve matrix binding ile
+dondurur. Belge source code, evidence PASS, acceptance, merge authority,
+runtime activation, general runtime authority veya Phase-19 closure kurmaz.
+
 Phase-19 karar siniri su kurallari korur:
 
 1. Runtime decision runtime implementation degildir.
@@ -689,6 +696,7 @@ Phase-19 karar siniri su kurallari korur:
 | Phase-19 Runtime Implementation Main Exact-SHA Evidence Sync | PR #181 MERGED / POST-MERGE EXACT-SHA REMOTE PASS / RUNTIME NOT ACTIVATED | Merge commit/main SHA `ed7e2798` icin strict freeze ve full Dev Loop sonucunu baglamak | `PHASE19_RUNTIME_IMPLEMENTATION_MAIN_EXACT_SHA_EVIDENCE_SYNC.md` | Sync runtime activation, general runtime authority, loader, installer, executor veya Phase-19 closure grant degildir |
 | Phase-19 Runtime Implementation Post-Merge Consistency Review | BOUNDED CONSISTENCY PASS / AUTHORITY DRIFT NOT OBSERVED / GENERAL RFC CONFORMANCE NOT GRANTED | Merged bounded subject'i Phase-18/19 contract ve terminology sinirlarina karsi review etmek | `PHASE19_RUNTIME_IMPLEMENTATION_POST_MERGE_CONSISTENCY_REVIEW.md` | Review yeni implementation decision, general parser, full reference-integrity validation, runtime activation veya Phase-19 closure grant degildir |
 | Phase-19 Reference Integrity Validation Decision Candidate | CANDIDATE / MATRIX DELTA CANDIDATE / IMPLEMENTATION NOT AUTHORIZED | Typed test-owned reference content icin canonical contract/schema/subject binding, SHA-256 recomputation ve exact stage-order evidence sinirini daraltmak | `PHASE19_REFERENCE_INTEGRITY_VALIDATION_DECISION_CANDIDATE.md` | Candidate source code, parser, loader, installer, execution, evidence PASS, runtime activation veya Phase-19 closure grant degildir |
+| Phase-19 Reference Integrity Validation Implementation Decision | IMPLEMENTATION DECISION / SEPARATE SOURCE PR ONLY / SOURCE NOT INCLUDED | Candidate sinirini tek-dosya typed test-owned source PR, denial precedence ve exact-SHA evidence kosullariyla dondurmak | `PHASE19_REFERENCE_INTEGRITY_VALIDATION_IMPLEMENTATION_DECISION.md` | Decision source acceptance, evidence PASS, acceptance, merge, parser, loader, execution, runtime activation veya Phase-19 closure grant degildir |
 
 PR koordinasyon kurallari:
 
@@ -1406,7 +1414,8 @@ Bu roadmap su olaylarda guncellenir:
 54. Phase-19 Runtime Implementation Main Exact-SHA Evidence Sync sonucu.
 55. Phase-19 Runtime Implementation Post-Merge Consistency Review sonucu.
 56. Phase-19 Reference Integrity Validation Decision Candidate sonucu.
-57. Yeni feature/ABI/authority surface onerisinin incelenmesi.
+57. Phase-19 Reference Integrity Validation Implementation Decision sonucu.
+58. Yeni feature/ABI/authority surface onerisinin incelenmesi.
 
 ## References
 
@@ -1471,6 +1480,7 @@ Bu roadmap su olaylarda guncellenir:
 - `PHASE19_RUNTIME_IMPLEMENTATION_MAIN_EXACT_SHA_EVIDENCE_SYNC.md`
 - `PHASE19_RUNTIME_IMPLEMENTATION_POST_MERGE_CONSISTENCY_REVIEW.md`
 - `PHASE19_REFERENCE_INTEGRITY_VALIDATION_DECISION_CANDIDATE.md`
+- `PHASE19_REFERENCE_INTEGRITY_VALIDATION_IMPLEMENTATION_DECISION.md`
 - `PHASE18_ROADMAP.md`
 - `shared/abi/syscall_v2.h`
 - `shared/abi/ayken_abi.h`

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -142,7 +142,10 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 44. `../../PHASE19_REFERENCE_INTEGRITY_VALIDATION_DECISION_CANDIDATE.md`:
    typed test-owned reference-integrity karar adayi ve candidate evidence
    matrix delta kaydidir; implementation authority kurmaz.
-45. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
+45. `../../PHASE19_REFERENCE_INTEGRITY_VALIDATION_IMPLEMENTATION_DECISION.md`:
+   yalniz ayri draft one-file source PR icin bounded implementation kararidir;
+   source acceptance, evidence, merge veya runtime activation kurmaz.
+46. `../../PHASE18_ROADMAP.md`: tarihsel pre-closure runtime-validation
    planlamasi; aktif Phase-18 otoritesi degildir.
 
 ## Current Status
@@ -156,6 +159,7 @@ tarihsel roadmap snapshot'larini ayri otorite sinirlarinda tutar.
 | Current review-fix boundary | `PHASE19_RUNTIME_IMPLEMENTATION_REVIEW_FINDINGS_UPDATE.md` subject `0a067dba` kaydidir; evidence re-bind, post-review acceptance ve merge decision update ayri kayitlidir; `PHASE19_RUNTIME_IMPLEMENTATION_MAIN_EXACT_SHA_EVIDENCE_SYNC.md` PR #181 merge commit `ed7e2798` icin post-merge strict freeze ve full Dev Loop PASS'i baglar |
 | Current consistency boundary | `PHASE19_RUNTIME_IMPLEMENTATION_POST_MERGE_CONSISTENCY_REVIEW.md` bounded contract/authority-drift PASS kaydidir; general parser, full reference-integrity validation, general RFC conformance ve sonraki implementation authority vermez |
 | Current next-decision boundary | `PHASE19_REFERENCE_INTEGRITY_VALIDATION_DECISION_CANDIDATE.md` canonical contract/schema/subject binding, test-owned SHA-256 recomputation ve exact stage-order evidence adayini tanimlar; source code veya implementation authority vermez |
+| Current implementation-decision boundary | `PHASE19_REFERENCE_INTEGRITY_VALIDATION_IMPLEMENTATION_DECISION.md` yalniz bir sonraki separate draft source PR icin tek-dosya typed test-owned siniri kabul eder; source/evidence/acceptance/merge veya runtime activation vermez |
 | ABI | Canonical `1000-1011` / 12 syscall, ABI version `0x00010001` |
 | Phase-18 | ACCEPTED PLATFORM CONSTITUTION REFERENCE SET; kernel expansion, runtime implementation and new syscalls forbidden unless a separate phase RFC/closure authority exists |
 | Phase-19 | ACTIVE AS PLANNING / VALIDATION-INTEGRATION / ADMISSION-RECORD / RECEIPT BOUNDARY; bounded admission/receipt PR #181 merged and post-merge verified at `ed7e2798`; runtime activation, general runtime authority and Phase-19 closure remain closed |
@@ -192,12 +196,12 @@ current execution priority otoritesi degildir:
 
 ---
 
-**Current action:** `PHASE19_REFERENCE_INTEGRITY_VALIDATION_DECISION_CANDIDATE.md`
-Post-merge review'da deferred kalan contract/schema/subject binding,
-test-owned content digest recomputation ve exact validation-stage order
-sinirini karar adayi ve candidate matrix delta olarak kaydeder. Bu candidate
-source code, evidence PASS, implementation authority, runtime activation,
-general runtime authority veya Phase-19 closure degildir.
+**Current action:** `PHASE19_REFERENCE_INTEGRITY_VALIDATION_IMPLEMENTATION_DECISION.md`
+Candidate sinirini tek source dosyasi, typed test-owned content, canonical
+contract map, SHA-256 recomputation, exact stage order, denial precedence ve
+matrix binding ile dondurur. Karar belgesi source code icermez; evidence,
+acceptance, merge, runtime activation, general runtime authority ve Phase-19
+closure ayri kalir.
 `CURRENT_PHASE=19` general runtime source code authority, loader, installer,
 workspace runtime, plugin host, capability issuer, trust issuer, Semantic CLI
 authority veya AI Runtime authority vermez. High-risk vocabulary

--- a/docs/specs/phase19-platform-runtime/README.md
+++ b/docs/specs/phase19-platform-runtime/README.md
@@ -178,6 +178,12 @@ contract/schema/subject binding, SHA-256 recomputation, and exact Phase-18
 stage-order verification. It does not authorize source changes, general
 parsing, loading, installation, execution, runtime activation, or closure.
 
+`../../../PHASE19_REFERENCE_INTEGRITY_VALIDATION_IMPLEMENTATION_DECISION.md`
+accepts that candidate only for one later separate draft source PR limited to
+`userspace/phase19-admission-receipt/src/lib.rs`. Source is not included;
+evidence, acceptance, merge, runtime activation, general parsing, loading,
+installation, execution, and closure remain separate and unauthorized.
+
 `RUNTIME_EVIDENCE_MATRIX.md` maps accepted evidence obligations to future
 proof rows. It is not a CI gate, evidence PASS, implementation decision, or
 runtime authority.


### PR DESCRIPTION
## What changed

- adds the code-free `PHASE19_REFERENCE_INTEGRITY_VALIDATION_IMPLEMENTATION_DECISION.md`
- accepts only one later separate draft source PR within `userspace/phase19-admission-receipt/src/lib.rs`
- freezes the typed test-owned content shape, canonical contract map, SHA-256 rules, exact ten-stage order, stable denial reasons, and denial precedence
- binds the candidate matrix rows to required future evidence
- synchronizes the established Phase-19 status and documentation indexes

## Authority boundary

This PR contains no source code. After its own exact-head remote PASS, it authorizes opening one separate draft source PR. It does not grant evidence PASS, acceptance, merge authority, general parsing, loading, installation, execution, runtime activation, general runtime authority, or Phase-19 closure.

## Validation

- `cargo test --manifest-path userspace/Cargo.toml -p phase19-admission-receipt -- --test-threads=1` - PASS, 7 tests
- `make ci-gate-governance` - PASS
- `python3 tools/ci/phase17_spec_validation_gate.py` - PASS, 0 violations
- `git diff --cached --check` - PASS