### PR TITLE
[codex] Add Phase-19 closure readiness manifest

### DIFF
--- a/PHASE19_CLOSURE_READINESS_EVIDENCE_MANIFEST.md
+++ b/PHASE19_CLOSURE_READINESS_EVIDENCE_MANIFEST.md
@@ -1,0 +1,250 @@
+# Phase-19 Closure Readiness Evidence Manifest
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_RUNTIME_IMPLEMENTATION_MAIN_EXACT_SHA_EVIDENCE_SYNC.md`,
+`PHASE19_RUNTIME_IMPLEMENTATION_POST_MERGE_CONSISTENCY_REVIEW.md`,
+`PHASE19_REFERENCE_INTEGRITY_VALIDATION_DECISION_CANDIDATE.md`,
+`PHASE19_REFERENCE_INTEGRITY_VALIDATION_IMPLEMENTATION_DECISION.md`,
+`PHASE19_REFERENCE_INTEGRITY_VALIDATION_EVIDENCE_PACKAGE.md`,
+`PHASE19_REFERENCE_INTEGRITY_VALIDATION_ACCEPTANCE_REVIEW.md`,
+`PHASE19_REFERENCE_INTEGRITY_VALIDATION_MERGE_DECISION.md`,
+`PHASE19_REFERENCE_INTEGRITY_VALIDATION_MERGE_DECISION_REBIND.md`, and
+`PHASE19_REFERENCE_INTEGRITY_VALIDATION_MAIN_EXACT_SHA_EVIDENCE_SYNC.md`.
+In case of conflict, those documents prevail unless this manifest is the
+narrower evidence-readiness snapshot for the exact main subject identified
+below.
+
+**Status:** CLOSURE READINESS EVIDENCE MANIFEST / EXACT MAIN SNAPSHOT
+RECORDED / POST-MERGE EVIDENCE RECORDED / NO CLOSURE AUTHORITY / NO RUNTIME
+ACTIVATION / PHASE-19 NOT CLOSED
+**Manifest date:** 2026-06-27
+**Manifest id:** `ayken.phase19.closure_readiness_evidence_manifest.v1`
+**Canonical main snapshot SHA:** `be47a8592011373bc0af1aa44415aa8042db3929`
+**Authority boundary:** Evidence-readiness manifest only; not a closure
+decision, not runtime activation, not general runtime authority, not a new
+implementation decision, not acceptance for another implementation subject,
+not constitutional approval, not execution authorization, and not Phase-19
+closure.
+
+## Purpose
+
+This document records the Phase-19 closure-readiness evidence snapshot for
+main subject:
+
+```text
+be47a8592011373bc0af1aa44415aa8042db3929
+```
+
+It records what evidence is present for later closure consideration.
+
+It does not produce closure authority, runtime authority, activation
+authority, or a Phase-19 closure decision.
+
+Readiness in this document refers only to recorded evidence availability. It
+does not imply that constitutional closure prerequisites are complete or that
+Phase-19 is ready to close.
+
+## Core Rule
+
+```text
+readiness evidence != closure authority
+exact-main PASS != runtime activation
+merged bounded source != general runtime authority
+closure manifest != Phase-19 closure decision
+```
+
+This manifest is an input to a later closure evaluation. It is not that
+evaluation.
+
+## Authority Boundary
+
+This document records evidence readiness only.
+
+It must not be interpreted as:
+
+1. Runtime activation.
+2. General runtime authority.
+3. Implementation acceptance beyond the already merged bounded sources.
+4. Closure grant.
+5. Constitutional authority.
+6. Execution authorization.
+7. Package installation, loading, mounting, scheduling, or publication.
+8. Capability, trust, Semantic CLI, AI Runtime, or agent authority.
+9. New syscall, kernel ABI, or Ring0 policy authority.
+
+Unknown authority readings fail closed.
+
+## Manifest Validity
+
+This manifest is valid only for exact canonical main snapshot:
+
+```text
+be47a8592011373bc0af1aa44415aa8042db3929
+```
+
+All observations in this document are bound exclusively to that exact main
+SHA.
+
+Any subsequent canonical main snapshot invalidates this readiness snapshot
+without requiring explicit revocation. A new exact-main readiness manifest is
+required after every canonical main transition.
+
+Unknown, later-discovered, or differently scoped closure prerequisites fail
+closed and are not satisfied by this manifest.
+
+## Publication And Main-Transition Boundary
+
+If this manifest is merged by PR #193, that merge creates a subsequent
+canonical main snapshot.
+
+That later main snapshot is not covered by this manifest.
+
+The PR #193 merge commit must be read only as publication of this historical
+readiness record for:
+
+```text
+be47a8592011373bc0af1aa44415aa8042db3929
+```
+
+The PR #193 merge commit must not be used as a closure-readiness snapshot for
+itself and must not be treated as an implicit re-bind of this manifest to the
+landing SHA.
+
+Any later closure review over the post-PR #193 main state requires a separate
+exact-main readiness manifest or reviewed exact-main re-bind for that later
+SHA.
+
+## Canonical Main Snapshot
+
+| Item | Recorded result |
+|---|---|
+| Current canonical main snapshot | `be47a8592011373bc0af1aa44415aa8042db3929` |
+| Reference-integrity source PR | PR #187, merged |
+| Reference-integrity accepted implementation subject | `e3028fee36d06efa23401184f21a4e4815f7757e` |
+| Reference-integrity final PR head | `9c928d8c77997c9127dc9769f65d003f44a7c0d8` |
+| Reference-integrity merge commit / main subject | `c82fe5f6a154f6d78708a5b94fa9b5dc367c02de` |
+| Baseline-renewal prerequisite | PR #191, merged |
+| Baseline-renewal merge commit | `8f7bf671ab42a205f1b66f9f3dbff5d9c454de03` |
+| Main rebind and exact-SHA sync PR | PR #192, merged |
+| Main rebind and sync merge commit | `be47a8592011373bc0af1aa44415aa8042db3929` |
+
+This section records repository facts only. It does not evaluate or grant
+closure authority.
+
+## Post-Merge Verification Snapshot
+
+All rows below are bound to canonical main snapshot:
+
+```text
+be47a8592011373bc0af1aa44415aa8042db3929
+```
+
+| Evidence | Run / job | Result |
+|---|---|---|
+| Strict `ci-freeze` | run `28283083840` | PASS |
+| AykenOS Dev Loop CI smoke | run `28283083852`, job `83802335377` | PASS |
+| AykenOS Dev Loop CI contract | run `28283083852`, job `83802403857` | PASS |
+| AykenOS Dev Loop CI full | run `28283083852`, job `83802526843` | PASS |
+| AykenOS Dev Loop CI isolation | run `28283083852`, job `83802696239` | PASS |
+| AykenOS Dev Loop CI performance | run `28283083852`, job `83802865011` | PASS |
+| Dev Loop optimized | run `28283083871` | PASS |
+| Dev Loop validation | run `28283083859` | PASS |
+| Governance Summary | run `28283083889` | PASS |
+| Spec Purity | run `28283083883` | PASS |
+| Evidence Isolation | runs `28283083853`, `28283083857` | PASS |
+| Observation Boundary | run `28283083882` | PASS |
+| Naming Compliance | runs `28283083854`, `28283083867` | PASS |
+| Workspace boundary | run `28283083876` | PASS |
+| Semantic CLI contract boundary | run `28283083846` | PASS |
+| BCIB core boundary | run `28283083868` | PASS |
+| DSL BCIB contract boundary | run `28283083875` | PASS |
+| Data runtime BCIB boundary | run `28283083870` | PASS |
+| AI Runtime boundary | run `28283083860` | PASS |
+| Capability manager boundary | run `28283083844` | PASS |
+| Proofd observability boundary | run `28283083872` | PASS |
+| Toolchain opcode registry boundary | run `28283083839` | PASS |
+
+These rows record observed post-merge evidence. They do not imply closure,
+runtime activation, or general runtime authority.
+
+## Runtime Evidence Lineage
+
+| Lineage element | Recorded subject or record |
+|---|---|
+| Phase-19 runtime decision boundary | `PHASE19_RUNTIME_DECISION.md` |
+| Runtime evidence matrix | `docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md` |
+| First bounded admission/receipt implementation PR | PR #181 |
+| Current bounded runtime implementation subject recorded by post-review chain | `0a067dbaa230838e2c14e1e1f0bd91494092713e` |
+| PR #181 merge commit / main subject | `ed7e2798bfd8ddb41f2741ec8591f2bb32d0da95` |
+| PR #181 main exact-SHA sync | `PHASE19_RUNTIME_IMPLEMENTATION_MAIN_EXACT_SHA_EVIDENCE_SYNC.md` |
+| PR #181 post-merge consistency review | `PHASE19_RUNTIME_IMPLEMENTATION_POST_MERGE_CONSISTENCY_REVIEW.md` |
+| Reference-integrity validation implementation PR | PR #187 |
+| Reference-integrity accepted implementation subject | `e3028fee36d06efa23401184f21a4e4815f7757e` |
+| Reference-integrity merge-decision rebind | `PHASE19_REFERENCE_INTEGRITY_VALIDATION_MERGE_DECISION_REBIND.md` |
+| Reference-integrity main exact-SHA sync | `PHASE19_REFERENCE_INTEGRITY_VALIDATION_MAIN_EXACT_SHA_EVIDENCE_SYNC.md` |
+| Current canonical main snapshot for later closure consideration | `be47a8592011373bc0af1aa44415aa8042db3929` |
+
+This lineage records evidence ancestry only. It does not collapse those
+records into a closure decision and does not expand any bounded
+implementation subject.
+
+Evidence lineage must not be interpreted as authority inheritance. No listed
+record transfers closure authority, runtime activation authority, general
+runtime authority, or implementation authority beyond its own bounded scope.
+
+## Closure Readiness Prerequisites Matrix
+
+| Requirement | Status |
+|---|---|
+| First bounded admission/receipt implementation | MERGED AND POST-MERGE RECORDED FOR PR #181 SCOPE |
+| Reference-integrity merged slice | CLOSED FOR PR #187 SCOPE |
+| Reference-integrity merge-decision rebind | CLOSED FOR PR #187 LIVE MERGE PATH |
+| Exact main synchronization | CLOSED FOR `be47a8592011373bc0af1aa44415aa8042db3929` |
+| Post-merge validation | RECORDED PASS FOR `be47a8592011373bc0af1aa44415aa8042db3929` |
+| Governance boundary checks | RECORDED PASS FOR `be47a8592011373bc0af1aa44415aa8042db3929` |
+| Spec purity checks | RECORDED PASS FOR `be47a8592011373bc0af1aa44415aa8042db3929` |
+| Evidence isolation checks | RECORDED PASS FOR `be47a8592011373bc0af1aa44415aa8042db3929` |
+| Runtime activation | NOT IN SCOPE |
+| General runtime authority | NOT IN SCOPE |
+| Closure authority | OPEN |
+| Phase-19 closure decision | OPEN |
+| Constitutional closure review | OPEN |
+| Unknown closure prerequisite | FAIL CLOSED |
+
+The `CLOSED` statuses above are scoped only to the named bounded slices.
+They must not be read as Phase-19 closure.
+
+## Explicit Non-Claims
+
+This document does not claim:
+
+1. Runtime activation.
+2. General runtime authority.
+3. Phase-19 is officially closed.
+4. Implementation acceptance beyond merged bounded source subjects.
+5. Constitutional approval.
+6. Evidence PASS equals closure authority.
+7. Execution authorization.
+8. Parser, loader, installer, mount, package, registry, workspace runtime,
+   capability, trust, Semantic CLI, AI Runtime, or agent authority.
+9. New syscall, kernel ABI, workflow-threshold, or Ring0 authority.
+
+## Readiness Verdict
+
+Reference integrity, exact-main synchronization, and associated post-merge
+evidence are recorded for:
+
+```text
+be47a8592011373bc0af1aa44415aa8042db3929
+```
+
+Phase-19 closure authority remains pending until all constitutional closure
+prerequisites are satisfied by a separate closure decision.
+
+This manifest expires for any subsequent canonical main SHA. A new exact-main
+readiness manifest is required after every canonical main transition.


### PR DESCRIPTION
Adds PHASE19_CLOSURE_READINESS_EVIDENCE_MANIFEST.md for canonical main SHA be47a8592011373bc0af1aa44415aa8042db3929. The manifest records closure-readiness evidence only: exact-main snapshot, PR #187/#191/#192 lineage, post-merge PASS runs, runtime evidence lineage, scoped readiness matrix, and explicit non-claims. It does not grant runtime activation, general runtime authority, closure authority, or Phase-19 closure. Validation: git diff --cached --check before commit.