### PR TITLE
[codex] Add Phase-19 closure decision

### DIFF
--- a/PHASE19_CLOSURE_DECISION.md
+++ b/PHASE19_CLOSURE_DECISION.md
@@ -1,0 +1,225 @@
+# Phase-19 Closure Decision
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_RUNTIME_IMPLEMENTATION_MAIN_EXACT_SHA_EVIDENCE_SYNC.md`,
+`PHASE19_RUNTIME_IMPLEMENTATION_POST_MERGE_CONSISTENCY_REVIEW.md`,
+`PHASE19_REFERENCE_INTEGRITY_VALIDATION_MAIN_EXACT_SHA_EVIDENCE_SYNC.md`,
+`PHASE19_CLOSURE_READINESS_EVIDENCE_MANIFEST.md`,
+`PHASE19_CLOSURE_READINESS_EXACT_MAIN_REBIND.md`, and
+`PHASE19_CONSTITUTIONAL_CLOSURE_REVIEW.md`. In case of conflict, those
+documents prevail unless this decision is the narrower Phase-19 closure
+decision for the exact subject identified below.
+
+**Status:** EXACT-SUBJECT PHASE-19 CLOSURE DECISION / CLOSURE GRANTED FOR
+DECISION SUBJECT ONLY / NO RUNTIME ACTIVATION / NO GENERAL RUNTIME AUTHORITY /
+PHASE-20 POINTER TRANSITION NOT AUTHORIZED
+**Decision date:** 2026-06-27
+**Decision id:** `ayken.phase19.closure_decision.v1`
+**Decision subject SHA:** `17de2131e01f743d8ca3ac4e431e9362f08dff39`
+**Constitutional closure review subject SHA:** `32e37ce374c64986baac4155d973574c22f944b3`
+**Constitutional closure review PR:** PR #195, merged
+**Constitutional closure review merge commit:** `17de2131e01f743d8ca3ac4e431e9362f08dff39`
+**Authority boundary:** Phase-19 closure decision only; not runtime
+activation, not general runtime authority, not Phase-20 pointer transition,
+not a new implementation decision, not new source acceptance, not new
+evidence generation, not exact-main rebind authority, not constitutional
+amendment authority, not execution authorization, and not package, module,
+workspace, plugin, capability, trust, Semantic CLI, AI Runtime, agent,
+syscall, kernel ABI, workflow-threshold, baseline, dependency, or Ring0
+authority.
+
+## Purpose
+
+This document records the Phase-19 closure decision for exact main subject:
+
+```text
+17de2131e01f743d8ca3ac4e431e9362f08dff39
+```
+
+The decision relies on the merged Constitutional Closure Review and its
+reviewed evidence chain. It does not re-run the review, create new evidence,
+or introduce a new constitutional rule.
+
+## Core Rule
+
+```text
+closure decision != runtime activation
+closure decision != Phase-20 pointer transition
+closure decision != new evidence or rebind
+Phase-19 closed != general runtime authority
+```
+
+This decision closes Phase-19 only within the exact scope reviewed and
+recorded by the Phase-19 governance chain.
+
+## Decision Inputs
+
+| Input | Recorded result |
+|---|---|
+| Decision subject | `17de2131e01f743d8ca3ac4e431e9362f08dff39` |
+| Constitutional Closure Review | `PHASE19_CONSTITUTIONAL_CLOSURE_REVIEW.md` |
+| Constitutional Closure Review PR | PR #195 |
+| PR #195 head | `4f97f598538dc8b2a317d05e1beea1f15e7d1fe6` |
+| PR #195 review | Approved by `kenanay2020-hub` |
+| PR #195 merge method | Normal maintainer squash merge; no admin bypass |
+| PR #195 changed file | `PHASE19_CONSTITUTIONAL_CLOSURE_REVIEW.md` |
+| PR #195 merge commit / decision subject | `17de2131e01f743d8ca3ac4e431e9362f08dff39` |
+
+The diff from `32e37ce374c64986baac4155d973574c22f944b3` to
+`17de2131e01f743d8ca3ac4e431e9362f08dff39` changes exactly:
+
+```text
+PHASE19_CONSTITUTIONAL_CLOSURE_REVIEW.md
+```
+
+No runtime source, kernel source, syscall metadata, ABI metadata,
+dependencies, workflows, baselines, or production runtime wiring changed in
+the PR #195 merge.
+
+## Reviewed Closure Basis
+
+The merged Constitutional Closure Review found that, for its exact review
+subject, the known Phase-19 bounded implementation, evidence, exact-main,
+closure-readiness, rebind, and post-merge governance records were sufficient
+to proceed to a separate Phase-19 closure decision.
+
+This decision accepts that finding as the closure-decision input. It does
+not extend, reinterpret, or replace the review.
+
+## Exact-Subject Post-Merge Verification Input
+
+The following post-merge verification input is bound to decision subject:
+
+```text
+17de2131e01f743d8ca3ac4e431e9362f08dff39
+```
+
+| Evidence | Run / job | Result |
+|---|---|---|
+| Strict `ci-freeze` | run `28300654228`, job `83848222016` | PASS |
+| AykenOS Dev Loop CI smoke | run `28300654262`, job `83848222137` | PASS |
+| AykenOS Dev Loop CI contract | run `28300654262`, job `83848292918` | PASS |
+| AykenOS Dev Loop CI full | run `28300654262`, job `83848448268` | PASS |
+| AykenOS Dev Loop CI isolation | run `28300654262`, job `83848626491` | PASS |
+| AykenOS Dev Loop CI performance | run `28300654262`, job `83848782060` | PASS |
+| Dev Loop optimized | run `28300654244`, job `83848222019` | PASS |
+| Dev Loop validation | run `28300654236`, job `83848222025` | PASS |
+| Governance Summary | run `28300654253` | PASS |
+| Spec Purity | run `28300654258` | PASS |
+| Evidence Isolation | runs `28300654233` and `28300654245` | PASS |
+| Observation Boundary | run `28300654239` | PASS |
+| Naming Compliance | runs `28300654219` and `28300654254` | PASS |
+| Workspace boundary | run `28300654252` | PASS |
+| Semantic CLI contract boundary | run `28300654268` | PASS |
+| BCIB core boundary | run `28300654223` | PASS |
+| DSL BCIB contract boundary | run `28300654250` | PASS |
+| Data runtime BCIB boundary | run `28300654230` | PASS |
+| AI Runtime boundary | run `28300654248` | PASS |
+| Capability manager boundary | run `28300654221` | PASS |
+| Proofd observability boundary | run `28300654237` | PASS |
+| Toolchain opcode registry boundary | run `28300654229` | PASS |
+
+This table records decision input only. It is not a new evidence package and
+does not grant runtime activation, general runtime authority, or Phase-20
+pointer transition.
+
+## Closure Decision
+
+Phase-19 is closed for exact decision subject:
+
+```text
+17de2131e01f743d8ca3ac4e431e9362f08dff39
+```
+
+The closure is limited to the Phase-19 Platform Runtime MVP
+planning/admission/receipt boundary, the bounded admission/receipt
+implementation, the reference-integrity validation slice, the exact-main
+readiness chain, and the merged Constitutional Closure Review.
+
+The closure does not convert any Phase-19 evidence, receipt, validation
+record, admission record, readiness record, or review record into runtime
+activation or general runtime authority.
+
+## Closed Scope
+
+| Scope item | Closure result |
+|---|---|
+| Phase-19 Runtime RFC boundary | CLOSED |
+| First bounded admission/receipt implementation | CLOSED FOR PR #181 SCOPE |
+| Runtime implementation post-merge consistency | CLOSED FOR BOUNDED SUBJECT ONLY |
+| Reference-integrity validation implementation | CLOSED FOR PR #187 SCOPE |
+| Reference-integrity exact-main synchronization | CLOSED FOR RECORDED SUBJECTS |
+| Closure-readiness manifest and exact-main rebind | CLOSED AS DECISION INPUT |
+| Constitutional Closure Review | CLOSED AS DECISION INPUT |
+| Decision subject post-merge verification | CLOSED FOR `17de2131e01f743d8ca3ac4e431e9362f08dff39` |
+
+The `CLOSED` statuses above are scoped closure results. They must not be
+read as runtime activation, general runtime authority, or Phase-20 pointer
+transition.
+
+## Explicit Non-Authorization
+
+This decision does not authorize:
+
+1. Runtime activation.
+2. General runtime authority.
+3. Package installation, loading, mounting, scheduling, publication, or
+   execution.
+4. Module or plugin loading.
+5. Workspace creation, workspace runtime, or real mounts.
+6. Capability issuance, token minting, or trust assignment.
+7. Semantic CLI, AI Runtime, or agent authority.
+8. New syscalls, kernel ABI expansion, workflow-threshold changes,
+   dependency changes, baseline changes, or Ring0 policy.
+9. New evidence generation, exact-main rebind, implementation acceptance, or
+   constitutional amendment authority.
+10. Phase-20 pointer transition.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this decision is merged, that merge publishes the Phase-19 closure
+decision. The landing SHA is the publication location of this decision
+record; it must not be read as a new Phase-19 implementation subject, a new
+evidence subject, a runtime activation subject, or an implicit Phase-20
+pointer transition.
+
+The decision remains bound to:
+
+```text
+17de2131e01f743d8ca3ac4e431e9362f08dff39
+```
+
+The publication merge does not require a new closure-readiness rebind or a
+new Constitutional Closure Review merely because it publishes this decision.
+Any later technical change, authority expansion, pointer transition, or
+Phase-20 activation still requires a separate reviewed decision path.
+
+## Phase-20 Boundary
+
+Phase-20 remains unavailable until a separate pointer-transition artifact or
+decision package explicitly changes the phase authority boundary after this
+closure decision is accepted.
+
+That later transition must not treat this closure decision as runtime
+activation, general runtime authority, or implicit permission to implement
+Phase-20 capability ecosystem, module registry, Semantic CLI, AI Runtime, or
+agent behavior.
+
+## Decision Conclusion
+
+Phase-19 is closed for exact subject:
+
+```text
+17de2131e01f743d8ca3ac4e431e9362f08dff39
+```
+
+Runtime activation, general runtime authority, Phase-20 pointer transition,
+and all later-phase implementation authority remain pending and
+unauthorized until separately reviewed and decided.


### PR DESCRIPTION
Adds PHASE19_CLOSURE_DECISION.md as the Phase-19 closure decision for exact subject 17de2131e01f743d8ca3ac4e431e9362f08dff39. The decision grants Phase-19 closure only for the reviewed exact subject and explicitly does not authorize runtime activation, general runtime authority, Phase-20 pointer transition, new evidence, rebind, or implementation acceptance. Validation: git diff --cached --check before commit.