### PR TITLE
Phase-20: Add trust model RFC

### DIFF
--- a/PHASE20_TRUST_MODEL.md
+++ b/PHASE20_TRUST_MODEL.md
@@ -1,0 +1,660 @@
+# Phase-20 Trust Model
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE20_POINTER_TRANSITION_DECISION.md`,
+`PHASE20_GOVERNANCE_OVERVIEW.md`,
+`PHASE20_CAPABILITY_MODEL.md`,
+`PHASE20_CAPABILITY_IDENTITY.md`,
+`PHASE20_CAPABILITY_MANIFEST_SCHEMA.md`,
+`PHASE20_CAPABILITY_LIFECYCLE.md`,
+`PHASE20_REGISTRY_MODEL.md`, and
+`PHASE20_REGISTRY_GOVERNANCE.md`. In case of conflict, those documents
+prevail unless this trust model RFC is the narrower Phase-20 trust model
+record for the exact planning scope identified below.
+
+**Status:** PHASE-20 TRUST MODEL RFC / TRUST INPUT AND CONTEXT MODEL ONLY
+/ NO TRUST ASSIGNMENT / NO TRUST ISSUER AUTHORITY / NO CAPABILITY ISSUANCE
+/ NO REGISTRY PUBLICATION / NO DISTRIBUTION AUTHORITY / NO EVIDENCE
+ACCEPTANCE / NO IMPLEMENTATION AUTHORITY / NO RUNTIME ACTIVATION / NO
+GENERAL RUNTIME AUTHORITY
+**Trust model date:** 2026-06-29
+**Trust model id:** `ayken.phase20.trust_model.v1`
+**Trust model base main SHA:** `25ec94355b0d7687f2453e6c6bf6bd2057e56cba`
+**Current phase pointer:** `CURRENT_PHASE=20`
+**Authority boundary:** Trust input and context model only; not trust
+assignment, not trust issuer authority, not authenticity acceptance, not
+signature acceptance, not evidence acceptance, not registry publication,
+not distribution authority, not implementation authority, not runtime
+activation, not general runtime authority, not package installation, not
+package execution, not module loading, not workspace runtime, not plugin
+loading, not capability token minting, not capability issuance, not
+Semantic CLI authority, not AI Runtime authority, not agent authority, not
+syscall expansion, not kernel ABI expansion, not workflow-threshold,
+baseline, dependency, or Ring0 authority.
+
+## Purpose
+
+This document defines the Phase-20 trust model for AykenOS capability and
+registry governance records.
+
+It answers one question:
+
+```text
+How is trust modeled?
+```
+
+It does not answer:
+
+```text
+How is trust assigned?
+Who may issue trust?
+How is evidence accepted?
+How is a registry record published or distributed?
+How is a capability issued, implemented, activated, loaded, or run?
+```
+
+Those questions belong to later Phase-20 RFCs and implementation decisions.
+
+## Core Rule
+
+```text
+trust input != trust assignment
+trust claim != trust assignment
+trust proof reference != authority
+trust context != trust issuer authority
+trust model != trust issuer
+registry acceptance != trusted
+evidence presence != trust
+signature presence != signature acceptance
+trust model != capability issuance
+trust model != registry publication
+trust model != distribution authority
+trust model != implementation authority
+trust model != runtime activation
+```
+
+Trust modeling makes trust inputs, claims, proof references, context, and
+review boundaries explicit. It does not make a capability or registry record
+trusted, published, distributed, issued, implemented, executable, loadable,
+installable, runnable, or authority-bearing.
+
+Unknown authority readings fail closed.
+
+## Trust Mission
+
+The mission of the Phase-20 trust model is to define an inert, reviewable
+way to describe trust-related inputs before any trust assignment exists.
+
+Trust modeling exists so later RFCs can reason about:
+
+1. Trust inputs.
+2. Trust claims.
+3. Proof references.
+4. Trust context.
+5. Trust assessment classes.
+6. Disputed or revoked trust inputs.
+7. Registry governance relationships.
+8. Evidence relationships.
+9. Distribution prerequisites.
+10. Acceptance workflow inputs.
+
+The trust model itself grants no trust assignment, trust issuer authority,
+evidence acceptance, registry publication, distribution, implementation,
+runtime, or capability issuance authority.
+
+Each later use requires its own reviewed RFC or decision path.
+
+## Trust Definition
+
+Trust is a governance interpretation that may later be assigned only through
+a reviewed authority path.
+
+This RFC does not assign trust. It defines the model space for trust inputs
+and trust context.
+
+A trust model record may describe:
+
+1. The capability or registry subject being considered.
+2. The trust input being recorded.
+3. The trust claim being made.
+4. The proof reference supporting that claim.
+5. The governance context around that claim.
+6. The boundary that prevents the claim from becoming authority.
+
+A trust model record is not:
+
+1. Trust assignment.
+2. Trust issuer authority.
+3. Authenticity proof acceptance.
+4. Signature acceptance.
+5. Evidence acceptance.
+6. Registry publication.
+7. Distribution authorization.
+8. Capability issuance.
+9. Source acceptance.
+10. Implementation authority.
+11. Runtime activation.
+12. Semantic CLI, AI Runtime, or agent authority.
+
+## Trust Principles
+
+Every trust model rule must preserve these principles:
+
+1. **Input-only by default:** trust material is input for later review; it
+   is not trust assignment.
+2. **Identity-bound:** trust material must reference exact capability or
+   registry subjects and must not silently transfer across identity changes.
+3. **Registry-aware:** accepted registry governance state may be context; it
+   is not trust.
+4. **Evidence-aware:** evidence references may be context; they are not
+   evidence acceptance or trust.
+5. **Proof-denying:** proof references do not prove authenticity until a
+   later reviewed path accepts proof semantics.
+6. **Issuer-denying:** this RFC does not define trusted issuers, issuer
+   rights, issuer delegation, issuer revocation, or issuer authority.
+7. **Distribution-denying:** trust model records do not publish, release, or
+   distribute anything.
+8. **Authority-denying:** trust material does not imply implementation,
+   execution, loading, issuance, or runtime activation.
+9. **Audit-preserving:** disputed, rejected, revoked, or stale trust inputs
+   must remain reviewable.
+10. **Fail-closed:** missing, ambiguous, stale, inherited, colliding, or
+    differently scoped trust material fails closed.
+
+## Trust Components
+
+The conceptual trust model is composed of:
+
+| Component | Purpose | Authority result |
+|---|---|---|
+| Trust subject | Identifies the exact capability or registry subject under review | No trust assignment |
+| Trust input | Records trust-relevant material for later review | No authority |
+| Trust claim | States a trust-related assertion for review | No acceptance |
+| Trust proof reference | References proof material without accepting it | No proof authority |
+| Trust context | Records governance context around a trust input | No issuer authority |
+| Trust assessment class | Labels trust-review posture conceptually | No trust level assignment |
+| Trust dispute record | Records ambiguity or conflict | No rejection or fault by itself |
+| Trust revocation input | Records a revocation-relevant input for later review | No revocation by itself |
+| Trust audit record | Preserves trust-review history | No evidence acceptance |
+
+These components are conceptual. They do not define a database schema,
+storage engine, signature format, certificate format, key format, trust
+store, API endpoint, command, package format, wire format, runtime object,
+or issuer service.
+
+## Trust Subject
+
+A trust subject is the exact governance subject to which trust material
+refers.
+
+A trust subject may be:
+
+1. A capability identity.
+2. A capability manifest.
+3. A lifecycle state record.
+4. A registry entry.
+5. A registry governance decision record.
+6. A later evidence or acceptance record.
+
+The trust subject must be exact, reviewable, and bounded.
+
+Trust material must not transfer across changed identity, changed manifest
+scope, changed lifecycle state, changed registry entry, alias,
+supersession, rename, or replacement by implication.
+
+## Trust Input
+
+A trust input is trust-relevant material recorded for later governance
+review.
+
+Trust inputs may include references to:
+
+1. Maintainer assertions.
+2. Registry governance decisions.
+3. Proof material.
+4. Signature material.
+5. Key material.
+6. Revocation material.
+7. Evidence material.
+8. Audit material.
+9. External review notes.
+
+A trust input is not trust assignment.
+
+Trust input presence must not be interpreted as authenticity proof,
+signature acceptance, issuer authority, registry publication, distribution
+authority, evidence acceptance, implementation authority, capability
+issuance, or runtime activation.
+
+## Trust Claim
+
+A trust claim is a reviewable assertion about a trust subject.
+
+A trust claim may assert that a trust subject is associated with a stated
+input, proof reference, maintainer context, governance context, or audit
+context.
+
+A trust claim must identify:
+
+1. Exact claim subject.
+2. Claim date or review context.
+3. Claiming party or record, if applicable.
+4. Claimed trust-relevant relationship.
+5. Proof reference, if any.
+6. Governing RFCs.
+7. Non-authorization notice.
+
+A trust claim does not assign trust and does not prove the claim is true.
+
+Unknown, unsigned, ambiguous, inherited, stale, differently scoped, or
+conflicting claims fail closed.
+
+## Trust Proof Reference
+
+A trust proof reference is an inert reference to proof material.
+
+Proof material may later include:
+
+1. Digital signature material.
+2. Key identity material.
+3. Maintainer attestation material.
+4. Evidence digest material.
+5. Registry snapshot material.
+6. Revocation input material.
+7. Audit trail material.
+
+This RFC does not define proof acceptance.
+
+A proof reference is not:
+
+1. Signature acceptance.
+2. Authenticity acceptance.
+3. Evidence acceptance.
+4. Trust assignment.
+5. Trust issuer authority.
+6. Capability issuance.
+7. Runtime authority.
+
+Proof format, proof verification, signature verification, key management,
+digest canonicalization, evidence binding, and proof acceptance belong to
+later RFCs or reviewed decisions.
+
+## Trust Context
+
+Trust context is the governance context in which trust inputs and claims are
+reviewed.
+
+Trust context may include:
+
+1. Accepted registry governance state.
+2. Registry entry identity.
+3. Manifest reference.
+4. Lifecycle state.
+5. Review history.
+6. Quarantine or rejection history.
+7. Evidence references.
+8. Distribution policy references.
+9. Revocation inputs.
+
+Trust context is not trust assignment.
+
+Registry acceptance, manifest validity, lifecycle acceptance, evidence
+presence, or distribution eligibility must not be treated as trust by
+context alone.
+
+## Trust Assessment Classes
+
+Trust assessment classes are conceptual review labels for trust material.
+
+The initial trust assessment vocabulary is:
+
+| Class | Meaning | Authority result |
+|---|---|---|
+| `unassigned` | No trust assignment exists | No trust |
+| `input-recorded` | Trust input exists for later review | No acceptance |
+| `proof-referenced` | Proof material is referenced but not accepted | No proof authority |
+| `context-ready` | Registry or governance context is available for later trust review | No issuer authority |
+| `disputed` | Trust material has ambiguity, conflict, or scope concern | No authority |
+| `revocation-input-recorded` | Revocation-relevant trust input exists for later review | No revocation by itself |
+
+These classes are review labels only. They are not trust levels, trust
+scores, issuer decisions, policy decisions, distribution status, package
+status, runtime status, or authority grants.
+
+Later RFCs may define narrower trust assessment semantics. They must not
+turn assessment class presence into authority.
+
+## Trust Assessment Class Boundary
+
+Trust assessment classes are review labels only.
+
+They are not trust levels, clearance levels, issuer grades, capability
+permissions, registry publication status, distribution eligibility,
+evidence acceptance, implementation approval, or runtime authority.
+
+Any later trust-level or trust-assignment model requires a separate
+reviewed RFC or decision path.
+
+## Trust Boundary
+
+Trust modeling ends at reviewable trust material.
+
+This RFC does not define:
+
+1. Trust assignment.
+2. Trust issuer eligibility.
+3. Issuer delegation.
+4. Issuer revocation.
+5. Signature verification.
+6. Key management.
+7. Certificate validation.
+8. Proof acceptance.
+9. Evidence acceptance.
+10. Distribution eligibility.
+11. Runtime trust.
+
+Any reading that turns trust input, trust claim, proof reference, trust
+context, or assessment class into authority fails closed.
+
+## Trust Issuer Boundary
+
+This RFC does not define trusted issuers.
+
+It does not define:
+
+1. Who may issue trust.
+2. How issuers are identified.
+3. How issuers are delegated.
+4. How issuer keys are managed.
+5. How issuer signatures are accepted.
+6. How issuer trust is revoked.
+7. How issuer disputes are resolved.
+
+A named maintainer, reviewer, registry namespace, registry governance
+record, proof reference, or signature reference must not be interpreted as a
+trust issuer by this RFC.
+
+Issuer-specific authority requires a later reviewed RFC or decision path.
+
+## Trust Assignment Boundary
+
+Trust assignment is not defined by this RFC.
+
+No trust input, trust claim, proof reference, trust context, assessment
+class, registry governance state, evidence reference, or signature reference
+may assign trust by implication.
+
+A future trust assignment path, if accepted, must define:
+
+1. Exact trust subject.
+2. Exact trust input.
+3. Exact proof requirements.
+4. Exact issuer or decision authority.
+5. Exact accepted trust result.
+6. Denied authorities.
+7. Evidence requirements.
+8. Audit requirements.
+9. Revocation handling.
+10. Post-decision verification requirements.
+
+Until such a reviewed path exists, trust assignment remains denied.
+
+## Registry Relationship
+
+`PHASE20_REGISTRY_MODEL.md` defines registry records as inert governance
+records.
+
+`PHASE20_REGISTRY_GOVERNANCE.md` defines accepted registry governance state
+as explicit admission governance, not publication or trust.
+
+The trust model may use registry records and accepted registry governance
+state as trust context.
+
+It must not treat registry presence, registry admission, registry
+acceptance, registry index presence, registry view presence, registry
+snapshot presence, or registry governance decision presence as trust
+assignment.
+
+Registry ambiguity, collision, quarantine, rejection, stale reference, or
+differently scoped registry material fails closed for trust modeling.
+
+## Evidence Relationship
+
+Evidence may become trust context only after later evidence RFCs define
+evidence format, exact-subject binding, review requirements, and acceptance
+behavior.
+
+This RFC does not accept evidence.
+
+Evidence presence, evidence reference, evidence digest, evidence package,
+test result, signature material, or audit note must not be interpreted as
+trust assignment or proof acceptance by this RFC.
+
+Evidence inheritance is denied.
+
+## Distribution Relationship
+
+Trust modeling may become input to later distribution policy.
+
+This RFC does not define publication, distribution, mirror eligibility,
+release eligibility, package distribution, module distribution, plugin
+distribution, marketplace listing, rollback behavior, or revocation effects.
+
+Distribution policy must not interpret trust input presence as trust
+assignment or distribution authority.
+
+## Dispute And Revocation Input Boundary
+
+Trust disputes and trust revocation inputs are review material.
+
+A disputed trust input means trust material has ambiguity, conflict, scope
+concern, proof concern, issuer concern, evidence concern, or safety concern.
+
+A revocation input means later review may need to consider whether a trust
+input, proof reference, claim, or context should stop being used for future
+trust paths.
+
+Dispute or revocation input presence does not:
+
+1. Prove fault.
+2. Assign trust.
+3. Revoke trust by itself.
+4. Revoke a capability by itself.
+5. Publish an alternative record.
+6. Transfer authority to another record.
+7. Delete history.
+8. Activate runtime behavior.
+
+Dispute handling, revocation proof requirements, notification, rollback,
+distribution effects, registry effects, and acceptance effects belong to
+later RFCs.
+
+## Trust Validation
+
+Trust model validation is conceptual and fail-closed.
+
+Trust material is invalid for governance review when:
+
+1. Trust subject is missing or ambiguous.
+2. Trust input is missing or ambiguous.
+3. Claim subject differs from reviewed subject without explicit review.
+4. Proof reference is missing when a claim requires proof.
+5. Proof format interpretation is undefined.
+6. Signature interpretation is undefined.
+7. Issuer interpretation is undefined.
+8. Registry context conflicts with accepted registry records.
+9. Evidence context relies on unaccepted evidence semantics.
+10. Trust material relies on alias or supersession without accepted rules.
+11. Trust material implies publication or distribution.
+12. Trust material implies capability issuance.
+13. Trust material implies implementation or runtime authority.
+
+Validation failure grants no authority. It requires correction, rejection,
+quarantine, dispute recording, or a later reviewed decision path.
+
+## Trust Invariants
+
+Every later Phase-20 RFC must preserve these trust invariants:
+
+1. Trust input is not trust assignment.
+2. Trust claim is not trust assignment.
+3. Trust proof reference is not proof acceptance.
+4. Trust context is not trust issuer authority.
+5. Registry acceptance is not trust.
+6. Evidence presence is not trust.
+7. Signature presence is not signature acceptance.
+8. Trust assessment class is not an authority level.
+9. Trust material is identity-bound.
+10. Trust material must not silently transfer across rename, alias,
+    supersession, replacement, or changed scope.
+11. Trust material does not imply registry publication.
+12. Trust material does not imply distribution.
+13. Trust material does not imply evidence acceptance.
+14. Trust material does not imply capability issuance.
+15. Trust material does not imply implementation authority.
+16. Trust material does not imply runtime activation.
+
+Violation of any invariant fails closed.
+
+## Relationship To Later RFCs
+
+The trust model is a prerequisite for later Phase-20 RFCs.
+
+| Later RFC | Trust model relationship |
+|---|---|
+| `PHASE20_DISTRIBUTION_POLICY.md` | Uses trust context and trust inputs as distribution policy inputs without granting distribution. |
+| `PHASE20_CAPABILITY_EVIDENCE_MODEL.md` | Defines evidence binding and proof material relationships without evidence inheritance. |
+| `PHASE20_CAPABILITY_ACCEPTANCE_WORKFLOW.md` | Uses trust inputs and disputes for review tracking without implementation authority. |
+
+Later RFCs may narrow trust use. They must not broaden the trust model into
+trust assignment, trust issuer authority, evidence acceptance,
+distribution, implementation, issuance, or runtime authority without a
+separate reviewed decision.
+
+## Non-Goals
+
+This document does not define or authorize:
+
+1. Trust assignment.
+2. Trust issuer authority.
+3. Trust issuer registry.
+4. Issuer delegation.
+5. Issuer revocation.
+6. Signature verification.
+7. Signature acceptance.
+8. Key management.
+9. Certificate validation.
+10. Proof acceptance.
+11. Evidence package format.
+12. Evidence acceptance.
+13. Evidence inheritance.
+14. Registry publication.
+15. Distribution policy.
+16. Publication or mirror eligibility.
+17. Package repository.
+18. Module repository.
+19. Plugin marketplace.
+20. Dependency resolver.
+21. Alias implementation.
+22. Supersession implementation.
+23. Version compatibility rules.
+24. Lifecycle transition implementation.
+25. Source implementation.
+26. Runtime activation.
+27. Package installation, loading, execution, scheduling, or publication.
+28. Module loading.
+29. Workspace creation, workspace runtime, or real mounts.
+30. Plugin host, plugin loading, or plugin instantiation.
+31. Capability token minting or capability issuance.
+32. Semantic CLI execution or verdict authority.
+33. AI Runtime authority.
+34. Agent behavior.
+35. New syscalls.
+36. Kernel ABI expansion.
+37. Workflow-threshold, baseline, dependency, or Ring0 policy changes.
+
+## Implementation Gating
+
+No Phase-20 implementation slice may start from this trust model RFC alone.
+
+Implementation remains denied unless a later reviewed implementation
+decision:
+
+1. Identifies the exact implementation subject.
+2. References accepted prerequisite RFCs.
+3. States the bounded behavior being authorized.
+4. States the denied behaviors.
+5. Produces exact-subject evidence.
+6. Receives acceptance review.
+7. Is merged under the applicable governance path.
+8. Receives post-merge exact-SHA verification.
+
+Trust model is not implementation authority.
+
+## Explicit Non-Authorization
+
+This trust model RFC does not authorize:
+
+1. Runtime activation.
+2. General runtime authority.
+3. Phase-20 implementation.
+4. Source acceptance or merge authority.
+5. Trust assignment.
+6. Trust issuer authority.
+7. Signature acceptance.
+8. Authenticity acceptance.
+9. Evidence acceptance or evidence inheritance.
+10. Registry publication.
+11. Distribution authority.
+12. Capability issuance.
+13. Package installation, loading, execution, scheduling, or publication.
+14. Module loading.
+15. Workspace creation, workspace runtime, or real mounts.
+16. Plugin host, plugin loading, or plugin instantiation.
+17. Capability token minting.
+18. Semantic CLI execution or verdict authority.
+19. AI Runtime authority.
+20. Agent behavior.
+21. New syscalls.
+22. Kernel ABI expansion.
+23. Workflow-threshold, baseline, dependency, or Ring0 policy changes.
+24. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Trust Model Conclusion
+
+AykenOS trust modeling defines inert, reviewable trust inputs, trust claims,
+proof references, trust context, assessment classes, disputes, revocation
+inputs, and audit records for later governance.
+
+Trust model supports later distribution, evidence, acceptance, and
+implementation RFCs. It does not authorize any of them.
+
+Runtime activation, general runtime authority, Phase-20 implementation
+authority, capability issuance, registry publication, package execution,
+module loading, workspace runtime, plugin loading, trust assignment, trust
+issuer authority, Semantic CLI authority, AI Runtime authority, agent
+authority, syscall expansion, kernel ABI expansion, workflow-threshold
+changes, baseline changes, dependency changes, and Ring0 authority remain
+pending and unauthorized until separately reviewed and decided.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-20 RFC
+**Architecture status:** Draft / pending review
+**Authority notice:** This signature identifies the architectural authorship
+of this RFC. It grants no runtime authority, implementation authority, trust
+authority, execution authority, constitutional authority, registry authority,
+capability issuance authority, package authority, module authority, plugin
+authority, Semantic CLI authority, AI Runtime authority, agent authority, or
+Ring0 authority.


### PR DESCRIPTION
## Summary

Adds PHASE20_TRUST_MODEL.md as the Phase-20 trust input and context model after Registry Governance.

## Scope

- Defines trust subject, trust input, trust claim, proof reference, trust context, assessment classes, dispute input, revocation input, and audit records.
- Adds a Trust Assessment Class Boundary to keep assessment classes as review labels only.
- Preserves fail-closed boundaries between trust modeling and later distribution, evidence, acceptance, and implementation RFCs.

## Explicit non-authorization

This PR introduces no trust assignment, trust issuer authority, signature acceptance, authenticity acceptance, evidence acceptance, registry publication, distribution authority, implementation authority, capability issuance, runtime activation, or authority expansion.

This PR does not authorize trust assignment, trust issuer authority, signature acceptance, evidence acceptance, registry publication, distribution authority, capability issuance, source acceptance, implementation authority, runtime activation, package execution, module loading, plugin instantiation, Semantic CLI authority, AI Runtime authority, agent authority, syscall expansion, kernel ABI expansion, workflow-threshold changes, baseline changes, dependency changes, or Ring0 authority.

## Validation

- git diff --cached --check
- Verified restricted marker is absent from PHASE20_TRUST_MODEL.md
- Verified no disallowed assistant-name marker appears in PHASE20_TRUST_MODEL.md