### PR TITLE
Phase-20 runtime decision RFC

### DIFF
--- a/PHASE20_RUNTIME_DECISION.md
+++ b/PHASE20_RUNTIME_DECISION.md
@@ -1,0 +1,959 @@
+# Phase-20 Runtime Decision
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE20_POINTER_TRANSITION_DECISION.md`,
+`PHASE20_GOVERNANCE_OVERVIEW.md`,
+`PHASE20_CAPABILITY_MODEL.md`,
+`PHASE20_CAPABILITY_IDENTITY.md`,
+`PHASE20_CAPABILITY_MANIFEST_SCHEMA.md`,
+`PHASE20_CAPABILITY_LIFECYCLE.md`,
+`PHASE20_REGISTRY_MODEL.md`,
+`PHASE20_REGISTRY_GOVERNANCE.md`,
+`PHASE20_TRUST_MODEL.md`,
+`PHASE20_DISTRIBUTION_POLICY.md`,
+`PHASE20_CAPABILITY_EVIDENCE_MODEL.md`,
+`PHASE20_CAPABILITY_ACCEPTANCE_WORKFLOW.md`,
+`PHASE20_IMPLEMENTATION_DECISION.md`,
+`PHASE20_IMPLEMENTATION_SLICE.md`,
+`PHASE20_IMPLEMENTATION_REVIEW.md`, and
+`PHASE20_IMPLEMENTATION_ACCEPTANCE_DECISION.md`. In case of conflict,
+those documents prevail unless this runtime decision RFC is the narrower
+Phase-20 runtime decision record for the exact planning scope identified
+below.
+
+**Status:** PHASE-20 RUNTIME DECISION RFC / BOUNDED RUNTIME DECISION MODEL
+ONLY / NO RUNTIME ACTIVATION / NO GENERAL RUNTIME AUTHORITY / NO PACKAGE
+AUTHORITY / NO PACKAGE INSTALLATION / NO PACKAGE LOADING / NO PACKAGE
+EXECUTION / NO DEPLOYMENT / NO CAPABILITY ISSUANCE / NO TRUST ASSIGNMENT /
+NO REGISTRY PUBLICATION / NO DISTRIBUTION AUTHORITY / NO SOURCE MERGE
+AUTHORITY / NO SOURCE ACCEPTANCE
+**Runtime decision date:** 2026-06-30
+**Runtime decision id:** `ayken.phase20.runtime_decision.v1`
+**Runtime decision base main SHA:** `2f82e6d3b74f29cbd25cea5b3567462172a9a1b9`
+**Reviewed implementation acceptance decision SHA:** `2f82e6d3b74f29cbd25cea5b3567462172a9a1b9`
+**Current phase pointer:** `CURRENT_PHASE=20`
+**Authority boundary:** Bounded runtime decision model only; not runtime
+activation, not general runtime authority, not package authority, not
+package installation, not package loading, not package execution, not
+deployment, not source acceptance, not source merge authority, not source
+repository authority, not module loading, not workspace runtime, not
+plugin loading, not capability token minting, not capability issuance,
+not trust assignment, not trust issuer authority, not registry authority,
+not registry publication, not publication authority, not distribution
+authority, not distribution execution, not Semantic CLI authority, not AI
+Runtime authority, not agent authority, not syscall expansion, not kernel
+ABI expansion, not workflow-threshold, baseline, dependency, or Ring0
+authority.
+
+## Purpose
+
+This document defines the Phase-20 runtime decision model for evaluating
+bounded runtime authority consideration after an accepted implementation
+proposal.
+
+It answers one question:
+
+```text
+How may an exact Runtime Decision evaluate bounded runtime authority after
+an accepted implementation proposal?
+```
+
+It does not answer:
+
+```text
+How is runtime activated?
+How is code executed?
+How is a package installed, loaded, executed, deployed, or distributed?
+How is a capability issued?
+How is trust assigned?
+How is a registry entry published?
+```
+
+Those questions belong to later reviewed RFCs or decision paths, if ever
+authorized.
+
+## Core Rule
+
+```text
+runtime decision != runtime activation
+runtime decision != general runtime authority
+runtime decision != package execution
+runtime decision != package loading
+runtime decision != deployment
+runtime decision != capability issuance
+runtime decision != registry publication
+runtime decision != trust assignment
+accepted implementation proposal != runtime enabled
+runtime decision record != runtime state
+runtime decision record != execution authority
+runtime consideration != runtime activation
+bounded runtime consideration != general runtime authority
+runtime decision result != runtime enabled
+runtime decision result != package executable
+```
+
+Runtime Decision may record bounded runtime authority consideration.
+
+Runtime Decision does not activate runtime behavior by itself.
+
+`PHASE20_RUNTIME_DECISION.md` consumes Phase-20 implementation acceptance
+context and remains subordinate to Phase-19 runtime authority records.
+
+Runtime Decision does not expand Slice scope.
+
+Runtime Decision does not grant package execution, package loading,
+deployment, registry publication, trust assignment, distribution
+authority, source merge authority, or capability issuance by implication.
+
+Unknown authority readings fail closed.
+
+## Runtime Decision Mission
+
+The mission of the Phase-20 runtime decision model is to define an
+explicit, auditable governance decision path for bounded runtime authority
+consideration after an exact implementation acceptance decision.
+
+Runtime decision exists so later RFCs can reason about:
+
+1. Runtime decision subjects.
+2. Exact implementation acceptance decision prerequisites.
+3. Accepted implementation proposal binding.
+4. Runtime decision identity.
+5. Bounded runtime authority consideration.
+6. Runtime consideration boundaries.
+7. Runtime non-activation rules.
+8. Denied runtime readings.
+9. Runtime decision records and outcomes.
+10. Relationship to Phase-19 runtime records.
+11. Post-decision exact-SHA verification.
+12. Later activation dependency, if ever authorized.
+
+The runtime decision model itself grants no runtime activation, general
+runtime authority, package authority, deployment, distribution, trust,
+registry, source merge, or capability issuance authority.
+
+Each later use requires its own reviewed RFC or decision path.
+
+## Runtime Decision Definition
+
+Runtime decision is a governance decision record that evaluates bounded
+runtime authority consideration for an exact accepted implementation
+proposal.
+
+A runtime decision may describe:
+
+1. The exact runtime decision subject.
+2. The exact implementation acceptance decision record.
+3. The exact accepted bounded implementation proposal.
+4. The exact Implementation Review record.
+5. The exact Implementation Slice record.
+6. The exact Slice identity and bounded source scope.
+7. The bounded runtime authority consideration.
+8. Denied runtime readings.
+9. Runtime decision result.
+10. Post-decision verification requirements.
+11. Later activation dependency, if ever authorized.
+12. Non-authorization notice.
+
+A runtime decision is not runtime activation, general runtime authority,
+package installation, package loading, package execution, deployment,
+capability issuance, registry publication, distribution authority, trust
+assignment, source acceptance, source merge authority, or Semantic CLI,
+AI Runtime, or agent authority.
+
+## Runtime Decision Scope
+
+This RFC defines only the bounded runtime decision model.
+
+It does not define runtime activation, runtime implementation, code
+execution, package installation, package loading, package execution,
+module loading, plugin loading, workspace runtime, deployment behavior,
+registry publication, distribution execution, trust assignment,
+capability issuance, source modification procedure, source acceptance, or
+source merge procedure.
+
+Runtime decision is a governance decision layer. It is not a runtime
+service, execution engine, package manager, installer, loader, deployment
+service, registry publisher, distribution engine, trust issuer,
+capability issuer, source merge engine, or source repository authority.
+
+Any activation-specific, execution-specific, package-specific,
+loader-specific, deployment-specific, runtime-specific,
+publication-specific, distribution-specific, trust-specific,
+capability-issuance-specific, or source-merge-specific interpretation
+fails closed until later reviewed RFCs define exact behavior.
+
+## Runtime Decision Subject
+
+A runtime decision subject is the exact accepted implementation proposal
+and bounded runtime authority consideration being decided after one exact
+Implementation Acceptance Decision record.
+
+A runtime decision subject must reference:
+
+1. Exact Implementation Acceptance Decision record.
+2. Exact implementation acceptance decision subject.
+3. Exact implementation acceptance decision result.
+4. Exact accepted bounded implementation proposal.
+5. Exact Implementation Review record.
+6. Exact Implementation Slice record.
+7. Exact Slice identity.
+8. Exact bounded source scope.
+9. Exact reviewed implementation acceptance decision SHA.
+10. Phase-19 runtime authority records used as boundary context.
+11. Governing RFCs.
+12. Non-authorization notice.
+
+Runtime decision subject is not runtime state.
+
+Runtime decision subject is not runtime activation, package ownership,
+package execution, source repository ownership, source merge authority,
+module ownership, plugin ownership, registry publication, deployment
+target, process, workspace state, or capability token.
+
+Changing the Implementation Acceptance Decision record, decision subject,
+decision result, accepted bounded implementation proposal, Implementation
+Review record, Slice record, Slice identity, bounded source scope,
+reviewed implementation acceptance decision SHA, bounded runtime
+consideration, or subject-defining context creates a different runtime
+decision subject unless a later reviewed RFC defines exact narrower
+behavior.
+
+## Exact Implementation Acceptance Decision Requirement
+
+Runtime decision requires an exact Implementation Acceptance Decision
+record.
+
+The reviewed implementation acceptance decision record for this RFC is
+`PHASE20_IMPLEMENTATION_ACCEPTANCE_DECISION.md` at exact main SHA
+`2f82e6d3b74f29cbd25cea5b3567462172a9a1b9`.
+
+Runtime decision must consume the exact reviewed Implementation
+Acceptance Decision record.
+
+Runtime decision must never reconstruct Slice scope, reinterpret Slice
+intent, expand bounded source scope, infer implementation acceptance, or
+infer runtime authority when the exact acceptance decision result is
+missing.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped implementation acceptance decision binding fails closed.
+
+## Accepted Implementation Proposal Requirement
+
+Runtime decision may consider only a bounded implementation proposal with
+an exact implementation acceptance decision result of `accepted`.
+
+Implementation acceptance result `accepted` is necessary but not
+sufficient for runtime decision.
+
+Implementation acceptance result `accepted` is not runtime authority by
+implication.
+
+Implementation acceptance decision outcomes or dispositions of
+`rejected`, `quarantined`, `deferred`, or `superseded` must not produce a
+runtime decision result that records bounded runtime authority
+consideration.
+
+Acceptance result ambiguity fails closed.
+
+## Phase-19 Runtime Authority Relationship
+
+Phase-20 Runtime Decision consumes Phase-20 implementation acceptance
+context and remains subordinate to Phase-19 runtime authority records.
+
+Phase-19 runtime records may be read as boundary context for:
+
+1. Runtime MVP planning boundaries.
+2. Runtime evidence expectations.
+3. Runtime non-goals and denials.
+4. Platform runtime constitutional constraints.
+5. Userspace-only runtime constraints.
+6. Frozen syscall and kernel ABI boundaries.
+7. Denied package, module, workspace, plugin, trust, capability, AI
+   Runtime, Semantic CLI, and agent authority readings.
+
+Phase-20 Runtime Decision must not broaden, replace, supersede, weaken, or
+reinterpret Phase-19 runtime authority records.
+
+Any Phase-20 runtime decision reading that conflicts with Phase-19 runtime
+authority records fails closed.
+
+## Runtime Decision Identity
+
+Runtime decision identity distinguishes one runtime decision record from
+another.
+
+Runtime decision identity is conceptually composed of:
+
+```text
+(runtime_decision_domain, runtime_decision_subject,
+ implementation_acceptance_decision_record,
+ accepted_bounded_implementation_proposal,
+ bounded_runtime_consideration, runtime_decision_binding)
+```
+
+This tuple is conceptual. It is not a source path syntax, source ownership
+claim, package name, module name, crate name, repository branch, database
+schema, command, token, runtime handle, process handle, loader key,
+execution key, merge key, deployment key, or capability key.
+
+Runtime decision identity remains stable for the lifetime of that decision
+record. Changing identity-defining runtime decision fields creates a
+different runtime decision record unless a later reviewed RFC defines
+exact narrower behavior.
+
+Runtime decision identity does not imply runtime activation, package
+authority, deployment authority, registry publication, distribution
+authority, trust assignment, source merge authority, or capability
+issuance.
+
+## Bounded Runtime Authority Consideration
+
+Bounded runtime authority consideration is the exact runtime authority
+question that a Runtime Decision may evaluate for an accepted bounded
+implementation proposal.
+
+Bounded runtime authority consideration may identify:
+
+1. Exact accepted bounded implementation proposal.
+2. Exact runtime boundary being considered.
+3. Exact denied runtime behaviors.
+4. Exact Phase-19 runtime boundary references.
+5. Exact non-activation notice.
+6. Exact package, loader, deployment, issuance, publication, trust,
+   distribution, source merge, Semantic CLI, AI Runtime, and agent
+   denials.
+7. Later activation dependency, if ever authorized.
+
+Bounded runtime authority consideration is not runtime activation.
+
+Bounded runtime authority consideration is not code execution, package
+installation, package loading, package execution, module loading, plugin
+loading, deployment, registry publication, trust assignment, distribution
+execution, or capability issuance.
+
+Bounded runtime authority consideration must be exact, auditable, and
+bound to one runtime decision subject.
+
+Approximate, inherited, stale, implied, unbounded, or differently scoped
+runtime consideration readings fail closed.
+
+## Runtime Consideration Boundary
+
+Runtime consideration boundary is the limit of what Runtime Decision may
+evaluate.
+
+Runtime decision may evaluate whether:
+
+1. Exact Implementation Acceptance Decision record is present.
+2. Exact implementation acceptance decision result is `accepted`.
+3. Accepted bounded implementation proposal is exact and stable.
+4. Proposal remains bound to the exact Implementation Review record.
+5. Proposal remains bound to the exact Implementation Slice record.
+6. Bounded source scope is not expanded.
+7. Slice intent is not reinterpreted.
+8. Phase-19 runtime boundary context is preserved.
+9. Runtime activation is denied by default.
+10. Package, loader, deployment, issuance, publication, trust,
+    distribution, source merge, Semantic CLI, AI Runtime, and agent
+    authority readings remain denied.
+11. Non-authorization notices remain present.
+
+Runtime decision must not decide runtime activation, code execution,
+package installation, package loading, package execution, deployment
+readiness, capability issuance, registry publication, distribution
+execution, trust assignment, source merge authorization, source repository
+state, or production readiness.
+
+Any decision reading that crosses the runtime consideration boundary fails
+closed.
+
+## Runtime Non-Activation Rule
+
+Runtime Decision does not activate runtime behavior by itself.
+
+Runtime Decision does not start a process, load a package, load a module,
+instantiate a plugin, mount a workspace, execute code, mint a capability
+token, publish a registry entry, assign trust, distribute artifacts, or
+deploy anything.
+
+Runtime Decision may only record bounded runtime authority consideration
+for later separately reviewed activation authority, if ever authorized.
+
+Until a later reviewed activation RFC or decision path exists, runtime
+activation remains denied.
+
+## Denied Runtime Readings
+
+This RFC denies runtime decision readings that imply:
+
+1. Runtime activation.
+2. General runtime authority.
+3. Code execution.
+4. Package installation.
+5. Package loading.
+6. Package execution.
+7. Package scheduling.
+8. Deployment behavior.
+9. Module loading.
+10. Plugin loading.
+11. Workspace runtime or real mounts.
+12. Capability token minting or capability issuance.
+13. Registry publication.
+14. Distribution execution.
+15. Trust assignment.
+16. Source acceptance or source merge authority.
+17. Semantic CLI execution or verdict authority.
+18. AI Runtime authority.
+19. Agent behavior.
+20. Kernel ABI expansion.
+21. Syscall expansion.
+22. Ring0 policy changes.
+23. Workflow-threshold, baseline, or dependency changes.
+
+Denied runtime readings remain denied even if they are associated with an
+accepted bounded implementation proposal.
+
+Denied-reading ambiguity fails closed.
+
+## Decision Input Set
+
+A decision input set is the exact set of records considered by one runtime
+decision.
+
+A decision input set must include:
+
+1. Exact runtime decision subject.
+2. Exact Implementation Acceptance Decision record.
+3. Exact implementation acceptance decision result.
+4. Exact accepted bounded implementation proposal.
+5. Exact Implementation Review record.
+6. Exact Implementation Slice record.
+7. Exact Slice identity.
+8. Exact bounded source scope.
+9. Exact reviewed implementation acceptance decision SHA.
+10. Exact bounded runtime authority consideration.
+11. Phase-19 runtime boundary references.
+12. Denied runtime readings.
+13. Non-authorization notice.
+
+One runtime decision evaluates one bounded runtime authority consideration
+for one accepted bounded implementation proposal from one exact
+Implementation Acceptance Decision record.
+
+Decision input presence is not runtime authority.
+
+Decision input completeness is not runtime activation.
+
+Decision input set must not silently include adjacent files, generated
+artifacts, dependency trees, build products, package outputs, runtime
+objects, deployment state, workspace state, process state, runtime handles,
+or capability tokens.
+
+## Exact-SHA Binding
+
+Runtime decision is exact-SHA bound.
+
+The conceptual decision chain is:
+
+```text
+Implementation Acceptance Decision Record
+  -> Accepted Bounded Implementation Proposal
+  -> Bounded Runtime Authority Consideration
+  -> Runtime Decision Record
+  -> later activation decision path, if ever authorized
+```
+
+Every arrow is a governance dependency. No arrow implies runtime
+activation, code execution, package installation, package loading, package
+execution, deployment, distribution, capability issuance, registry
+publication, trust assignment, source acceptance, or source merge
+authority.
+
+Exact-SHA binding may use the exact reviewed implementation acceptance
+decision SHA, exact Implementation Acceptance Decision record identifier,
+exact accepted bounded implementation proposal identifier, exact bounded
+runtime consideration identifier, exact runtime decision record
+identifier, and exact runtime decision result identifier.
+
+This RFC does not define canonical hash construction, digest algorithm,
+artifact digest format, package digest format, source merge mechanics,
+diff format, runtime identity, process identity, runtime handle format, or
+signature format.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped runtime decision binding fails closed.
+
+## Decision Evaluation Model
+
+Runtime decision evaluates whether an accepted bounded implementation
+proposal may receive a bounded runtime authority consideration governance
+result.
+
+Decision evaluation may compare:
+
+1. Implementation acceptance decision result against required `accepted`
+   result.
+2. Accepted proposal identity against the exact acceptance decision record.
+3. Implementation Review identity against the exact acceptance decision
+   record.
+4. Slice identity against the exact acceptance decision record.
+5. Bounded source scope against the exact Slice record.
+6. Bounded runtime consideration against Phase-19 runtime boundaries.
+7. Denied runtime readings against the proposed consideration.
+8. Non-authorization notices against governing RFCs.
+9. Relationship context against denied authority readings.
+
+Decision evaluation does not reconstruct Slice scope.
+
+Decision evaluation does not reinterpret Slice intent.
+
+Decision evaluation does not expand bounded source scope.
+
+Decision evaluation does not activate runtime behavior.
+
+Decision output records only a bounded runtime decision governance result
+until a later activation RFC or decision path defines separate activation
+authority, if ever authorized.
+
+## Decision Record
+
+A runtime decision record records the decision result for bounded runtime
+authority consideration.
+
+Allowed runtime decision results are:
+
+1. `bounded_consideration_recorded`
+2. `denied`
+3. `quarantined`
+
+No other runtime decision result is defined by this RFC.
+
+A runtime decision record must identify the exact runtime decision subject,
+exact Implementation Acceptance Decision record, exact implementation
+acceptance decision result, exact accepted bounded implementation
+proposal, exact bounded runtime authority consideration, exact Phase-19
+runtime boundary context, decision result, reason for decision, exact-SHA
+binding, denied runtime readings, non-authorization notice, and
+fail-closed handling for later ambiguity.
+
+Runtime decision records governance state only.
+
+Runtime decision record never activates runtime, executes code, installs
+packages, loads packages, executes packages, deploys artifacts, issues
+capabilities, publishes registry entries, assigns trust, accepts source,
+merges source, or authorizes distribution.
+
+## Runtime Decision Outcomes
+
+Runtime decision outcomes are governance outcomes only.
+
+This RFC defines:
+
+| Outcome | Meaning | Authority result |
+|---|---|---|
+| `bounded_consideration_recorded` | Bounded runtime authority consideration is recorded for the exact decision subject | No runtime activation |
+| `denied` | Bounded runtime authority consideration is denied for the exact decision subject | No deletion or revocation by itself |
+| `quarantined` | Runtime consideration or decision input is held for unresolved ambiguity, conflict, or safety concern | No authority |
+| `deferred` | Decision is delayed before a runtime decision result can be recorded | No runtime decision result |
+| `superseded` | Decision is replaced by a later exact reviewed decision | No inheritance |
+
+`bounded_consideration_recorded`, `denied`, and `quarantined` are runtime
+decision results.
+
+`deferred` and `superseded` are decision dispositions. They are not
+runtime decision results.
+
+Outcome presence must not be interpreted as runtime activation, code
+execution, source merge authority, trust assignment, registry publication,
+distribution authority, package execution, deployment authority, or
+capability issuance.
+
+## Explicit Separation
+
+Runtime decision concepts do not imply authority-bearing runtime
+outcomes.
+
+| Runtime decision concept | Is not |
+|---|---|
+| Runtime decision result | Runtime enabled |
+| Bounded consideration recorded | Runtime activated |
+| Accepted implementation proposal | Runtime enabled |
+| Runtime decision record | Runtime state |
+| Runtime decision record | Execution authority |
+| Runtime consideration | Package executable |
+| Runtime consideration | Capability issued |
+| Runtime consideration | Registry published |
+| Runtime consideration | Trust assigned |
+
+No concept in this table implies another by default.
+
+Unknown runtime, execution, source, issuance, publication, trust, or
+distribution readings fail closed.
+
+## Decision Disposition Handling
+
+Decision dispositions preserve audit history for denial, quarantine,
+deferral, and supersession.
+
+Denial records that bounded runtime authority consideration was not
+recorded for the exact decision subject. It does not delete history,
+revoke another record, transfer authority to a replacement, establish
+alias or supersession by itself, prove fault by itself, or block later
+resubmission by itself.
+
+Quarantine is the safe decision result for unresolved ambiguity, including
+runtime decision subject ambiguity, implementation acceptance decision
+record ambiguity, acceptance result ambiguity, accepted proposal
+ambiguity, bounded runtime consideration ambiguity, Phase-19 runtime
+boundary conflict, denied-reading concern, missing decision prerequisite,
+or incompatible interpretation across governing records.
+
+Deferral may record that later information is required before a runtime
+decision result can be made.
+
+Supersession may record that a later exact runtime decision replaces the
+current decision for decision purposes. Supersession inheritance is denied
+unless a later reviewed RFC defines exact narrower behavior.
+
+No disposition activates runtime, executes code, accepts source, merges
+source, assigns trust, publishes registry entries, authorizes
+distribution, issues capabilities, deploys artifacts, installs packages,
+loads packages, or executes packages.
+
+## Post-Decision Exact-SHA Verification
+
+Post-decision exact-SHA verification is a governance verification step
+after a runtime decision record has been recorded.
+
+The conceptual verification path is:
+
+```text
+implementation_acceptance_decision
+  -> runtime_decision
+  -> exact_runtime_decision_sha
+  -> post_runtime_decision_verification
+  -> later_activation_decision_input_if_authorized
+```
+
+Every arrow is a governance dependency. No arrow implies runtime
+activation, code execution, package execution, deployment, distribution,
+capability issuance, registry publication, trust assignment, source
+acceptance, or source merge authority.
+
+Post-decision verification may confirm the exact runtime decision record
+SHA, exact Implementation Acceptance Decision record, exact accepted
+bounded implementation proposal, exact bounded runtime authority
+consideration, expected non-authorization notices, expected governance
+check results, expected Phase-19 runtime boundary preservation, and no
+unexpected runtime or authority expansion.
+
+Post-decision PASS is not runtime activation.
+
+Post-decision PASS is not execution authority.
+
+Post-decision verification records exact-SHA verification only. It never
+records activation authority.
+
+## Relationship Boundaries
+
+Runtime decision may consume prior Phase-20 and Phase-19 governance
+records as decision context only.
+
+| Previous record | Accepted reading | Denied reading |
+|---|---|---|
+| `PHASE20_IMPLEMENTATION_ACCEPTANCE_DECISION.md` | Exact acceptance decision record and `accepted` result as decision prerequisite | Implementation accepted is not runtime enabled |
+| `PHASE20_IMPLEMENTATION_REVIEW.md` | Exact review record as context through acceptance decision | Review PASS is not runtime authority |
+| `PHASE20_IMPLEMENTATION_SLICE.md` | Exact Slice record, Slice Identity, and Bounded Source Scope as context | Slice scope is never reconstructed, expanded, or reinterpreted |
+| `PHASE20_IMPLEMENTATION_DECISION.md` | Eligible decision record as prerequisite context | Eligibility is not runtime authority |
+| `PHASE20_CAPABILITY_ACCEPTANCE_WORKFLOW.md` | Accepted workflow subject and acceptance decision record as context | Accepted workflow subject is not runtime enabled |
+| `PHASE20_CAPABILITY_EVIDENCE_MODEL.md` | Accepted evidence through acceptance workflow context | Accepted evidence is not runtime proof |
+| `PHASE20_REGISTRY_MODEL.md` and `PHASE20_REGISTRY_GOVERNANCE.md` | Registry context for subject consistency | Registry context is not publication, issuance, runtime activation, or runtime authority |
+| `PHASE20_TRUST_MODEL.md` | Trust context for decision context | Trust context is not trust assignment or runtime authority |
+| `PHASE20_DISTRIBUTION_POLICY.md` | Distribution policy context for decision context | Distribution eligibility is not distribution execution or runtime authority |
+| `PHASE19_RUNTIME_DECISION.md` and Phase-19 Runtime RFC set | Runtime boundary context and denied readings | Phase-20 Runtime Decision does not broaden or replace Phase-19 runtime authority |
+
+Runtime decision does not modify prior governance records.
+
+Runtime decision does not modify implementation acceptance decision
+records.
+
+Runtime decision does not modify review records.
+
+Runtime decision does not modify Slice scope.
+
+Runtime decision does not modify acceptance state.
+
+Runtime decision does not modify evidence records.
+
+Runtime decision does not modify Phase-19 runtime authority records.
+
+Ambiguous, stale, inherited, unaccepted, or differently scoped
+relationship material fails closed for runtime decision.
+
+## Later Activation Boundary
+
+Runtime decision is a prerequisite input for later runtime activation
+records only if a separate reviewed activation RFC or decision path is
+ever authorized.
+
+Runtime decision does not define runtime activation authority.
+
+A later runtime activation decision, if ever authorized, must define the
+exact activation subject, exact Runtime Decision record, exact bounded
+runtime consideration, exact accepted bounded implementation proposal,
+exact runtime behavior being activated, exact denied runtime behaviors,
+exact runtime boundary, package, loader, deployment, issuance,
+publication, trust, distribution, source, Semantic CLI, AI Runtime, agent,
+syscall, kernel ABI, and Ring0 denials, required activation review path,
+required post-activation verification, and non-authorization notice for
+anything outside scope.
+
+Until such a reviewed activation RFC or decision path exists, runtime
+activation remains denied.
+
+## Decision Validation Model
+
+Runtime decision validation is conceptual and fail-closed.
+
+Decision validation must never activate runtime behavior.
+
+Decision validation must never reconstruct Slice scope.
+
+Decision validation must never expand bounded source scope.
+
+Decision validation must never reinterpret Slice intent.
+
+Decision validation must never infer missing implementation acceptance
+material.
+
+Decision validation must never infer Phase-19 runtime authority.
+
+Runtime decision material is invalid for governance review when:
+
+1. Runtime decision subject is missing or ambiguous.
+2. Runtime decision identity is missing or ambiguous.
+3. Exact Implementation Acceptance Decision record is missing, stale,
+   ambiguous, inherited, or differently scoped.
+4. Reviewed implementation acceptance decision SHA is missing or
+   ambiguous.
+5. Implementation acceptance decision result is missing, ambiguous, or not
+   `accepted` for `bounded_consideration_recorded`.
+6. Accepted bounded implementation proposal is missing or ambiguous.
+7. Bounded runtime authority consideration is missing or ambiguous.
+8. Phase-19 runtime boundary context is missing, ambiguous, weakened, or
+   reinterpreted.
+9. Decision input set is missing or ambiguous.
+10. Decision validation activates runtime behavior.
+11. Decision validation reconstructs Slice scope.
+12. Decision validation expands bounded source scope.
+13. Decision validation reinterprets Slice intent.
+14. Decision validation infers missing implementation acceptance material.
+15. Decision validation infers Phase-19 runtime authority.
+16. Accepted implementation proposal is treated as runtime enabled.
+17. Runtime decision result is treated as runtime activation.
+18. Runtime decision result is treated as package execution authority.
+19. Runtime decision result is treated as registry publication.
+20. Runtime decision result is treated as trust assignment.
+21. Runtime decision result is treated as capability issuance.
+22. Runtime decision material depends on runtime-observed state.
+23. Runtime decision material relies on alias or supersession without
+    accepted rules.
+24. Runtime decision material implies source merge authority.
+25. Runtime decision material implies general runtime authority.
+
+Validation failure grants no authority. It requires correction, denial,
+deferral, quarantine, supersession, dispute recording, or a later reviewed
+decision path.
+
+Runtime decision validation is not runtime activation.
+
+Validation produces only a validation result.
+
+Validation never produces runtime activation, execution authority, package
+authority, deployment authority, source authority, merge authority, trust
+assignment, registry publication, distribution authority, or capability
+issuance.
+
+## Runtime Decision Invariants
+
+Every later Phase-20 RFC must preserve these runtime decision invariants:
+
+1. Runtime Decision consumes the exact Implementation Acceptance Decision
+   record.
+2. Runtime Decision requires exact implementation acceptance result
+   binding.
+3. Runtime Decision may record bounded runtime authority consideration
+   only after implementation acceptance result `accepted`.
+4. Implementation acceptance result `accepted` is necessary but not
+   sufficient for runtime decision.
+5. Accepted implementation proposal is not runtime enabled.
+6. Runtime Decision does not activate runtime behavior by itself.
+7. Runtime Decision is not general runtime authority.
+8. Runtime Decision does not reconstruct Slice scope.
+9. Runtime Decision does not expand bounded source scope.
+10. Runtime Decision does not reinterpret Slice intent.
+11. Runtime Decision remains subordinate to Phase-19 runtime authority
+    records.
+12. Runtime Decision does not broaden Phase-19 runtime authority.
+13. Runtime Decision does not grant package installation.
+14. Runtime Decision does not grant package loading.
+15. Runtime Decision does not grant package execution.
+16. Runtime Decision does not grant deployment authority.
+17. Runtime Decision does not grant registry publication.
+18. Runtime Decision does not grant trust assignment.
+19. Runtime Decision does not grant distribution authority.
+20. Runtime Decision does not grant capability issuance.
+21. Runtime Decision does not grant source merge authority.
+22. One runtime decision evaluates one bounded runtime authority
+    consideration for one accepted bounded implementation proposal.
+23. Runtime decision record is not runtime state.
+24. Runtime decision record is not execution authority.
+25. Runtime decision does not modify prior governance records.
+26. Later activation requires separate governance review, if ever
+    authorized.
+27. Post-decision PASS is not runtime activation.
+28. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Later RFC Dependencies
+
+The runtime decision model is a prerequisite for later Phase-20 runtime
+activation paths only if separate activation authority is ever reviewed
+and authorized.
+
+| Later record | Runtime decision relationship |
+|---|---|
+| Later reviewed runtime activation RFC or decision path, if ever authorized | May consider activation only after separate reviewed activation authority and exact Runtime Decision binding. |
+
+Later RFCs may narrow runtime decision use. They must not broaden this
+decision model into runtime activation, general runtime authority, package
+installation, package loading, package execution, deployment, trust
+assignment, registry publication, distribution authority, capability
+issuance, source merge authority, Semantic CLI authority, AI Runtime
+authority, agent authority, syscall expansion, kernel ABI expansion, or
+Ring0 authority without a separate reviewed decision.
+
+Runtime Decision is the Phase-20 RFC in this chain that records bounded
+runtime authority consideration for accepted bounded implementation
+proposals.
+
+Runtime Decision does not activate runtime behavior.
+
+The current Phase-20 dependency chain is:
+
+```text
+Capability Model
+  -> Capability Identity
+  -> Capability Manifest Schema
+  -> Capability Lifecycle
+  -> Registry Model
+  -> Registry Governance
+  -> Trust Model
+  -> Distribution Policy
+  -> Capability Evidence Model
+  -> Capability Acceptance Workflow
+  -> Implementation Decision
+  -> Implementation Slice
+  -> Implementation Review
+  -> Implementation Acceptance Decision
+  -> Runtime Decision
+```
+
+Every arrow means a governance dependency. It does not imply source merge
+authority, publication, distribution, installation, loading, execution,
+issuance, deployment, runtime activation, or general runtime authority.
+
+Every dependency is explicit.
+
+No dependency is implied.
+
+Each RFC defines only its own layer. No RFC produces the authority of the
+next layer.
+
+## Explicit Non-Authorization
+
+This runtime decision RFC does not authorize:
+
+1. Runtime activation.
+2. General runtime authority.
+3. Runtime implementation.
+4. Code execution.
+5. Package installation, loading, execution, scheduling, or publication.
+6. Deployment behavior.
+7. Module loading.
+8. Workspace creation, workspace runtime, or real mounts.
+9. Plugin host, plugin loading, or plugin instantiation.
+10. Capability token minting or capability issuance.
+11. Trust assignment.
+12. Trust issuer authority.
+13. Registry authority.
+14. Registry publication.
+15. Publication authority.
+16. Distribution authority.
+17. Distribution execution.
+18. Source acceptance or source merge authority.
+19. Source repository authority.
+20. Semantic CLI execution or verdict authority.
+21. AI Runtime authority.
+22. Agent behavior.
+23. New syscalls.
+24. Kernel ABI expansion.
+25. Workflow-threshold, baseline, dependency, or Ring0 policy changes.
+26. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-20 RFC
+**Architecture status:** Draft RFC / pending architectural review
+**Authority notice:** This signature identifies the architectural authorship
+of this RFC. It grants no runtime activation authority, general runtime
+authority, implementation authority, implementation approval authority,
+source merge authority, trust authority, evidence authority, acceptance
+authority, proof authority, execution authority, constitutional authority,
+registry authority, distribution authority, publication authority,
+capability issuance authority, package authority, deployment authority,
+module authority, plugin authority, Semantic CLI authority, AI Runtime
+authority, agent authority, or Ring0 authority.
+
+## Non-Goals
+
+This document does not define or authorize:
+
+1. Runtime activation or general runtime authority.
+2. Runtime implementation.
+3. Code execution.
+4. Package format, repository, installation, loading, or execution.
+5. Deployment behavior.
+6. Artifact storage or binary format.
+7. Module loading.
+8. Workspace creation, workspace runtime, or real mounts.
+9. Plugin host, plugin loading, or plugin instantiation.
+10. Capability token minting or capability issuance.
+11. Trust assignment or trust issuer authority.
+12. Registry authority or registry publication.
+13. Publication workflow or publication approval.
+14. Distribution authority or distribution execution.
+15. Source acceptance or source merge authority.
+16. Source repository authority.
+17. Repository branch protection.
+18. Proof verification, signature verification, or signature acceptance.
+19. Semantic CLI execution or verdict authority.
+20. AI Runtime authority.
+21. Agent behavior.
+22. New syscalls.
+23. Kernel ABI expansion.
+24. Workflow-threshold, baseline, dependency, or Ring0 policy changes.


### PR DESCRIPTION
This PR adds the Phase-20 runtime decision RFC.

The RFC defines a bounded runtime decision model for evaluating runtime authority consideration after an accepted implementation proposal.

It is bound to the exact PHASE20_IMPLEMENTATION_ACCEPTANCE_DECISION.md record published at:
2f82e6d3b74f29cbd25cea5b3567462172a9a1b9

It preserves:
- exact Implementation Acceptance Decision binding
- Phase-19 runtime authority subordination
- no runtime activation
- no general runtime authority
- no code execution
- no package installation/loading/execution
- no deployment
- no capability issuance
- no registry publication
- no trust assignment
- no source merge authority
- no Semantic CLI / AI Runtime / agent authority

This PR changes only PHASE20_RUNTIME_DECISION.md.