### PR TITLE
Phase-20 runtime decision review RFC

### DIFF
--- a/PHASE20_RUNTIME_DECISION_REVIEW.md
+++ b/PHASE20_RUNTIME_DECISION_REVIEW.md
@@ -1,0 +1,939 @@
+# Phase-20 Runtime Decision Review
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE20_POINTER_TRANSITION_DECISION.md`,
+`PHASE20_GOVERNANCE_OVERVIEW.md`,
+`PHASE20_CAPABILITY_MODEL.md`,
+`PHASE20_CAPABILITY_IDENTITY.md`,
+`PHASE20_CAPABILITY_MANIFEST_SCHEMA.md`,
+`PHASE20_CAPABILITY_LIFECYCLE.md`,
+`PHASE20_REGISTRY_MODEL.md`,
+`PHASE20_REGISTRY_GOVERNANCE.md`,
+`PHASE20_TRUST_MODEL.md`,
+`PHASE20_DISTRIBUTION_POLICY.md`,
+`PHASE20_CAPABILITY_EVIDENCE_MODEL.md`,
+`PHASE20_CAPABILITY_ACCEPTANCE_WORKFLOW.md`,
+`PHASE20_IMPLEMENTATION_DECISION.md`,
+`PHASE20_IMPLEMENTATION_SLICE.md`,
+`PHASE20_IMPLEMENTATION_REVIEW.md`,
+`PHASE20_IMPLEMENTATION_ACCEPTANCE_DECISION.md`, and
+`PHASE20_RUNTIME_DECISION.md`. In case of conflict, those documents
+prevail unless this runtime decision review RFC is the narrower Phase-20
+runtime decision review record for the exact planning scope identified
+below.
+
+**Status:** PHASE-20 RUNTIME DECISION REVIEW RFC / RUNTIME DECISION
+CONFORMANCE REVIEW MODEL ONLY / NO RUNTIME ACCEPTANCE / NO RUNTIME
+ACTIVATION / NO EXECUTION AUTHORITY / NO RUNTIME STATE / NO GENERAL
+RUNTIME AUTHORITY / NO PACKAGE AUTHORITY / NO PACKAGE INSTALLATION / NO
+PACKAGE LOADING / NO PACKAGE EXECUTION / NO DEPLOYMENT / NO CAPABILITY
+ISSUANCE / NO TRUST ASSIGNMENT / NO REGISTRY PUBLICATION / NO
+DISTRIBUTION AUTHORITY / NO SOURCE MERGE AUTHORITY / NO SOURCE ACCEPTANCE
+**Runtime decision review date:** 2026-06-30
+**Runtime decision review id:** `ayken.phase20.runtime_decision_review.v1`
+**Runtime decision review base main SHA:** `0ccbcf98e86937f6b89697c5cf0e867bfad07098`
+**Reviewed runtime decision SHA:** `0ccbcf98e86937f6b89697c5cf0e867bfad07098`
+**Current phase pointer:** `CURRENT_PHASE=20`
+**Authority boundary:** Runtime decision conformance review model only;
+not runtime acceptance, not runtime activation, not execution authority,
+not runtime state, not general runtime authority, not package authority,
+not package installation, not package loading, not package execution, not
+deployment, not source acceptance, not source merge authority, not source
+repository authority, not module loading, not workspace runtime, not
+plugin loading, not capability token minting, not capability issuance,
+not trust assignment, not trust issuer authority, not registry authority,
+not registry publication, not publication authority, not distribution
+authority, not distribution execution, not Semantic CLI authority, not AI
+Runtime authority, not agent authority, not syscall expansion, not kernel
+ABI expansion, not workflow-threshold, baseline, dependency, or Ring0
+authority.
+
+## Purpose
+
+`PHASE20_RUNTIME_DECISION_REVIEW.md` defines how a bounded runtime
+authority consideration proposal is reviewed for conformance to the exact
+`PHASE20_RUNTIME_DECISION.md` record.
+
+It answers one question:
+
+```text
+Does a later bounded runtime authority consideration proposal conform to
+the exact Runtime Decision record?
+```
+
+It does not answer:
+
+```text
+How is runtime accepted?
+How is runtime activated?
+How is code executed?
+How is a package installed, loaded, executed, deployed, or distributed?
+How is execution authority granted?
+How is a capability issued?
+How is trust assigned?
+How is a registry entry published?
+```
+
+Those questions belong to later reviewed RFCs or decision paths, if ever
+authorized.
+
+## Core Rule
+
+```text
+runtime decision review != runtime acceptance
+runtime decision review != runtime activation
+runtime decision review != execution authority
+runtime decision review != runtime state
+runtime decision review != general runtime authority
+runtime decision review != package execution
+runtime decision review != package loading
+runtime decision review != deployment
+runtime decision review != capability issuance
+runtime decision review != registry publication
+runtime decision review != trust assignment
+review result != runtime accepted
+review result != runtime enabled
+review result != execution authority
+review evaluates conformance to exact Runtime Decision record
+review never reconstructs Runtime Decision scope
+review never broadens Phase-19 runtime authority
+review never expands Slice scope
+conforms != runtime accepted
+conforms != runtime activation
+conforms != execution authority
+```
+
+Runtime Decision Review evaluates conformance to the exact Runtime
+Decision record.
+
+Runtime Decision Review never activates runtime behavior.
+
+Runtime Decision Review never grants execution authority.
+
+Runtime Decision Review never broadens Phase-19 runtime authority.
+
+Runtime Decision Review never expands Slice scope.
+
+Runtime Decision Review does not grant package execution, package
+loading, deployment, registry publication, trust assignment, distribution
+authority, source merge authority, or capability issuance by implication.
+
+Unknown authority readings fail closed.
+
+## Runtime Decision Review Mission
+
+The mission of the Phase-20 runtime decision review model is to define an
+explicit, auditable conformance review path for bounded runtime authority
+consideration proposals against exact Runtime Decision records.
+
+Runtime decision review exists so later RFCs can reason about:
+
+1. Runtime decision review subjects.
+2. Exact Runtime Decision record prerequisites.
+3. Bounded runtime authority consideration proposal inputs.
+4. Runtime decision review identity.
+5. Review input sets.
+6. Conformance boundaries.
+7. Review findings.
+8. Review results and dispositions.
+9. Phase-19 runtime authority preservation.
+10. Later runtime acceptance decision prerequisites.
+
+The runtime decision review model itself grants no runtime acceptance,
+runtime activation, execution authority, runtime state, general runtime
+authority, package authority, deployment, distribution, trust, registry,
+source merge, or capability issuance authority.
+
+Each later use requires its own reviewed RFC or decision path.
+
+## Runtime Decision Review Definition
+
+Runtime decision review is a governance review record that evaluates
+whether a bounded runtime authority consideration proposal conforms to
+the exact Runtime Decision record.
+
+A runtime decision review may describe:
+
+1. The exact runtime decision review subject.
+2. The exact Runtime Decision record.
+3. The Runtime Decision subject and identity.
+4. The bounded runtime authority consideration proposal.
+5. The exact accepted bounded implementation proposal context.
+6. The exact Implementation Acceptance Decision record.
+7. The exact Implementation Review and Slice context.
+8. Review input records.
+9. Conformance findings.
+10. Review result.
+11. Later runtime acceptance decision dependency.
+12. Non-authorization notice.
+
+A runtime decision review is not runtime acceptance, runtime activation,
+execution authority, runtime state, general runtime authority, package
+artifact, package loading, package execution, deployment unit,
+capability issuance, registry publication, distribution authority, trust
+assignment, source acceptance, source merge authority, or Semantic CLI,
+AI Runtime, or agent authority.
+
+## Runtime Decision Review Scope
+
+This RFC defines only the runtime decision conformance review model.
+
+It does not define runtime acceptance, runtime activation, runtime
+implementation, code execution, package installation, package loading,
+package execution, module loading, plugin loading, workspace runtime,
+deployment behavior, registry publication, distribution execution, trust
+assignment, capability issuance, source modification procedure, source
+acceptance, or source merge procedure.
+
+Runtime decision review is a governance review layer. It is not a runtime
+service, execution engine, package manager, installer, loader,
+deployment service, registry publisher, distribution engine, trust
+issuer, capability issuer, source merge engine, or source repository
+authority.
+
+Any acceptance-specific, activation-specific, execution-specific,
+package-specific, loader-specific, deployment-specific,
+runtime-specific, publication-specific, distribution-specific,
+trust-specific, capability-issuance-specific, or source-merge-specific
+interpretation fails closed until later reviewed RFCs define exact
+behavior.
+
+## Runtime Decision Review Subject
+
+A runtime decision review subject is the exact bounded runtime authority
+consideration proposal being reviewed against one exact Runtime Decision
+record.
+
+A runtime decision review subject must reference:
+
+1. Exact Runtime Decision record.
+2. Exact Runtime Decision subject.
+3. Exact Runtime Decision identity.
+4. Exact bounded runtime authority consideration from the Runtime
+   Decision record.
+5. Exact bounded runtime authority consideration proposal identifier.
+6. Exact Implementation Acceptance Decision record.
+7. Exact accepted bounded implementation proposal.
+8. Exact Implementation Review record.
+9. Exact Implementation Slice record.
+10. Exact reviewed Runtime Decision SHA.
+11. Phase-19 runtime authority records used as boundary context.
+12. Governing RFCs.
+13. Non-authorization notice.
+
+Runtime decision review subject is not runtime acceptance.
+
+Runtime decision review subject is not runtime activation, execution
+authority, runtime state, package ownership, package execution, source
+repository ownership, source merge authority, module ownership, plugin
+ownership, registry publication, deployment target, process, workspace
+state, runtime handle, or capability token.
+
+Changing the Runtime Decision record, Runtime Decision subject, Runtime
+Decision identity, bounded runtime authority consideration, bounded
+runtime authority consideration proposal, accepted bounded
+implementation proposal, reviewed Runtime Decision SHA, Phase-19 boundary
+context, or subject-defining context creates a different runtime decision
+review subject unless a later reviewed RFC defines exact narrower
+behavior.
+
+## Exact Runtime Decision Record Requirement
+
+Runtime decision review requires an exact Runtime Decision record.
+
+The reviewed runtime decision record for this RFC is
+`PHASE20_RUNTIME_DECISION.md` at exact main SHA
+`0ccbcf98e86937f6b89697c5cf0e867bfad07098`.
+
+Runtime decision review must consume the exact reviewed Runtime Decision
+record.
+
+Runtime decision review must never reconstruct Runtime Decision scope.
+
+Runtime decision review must never reinterpret Runtime Decision intent.
+
+Runtime decision review must never broaden Phase-19 runtime authority.
+
+Runtime decision review must never expand Slice scope.
+
+Runtime decision review must never infer runtime acceptance, runtime
+activation, or execution authority from the Runtime Decision record.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped Runtime Decision binding fails closed.
+
+## Runtime Decision Review Identity
+
+Runtime decision review identity distinguishes one runtime decision review
+record from another.
+
+Runtime decision review identity is conceptually composed of:
+
+```text
+(runtime_decision_review_domain, runtime_decision_review_subject,
+ runtime_decision_record, runtime_decision_identity,
+ bounded_runtime_authority_consideration_proposal, review_binding)
+```
+
+This tuple is conceptual. It is not a source path syntax, source
+ownership claim, package name, module name, crate name, repository
+branch, database schema, command, token, runtime handle, process handle,
+loader key, execution key, merge key, deployment key, or capability key.
+
+Runtime decision review identity remains stable for the lifetime of that
+review record. Changing identity-defining review fields creates a
+different runtime decision review record unless a later reviewed RFC
+defines exact narrower behavior.
+
+Runtime decision review identity does not imply runtime acceptance,
+runtime activation, execution authority, package authority, deployment
+authority, registry publication, distribution authority, trust
+assignment, source merge authority, or capability issuance.
+
+## Bounded Runtime Authority Consideration Proposal Requirement
+
+A bounded runtime authority consideration proposal is the exact proposal
+material reviewed for conformance to the Runtime Decision record.
+
+A bounded runtime authority consideration proposal may identify:
+
+1. Exact bounded runtime authority consideration being proposed for
+   review.
+2. Exact Runtime Decision record reference.
+3. Exact accepted bounded implementation proposal context.
+4. Exact Phase-19 runtime boundary references.
+5. Denied runtime readings.
+6. Conformance claims.
+7. Review evidence references.
+8. Non-authorization notice.
+
+A bounded runtime authority consideration proposal is not runtime
+acceptance.
+
+A bounded runtime authority consideration proposal is not runtime
+activation, execution authority, runtime state, package installation,
+package loading, package execution, module loading, plugin loading,
+workspace runtime, deployment, registry publication, trust assignment,
+distribution execution, source merge authority, or capability issuance.
+
+Proposal presence is not review result `conforms`.
+
+Proposal completeness is not runtime acceptance.
+
+Proposal review is not runtime activation.
+
+## Review Input Set
+
+A review input set is the exact set of records considered by one runtime
+decision review.
+
+A review input set must include:
+
+1. Exact runtime decision review subject.
+2. Exact Runtime Decision record.
+3. Exact Runtime Decision identity.
+4. Exact bounded runtime authority consideration from the Runtime
+   Decision record.
+5. Exact bounded runtime authority consideration proposal identifier.
+6. Exact Implementation Acceptance Decision record.
+7. Exact accepted bounded implementation proposal.
+8. Exact Implementation Review record.
+9. Exact Implementation Slice record.
+10. Exact reviewed Runtime Decision SHA.
+11. Phase-19 runtime authority boundary references.
+12. Review evidence references.
+13. Non-authorization notice.
+
+One runtime decision review evaluates one bounded runtime authority
+consideration proposal against one exact Runtime Decision record.
+
+Review input presence is not runtime decision review completion.
+
+Review input completeness is not runtime acceptance.
+
+Review input set must not silently include adjacent files, generated
+artifacts, dependency trees, build products, package outputs, runtime
+objects, deployment state, workspace state, process state, runtime
+handles, or capability tokens.
+
+## Exact-SHA Binding
+
+Runtime decision review is exact-SHA bound.
+
+The conceptual review chain is:
+
+```text
+Runtime Decision Record
+  -> Bounded Runtime Authority Consideration
+  -> Bounded Runtime Authority Consideration Proposal
+  -> Runtime Decision Review Record
+  -> later Runtime Acceptance Decision
+```
+
+Every arrow is a governance dependency. No arrow implies runtime
+acceptance, runtime activation, code execution, package installation,
+package loading, package execution, deployment, distribution, capability
+issuance, registry publication, trust assignment, source acceptance, or
+source merge authority.
+
+Exact-SHA binding may use:
+
+1. Exact reviewed Runtime Decision SHA.
+2. Exact Runtime Decision record identifier.
+3. Exact Runtime Decision identity.
+4. Exact bounded runtime authority consideration identifier.
+5. Exact bounded runtime authority consideration proposal identifier.
+6. Exact runtime decision review record identifier.
+7. Exact review result identifier.
+
+This RFC does not define canonical hash construction, digest algorithm,
+artifact digest format, package digest format, source merge mechanics,
+diff format, runtime identity, process identity, runtime handle format,
+or signature format.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped review binding fails closed.
+
+## Conformance Boundary
+
+Conformance boundary is the limit of what runtime decision review may
+evaluate.
+
+Runtime decision review may evaluate whether the bounded runtime
+authority consideration proposal:
+
+1. Is bound to the exact Runtime Decision record.
+2. Preserves the exact Runtime Decision subject and identity.
+3. Preserves the bounded runtime authority consideration recorded by the
+   Runtime Decision.
+4. Preserves the accepted bounded implementation proposal context.
+5. Preserves the exact Implementation Acceptance Decision record
+   binding.
+6. Preserves the exact Implementation Review and Slice context.
+7. Avoids Runtime Decision scope reconstruction.
+8. Avoids Runtime Decision intent reinterpretation.
+9. Avoids Slice scope expansion.
+10. Preserves Phase-19 runtime authority boundaries.
+11. Avoids runtime acceptance, runtime activation, execution authority,
+    runtime state, package, deployment, issuance, publication, trust,
+    distribution, source merge, Semantic CLI, AI Runtime, or agent
+    authority readings.
+
+Runtime decision review must not evaluate or decide:
+
+1. Runtime acceptance.
+2. Runtime activation.
+3. Execution authority.
+4. Runtime state.
+5. Code execution.
+6. Package installation, loading, execution, scheduling, or publication.
+7. Deployment readiness.
+8. Capability issuance.
+9. Registry publication.
+10. Distribution execution.
+11. Trust assignment.
+12. Source merge authorization.
+13. Source repository state.
+14. Production readiness.
+
+Any review reading that crosses the conformance boundary fails closed.
+
+## Review Evaluation Model
+
+Runtime decision review evaluates conformance to the exact Runtime
+Decision record.
+
+Review evaluation may compare:
+
+1. Proposal binding against the exact Runtime Decision record.
+2. Proposal scope against the bounded runtime authority consideration.
+3. Proposal claims against denied runtime readings.
+4. Proposal context against the exact Implementation Acceptance Decision
+   record.
+5. Accepted bounded implementation proposal identity against the Runtime
+   Decision record.
+6. Runtime Decision references against exact-SHA binding.
+7. Phase-19 runtime boundary claims against Phase-19 runtime authority
+   records.
+8. Proposal evidence against the review input set.
+9. Proposal non-authorization notices against governing RFCs.
+10. Relationship context against denied authority readings.
+
+Review evaluation does not reconstruct Runtime Decision scope.
+
+Review evaluation does not reinterpret Runtime Decision intent.
+
+Review evaluation does not broaden Phase-19 runtime authority.
+
+Review evaluation does not expand Slice scope.
+
+Review evaluation does not activate runtime behavior.
+
+Review evaluation does not grant execution authority.
+
+Review output records only a runtime decision review governance result
+until a later Runtime Acceptance Decision records a separate governance
+result, if ever authorized.
+
+## Reviewer Finding
+
+A reviewer finding is a governance review record produced during runtime
+decision review.
+
+A reviewer finding may include:
+
+1. Reviewed bounded runtime authority consideration proposal reference.
+2. Exact Runtime Decision record reference.
+3. Exact Runtime Decision identity reference.
+4. Exact bounded runtime authority consideration reference.
+5. Phase-19 runtime boundary preservation notes.
+6. Conformance summary.
+7. Missing material notes.
+8. Ambiguity or conflict notes.
+9. Recommended review result.
+10. Non-authorization notice.
+
+A reviewer finding does not decide runtime acceptance.
+
+Reviewer finding presence must not be interpreted as runtime acceptance,
+runtime activation, execution authority, runtime state, source
+acceptance, source merge authority, trust assignment, publication
+authority, distribution authority, capability issuance, package
+execution, deployment authority, or general runtime authority.
+
+## Review Results
+
+Runtime decision review results are governance review results only.
+
+This RFC defines:
+
+| Result | Meaning | Authority result |
+|---|---|---|
+| `conforms` | Proposal appears to conform to the exact Runtime Decision record | No runtime acceptance |
+| `does_not_conform` | Proposal does not conform to the exact Runtime Decision record | No deletion or revocation by itself |
+| `quarantined` | Proposal is held due to unresolved ambiguity, conflict, or safety concern | No authority |
+| `deferred` | Review is delayed before a conformance result can be recorded | No conformance result |
+| `superseded` | Review is replaced by a later exact reviewed workflow | No inheritance |
+
+`conforms`, `does_not_conform`, and `quarantined` are runtime decision
+review results.
+
+`deferred` and `superseded` are review dispositions. They are not runtime
+decision review results.
+
+`conforms` is not runtime accepted.
+
+`conforms` is not runtime activation.
+
+`conforms` is not execution authority.
+
+Result presence must not be interpreted as runtime acceptance, runtime
+activation, execution authority, runtime state, source merge authority,
+trust assignment, registry publication, distribution authority, package
+execution, deployment authority, general runtime authority, or capability
+issuance.
+
+## Explicit Separation
+
+Runtime decision review concepts do not imply authority-bearing runtime
+outcomes.
+
+| Runtime decision review concept | Is not |
+|---|---|
+| Review result `conforms` | Runtime accepted |
+| Review result `conforms` | Runtime activated |
+| Review result `conforms` | Execution authority |
+| Review finding | Runtime acceptance decision |
+| Proposal conforms | Runtime enabled |
+| Proposal reviewed | Package executable |
+| Review completed | Runtime state |
+| Review evidence | Runtime authority |
+| Review record | Runtime handle |
+
+No concept in this table implies another by default.
+
+Unknown runtime, execution, source, issuance, publication, trust, or
+distribution readings fail closed.
+
+## Review Disposition Handling
+
+Review dispositions preserve audit history for non-conformance,
+quarantine, deferral, and supersession.
+
+Non-conformance records that a bounded runtime authority consideration
+proposal did not conform to the exact Runtime Decision record. It does
+not delete history, revoke another record, transfer authority to a
+replacement, establish alias or supersession by itself, prove fault by
+itself, or block later resubmission by itself.
+
+Quarantine is the safe review result for unresolved ambiguity, including
+review subject ambiguity, Runtime Decision record ambiguity, Runtime
+Decision identity ambiguity, bounded runtime authority consideration
+ambiguity, bounded runtime authority consideration proposal ambiguity,
+Phase-19 runtime boundary conflict, denied-reading concern, missing
+review prerequisite, or incompatible interpretation across governing
+records.
+
+Deferral may record that later information is required before a
+conformance review result can be made.
+
+Supersession may record that a later exact runtime decision review
+replaces the current review for review purposes. Supersession inheritance
+is denied unless a later reviewed RFC defines exact narrower behavior.
+
+No disposition accepts runtime, activates runtime, grants execution
+authority, defines runtime state, accepts source, merges source, assigns
+trust, publishes registry entries, authorizes distribution, issues
+capabilities, deploys artifacts, installs packages, loads packages, or
+executes packages.
+
+## Phase-19 Runtime Authority Relationship
+
+Phase-20 Runtime Decision Review consumes Phase-20 Runtime Decision
+context and remains subordinate to Phase-19 runtime authority records.
+
+Phase-19 runtime records may be read as boundary context for:
+
+1. Runtime MVP planning boundaries.
+2. Runtime evidence expectations.
+3. Runtime non-goals and denials.
+4. Platform runtime constitutional constraints.
+5. Userspace-only runtime constraints.
+6. Frozen syscall and kernel ABI boundaries.
+7. Denied package, module, workspace, plugin, trust, capability, AI
+   Runtime, Semantic CLI, and agent authority readings.
+
+Phase-20 Runtime Decision Review must not broaden, replace, supersede,
+weaken, or reinterpret Phase-19 runtime authority records.
+
+Phase-20 Runtime Decision Review must not use a review result to infer
+Phase-19 runtime authority.
+
+Any Phase-20 runtime decision review reading that conflicts with
+Phase-19 runtime authority records fails closed.
+
+## Relationship Boundaries
+
+Runtime decision review may consume prior Phase-20 and Phase-19
+governance records as review context only.
+
+| Previous record | Accepted reading | Denied reading |
+|---|---|---|
+| `PHASE20_RUNTIME_DECISION.md` | Exact Runtime Decision record, Runtime Decision Subject, Runtime Decision Identity, and bounded runtime authority consideration as conformance baseline | Runtime Decision scope is never reconstructed, expanded, or reinterpreted |
+| `PHASE20_IMPLEMENTATION_ACCEPTANCE_DECISION.md` | Exact acceptance decision record and `accepted` result as context through Runtime Decision | Implementation accepted is not runtime enabled |
+| `PHASE20_IMPLEMENTATION_REVIEW.md` | Exact review record as context through acceptance decision | Review result is not runtime authority |
+| `PHASE20_IMPLEMENTATION_SLICE.md` | Exact Slice record, Slice Identity, and Bounded Source Scope as context | Slice scope is never reconstructed, expanded, or reinterpreted |
+| `PHASE20_IMPLEMENTATION_DECISION.md` | Eligible decision record as prerequisite context | Eligibility is not runtime authority |
+| `PHASE20_CAPABILITY_ACCEPTANCE_WORKFLOW.md` | Accepted workflow subject and acceptance decision record as context | Accepted workflow subject is not runtime enabled |
+| `PHASE20_CAPABILITY_EVIDENCE_MODEL.md` | Accepted evidence through acceptance workflow context | Accepted evidence is not runtime proof |
+| `PHASE20_REGISTRY_MODEL.md` and `PHASE20_REGISTRY_GOVERNANCE.md` | Registry context for subject consistency | Registry context is not publication, issuance, runtime activation, or runtime authority |
+| `PHASE20_TRUST_MODEL.md` | Trust context for review context | Trust context is not trust assignment or runtime authority |
+| `PHASE20_DISTRIBUTION_POLICY.md` | Distribution policy context for review context | Distribution eligibility is not distribution execution or runtime authority |
+| `PHASE19_RUNTIME_DECISION.md` and Phase-19 Runtime RFC set | Runtime boundary context and denied readings | Runtime Decision Review does not broaden or replace Phase-19 runtime authority |
+
+Runtime decision review does not modify prior governance records.
+
+Runtime decision review does not modify Runtime Decision records.
+
+Runtime decision review does not modify implementation acceptance
+decision records.
+
+Runtime decision review does not modify review records.
+
+Runtime decision review does not modify Slice scope.
+
+Runtime decision review does not modify acceptance state.
+
+Runtime decision review does not modify evidence records.
+
+Runtime decision review does not modify Phase-19 runtime authority
+records.
+
+Ambiguous, stale, inherited, unaccepted, or differently scoped
+relationship material fails closed for runtime decision review.
+
+## Runtime Acceptance Decision Boundary
+
+Runtime decision review is a prerequisite input for later Runtime
+Acceptance Decision records, if such records are ever reviewed and
+authorized.
+
+Runtime decision review does not define runtime acceptance decision
+authority.
+
+A later Runtime Acceptance Decision, if ever authorized, must define:
+
+1. Exact runtime acceptance decision subject.
+2. Exact Runtime Decision Review record.
+3. Exact review result.
+4. Exact bounded runtime authority consideration proposal.
+5. Exact Runtime Decision record.
+6. Exact accepted and denied authority readings.
+7. Required post-review verification.
+8. Runtime activation boundary.
+9. Phase-19 runtime authority preservation requirement.
+10. Non-authorization notice for anything outside scope.
+
+Until such a reviewed Runtime Acceptance Decision exists, runtime
+acceptance authority remains denied.
+
+Runtime acceptance is not runtime activation.
+
+Runtime acceptance is not execution authority.
+
+## Review Validation Model
+
+Runtime decision review validation is conceptual and fail-closed.
+
+Review validation must never reconstruct Runtime Decision scope.
+
+Review validation must never reinterpret Runtime Decision intent.
+
+Review validation must never broaden Phase-19 runtime authority.
+
+Review validation must never expand Slice scope.
+
+Review validation must never activate runtime behavior.
+
+Review validation must never grant execution authority.
+
+Runtime decision review material is invalid for governance review when:
+
+1. Runtime decision review subject is missing or ambiguous.
+2. Runtime decision review identity is missing or ambiguous.
+3. Exact Runtime Decision record is missing, stale, ambiguous, inherited,
+   or differently scoped.
+4. Reviewed Runtime Decision SHA is missing or ambiguous.
+5. Bounded runtime authority consideration proposal is missing or
+   ambiguous.
+6. Review input set is missing or ambiguous.
+7. Runtime Decision scope is reconstructed.
+8. Runtime Decision intent is reinterpreted.
+9. Phase-19 runtime authority is broadened, weakened, replaced,
+   superseded, or reinterpreted.
+10. Slice scope is expanded.
+11. Proposal material implies runtime acceptance.
+12. Proposal material implies runtime activation.
+13. Proposal material implies execution authority.
+14. Proposal material implies runtime state.
+15. Review result is treated as runtime acceptance decision.
+16. Review result is treated as runtime activation.
+17. Review result is treated as package execution authority.
+18. Review result is treated as registry publication.
+19. Review result is treated as trust assignment.
+20. Review result is treated as capability issuance.
+21. Review material depends on runtime-observed state.
+22. Review material relies on alias or supersession without accepted
+    rules.
+23. Review material implies source merge authority.
+24. Review material implies general runtime authority.
+25. Review material implies Semantic CLI, AI Runtime, or agent authority.
+
+Validation failure grants no authority. It requires correction, denial,
+deferral, quarantine, supersession, dispute recording, or a later reviewed
+decision path.
+
+Runtime decision review validation is not runtime acceptance.
+
+Validation produces only a validation result.
+
+Validation never produces runtime activation, execution authority,
+runtime state, package authority, deployment authority, source authority,
+merge authority, trust assignment, registry publication, distribution
+authority, or capability issuance.
+
+## Review Invariants
+
+Every later Phase-20 RFC must preserve these runtime decision review
+invariants:
+
+1. Runtime Decision Review evaluates conformance to the exact Runtime
+   Decision record.
+2. Runtime Decision Review requires exact Runtime Decision record
+   binding.
+3. Runtime Decision Review requires one bounded runtime authority
+   consideration proposal.
+4. One runtime decision review evaluates one proposal against one Runtime
+   Decision record.
+5. Runtime Decision Review never reconstructs Runtime Decision scope.
+6. Runtime Decision Review never reinterprets Runtime Decision intent.
+7. Runtime Decision Review never broadens Phase-19 runtime authority.
+8. Runtime Decision Review never expands Slice scope.
+9. Runtime Decision Review is not runtime acceptance.
+10. Runtime Decision Review is not runtime activation.
+11. Runtime Decision Review is not execution authority.
+12. Runtime Decision Review is not runtime state.
+13. Runtime Decision Review is not general runtime authority.
+14. Review result `conforms` is not runtime accepted.
+15. Review result `conforms` is not runtime activation.
+16. Review result `conforms` is not execution authority.
+17. Review finding does not decide runtime acceptance.
+18. Review record is not runtime state.
+19. Review record is not execution authority.
+20. Runtime Decision Review does not grant package installation.
+21. Runtime Decision Review does not grant package loading.
+22. Runtime Decision Review does not grant package execution.
+23. Runtime Decision Review does not grant deployment authority.
+24. Runtime Decision Review does not grant registry publication.
+25. Runtime Decision Review does not grant trust assignment.
+26. Runtime Decision Review does not grant distribution authority.
+27. Runtime Decision Review does not grant capability issuance.
+28. Runtime Decision Review does not grant source merge authority.
+29. Runtime Decision Review does not modify prior governance records.
+30. Runtime Acceptance Decision requires separate governance review, if
+    ever authorized.
+31. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Later RFC Dependencies
+
+The runtime decision review model is a prerequisite for later Phase-20
+runtime acceptance decision paths only if separate runtime acceptance
+authority is ever reviewed and authorized.
+
+| Later record | Runtime decision review relationship |
+|---|---|
+| Later reviewed Runtime Acceptance Decision RFC or decision path, if ever authorized | May consider runtime acceptance only after exact Runtime Decision Review binding. |
+| Later reviewed Runtime Activation Decision RFC or decision path, if ever authorized | May consider activation only after separate reviewed activation authority and exact prior decision bindings. |
+
+Later RFCs may narrow runtime decision review use. They must not broaden
+this review model into runtime acceptance, runtime activation, general
+runtime authority, execution authority, runtime state, package
+installation, package loading, package execution, deployment, trust
+assignment, registry publication, distribution authority, capability
+issuance, source merge authority, Semantic CLI authority, AI Runtime
+authority, agent authority, syscall expansion, kernel ABI expansion, or
+Ring0 authority without a separate reviewed decision.
+
+Runtime Decision Review is the Phase-20 RFC in this chain that evaluates
+bounded runtime authority consideration proposal conformance against an
+exact Runtime Decision record.
+
+Runtime Decision Review does not activate runtime behavior.
+
+The current Phase-20 dependency chain is:
+
+```text
+Capability Model
+  -> Capability Identity
+  -> Capability Manifest Schema
+  -> Capability Lifecycle
+  -> Registry Model
+  -> Registry Governance
+  -> Trust Model
+  -> Distribution Policy
+  -> Capability Evidence Model
+  -> Capability Acceptance Workflow
+  -> Implementation Decision
+  -> Implementation Slice
+  -> Implementation Review
+  -> Implementation Acceptance Decision
+  -> Runtime Decision
+  -> Runtime Decision Review
+  -> Runtime Acceptance Decision
+  -> Runtime Activation Decision
+```
+
+Every arrow means a governance dependency. It does not imply runtime
+acceptance, source merge authority, publication, distribution,
+installation, loading, execution, issuance, deployment, runtime
+activation, or general runtime authority.
+
+Every dependency is explicit.
+
+No dependency is implied.
+
+Each RFC defines only its own layer. No RFC produces the authority of the
+next layer.
+
+## Explicit Non-Authorization
+
+This runtime decision review RFC does not authorize:
+
+1. Runtime acceptance.
+2. Runtime activation.
+3. Execution authority.
+4. Runtime state.
+5. General runtime authority.
+6. Runtime implementation.
+7. Code execution.
+8. Package installation, loading, execution, scheduling, or publication.
+9. Deployment behavior.
+10. Module loading.
+11. Workspace creation, workspace runtime, or real mounts.
+12. Plugin host, plugin loading, or plugin instantiation.
+13. Capability token minting or capability issuance.
+14. Trust assignment.
+15. Trust issuer authority.
+16. Registry authority.
+17. Registry publication.
+18. Publication authority.
+19. Distribution authority.
+20. Distribution execution.
+21. Source acceptance or source merge authority.
+22. Source repository authority.
+23. Semantic CLI execution or verdict authority.
+24. AI Runtime authority.
+25. Agent behavior.
+26. New syscalls.
+27. Kernel ABI expansion.
+28. Workflow-threshold, baseline, dependency, or Ring0 policy changes.
+29. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-20 RFC
+**Architecture status:** Draft RFC / pending architectural review
+**Authority notice:** This signature identifies the architectural authorship
+of this RFC. It grants no runtime acceptance authority, runtime
+activation authority, general runtime authority, implementation authority,
+implementation approval authority, source merge authority, trust
+authority, evidence authority, acceptance authority, proof authority,
+execution authority, constitutional authority, registry authority,
+distribution authority, publication authority, capability issuance
+authority, package authority, deployment authority, module authority,
+plugin authority, Semantic CLI authority, AI Runtime authority, agent
+authority, or Ring0 authority.
+
+## Non-Goals
+
+This document does not define or authorize:
+
+1. Runtime acceptance.
+2. Runtime activation or general runtime authority.
+3. Execution authority or runtime state.
+4. Runtime implementation.
+5. Code execution.
+6. Package format, repository, installation, loading, or execution.
+7. Deployment behavior.
+8. Artifact storage or binary format.
+9. Module loading.
+10. Workspace creation, workspace runtime, or real mounts.
+11. Plugin host, plugin loading, or plugin instantiation.
+12. Capability token minting or capability issuance.
+13. Trust assignment or trust issuer authority.
+14. Registry authority or registry publication.
+15. Publication workflow or publication approval.
+16. Distribution authority or distribution execution.
+17. Source acceptance or source merge authority.
+18. Source repository authority.
+19. Repository branch protection.
+20. Proof verification, signature verification, or signature acceptance.
+21. Semantic CLI execution or verdict authority.
+22. AI Runtime authority.
+23. Agent behavior.
+24. New syscalls.
+25. Kernel ABI expansion.
+26. Workflow-threshold, baseline, dependency, or Ring0 policy changes.


### PR DESCRIPTION
This PR adds the Phase-20 runtime decision review RFC.

The RFC defines a conformance review model for evaluating whether a bounded runtime authority consideration proposal conforms to the exact PHASE20_RUNTIME_DECISION.md record.

It is bound to the exact PHASE20_RUNTIME_DECISION.md record published at:
0ccbcf98e86937f6b89697c5cf0e867bfad07098

It preserves:
- exact Runtime Decision record binding
- no Runtime Decision scope reconstruction
- no Phase-19 runtime authority broadening
- no Slice scope expansion
- no runtime acceptance
- no runtime activation
- no execution authority
- no runtime state
- no package installation/loading/execution
- no deployment
- no capability issuance
- no registry publication
- no trust assignment
- no source merge authority
- no Semantic CLI / AI Runtime / agent authority

This PR changes only PHASE20_RUNTIME_DECISION_REVIEW.md.