### PR TITLE
Phase-20 runtime acceptance decision RFC

### DIFF
--- a/PHASE20_RUNTIME_ACCEPTANCE_DECISION.md
+++ b/PHASE20_RUNTIME_ACCEPTANCE_DECISION.md
@@ -1,0 +1,1003 @@
+# Phase-20 Runtime Acceptance Decision
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE20_POINTER_TRANSITION_DECISION.md`,
+`PHASE20_GOVERNANCE_OVERVIEW.md`,
+`PHASE20_CAPABILITY_MODEL.md`,
+`PHASE20_CAPABILITY_IDENTITY.md`,
+`PHASE20_CAPABILITY_MANIFEST_SCHEMA.md`,
+`PHASE20_CAPABILITY_LIFECYCLE.md`,
+`PHASE20_REGISTRY_MODEL.md`,
+`PHASE20_REGISTRY_GOVERNANCE.md`,
+`PHASE20_TRUST_MODEL.md`,
+`PHASE20_DISTRIBUTION_POLICY.md`,
+`PHASE20_CAPABILITY_EVIDENCE_MODEL.md`,
+`PHASE20_CAPABILITY_ACCEPTANCE_WORKFLOW.md`,
+`PHASE20_IMPLEMENTATION_DECISION.md`,
+`PHASE20_IMPLEMENTATION_SLICE.md`,
+`PHASE20_IMPLEMENTATION_REVIEW.md`,
+`PHASE20_IMPLEMENTATION_ACCEPTANCE_DECISION.md`,
+`PHASE20_RUNTIME_DECISION.md`, and
+`PHASE20_RUNTIME_DECISION_REVIEW.md`. In case of conflict, those
+documents prevail unless this runtime acceptance decision RFC is the
+narrower Phase-20 runtime acceptance decision record for the exact
+planning scope identified below.
+
+**Status:** PHASE-20 RUNTIME ACCEPTANCE DECISION RFC / RUNTIME
+ACCEPTANCE DECISION MODEL ONLY / NO RUNTIME ACTIVATION / NO EXECUTION
+AUTHORITY / NO RUNTIME STATE / NO GENERAL RUNTIME AUTHORITY / NO PACKAGE
+AUTHORITY / NO PACKAGE INSTALLATION / NO PACKAGE LOADING / NO PACKAGE
+EXECUTION / NO DEPLOYMENT / NO CAPABILITY ISSUANCE / NO TRUST ASSIGNMENT
+/ NO REGISTRY PUBLICATION / NO DISTRIBUTION AUTHORITY / NO SOURCE MERGE
+AUTHORITY / NO SOURCE ACCEPTANCE
+**Runtime acceptance decision date:** 2026-06-30
+**Runtime acceptance decision id:** `ayken.phase20.runtime_acceptance_decision.v1`
+**Runtime acceptance decision base main SHA:** `d7428d553975767c3681bed613705dfedf9862dc`
+**Reviewed runtime decision review SHA:** `d7428d553975767c3681bed613705dfedf9862dc`
+**Current phase pointer:** `CURRENT_PHASE=20`
+**Authority boundary:** Runtime acceptance decision model only; not
+runtime activation, not execution authority, not runtime state, not
+general runtime authority, not package authority, not package
+installation, not package loading, not package execution, not deployment,
+not source acceptance, not source merge authority, not source repository
+authority, not module loading, not workspace runtime, not plugin loading,
+not capability token minting, not capability issuance, not trust
+assignment, not trust issuer authority, not registry authority, not
+registry publication, not publication authority, not distribution
+authority, not distribution execution, not Semantic CLI authority, not AI
+Runtime authority, not agent authority, not syscall expansion, not kernel
+ABI expansion, not workflow-threshold, baseline, dependency, or Ring0
+authority.
+
+## Purpose
+
+This document defines the Phase-20 runtime acceptance decision model for
+deciding whether a reviewed bounded runtime authority consideration
+proposal is accepted as a governance result after exact Runtime Decision
+Review conformance.
+
+It answers one question:
+
+```text
+How is a reviewed bounded runtime authority consideration proposal
+accepted, rejected, or quarantined after exact Runtime Decision Review
+conformance?
+```
+
+It does not answer:
+
+```text
+How is runtime activated?
+How is code executed?
+How is a package installed, loaded, executed, deployed, or distributed?
+How is execution authority granted?
+How is runtime state created?
+How is a capability issued?
+How is trust assigned?
+How is a registry entry published?
+```
+
+Those questions belong to later reviewed RFCs or decision paths, if ever
+authorized.
+
+## Core Rule
+
+```text
+runtime acceptance decision != runtime activation
+runtime acceptance decision != execution authority
+runtime acceptance decision != runtime state
+runtime acceptance decision != general runtime authority
+runtime acceptance decision != package execution
+runtime acceptance decision != package loading
+runtime acceptance decision != deployment
+runtime acceptance decision != capability issuance
+runtime acceptance decision != registry publication
+runtime acceptance decision != trust assignment
+runtime accepted != runtime activated
+runtime accepted != runtime enabled
+runtime accepted != execution authority
+runtime accepted != runtime state
+review result conforms != runtime accepted
+review result conforms is necessary but not sufficient for runtime acceptance
+runtime acceptance decision record != runtime state
+runtime acceptance decision record != execution authority
+runtime acceptance decision never broadens Phase-19 runtime authority
+runtime acceptance decision never expands Slice scope
+```
+
+Runtime Acceptance Decision consumes the exact Runtime Decision Review
+record.
+
+Runtime Acceptance Decision may record governance acceptance for a
+reviewed bounded runtime authority consideration proposal.
+
+Runtime Acceptance Decision does not activate runtime behavior.
+
+Runtime Acceptance Decision does not grant execution authority.
+
+Runtime Acceptance Decision does not create runtime state.
+
+Runtime Acceptance Decision does not broaden Phase-19 runtime authority.
+
+Runtime Acceptance Decision does not expand Slice scope.
+
+Runtime Acceptance Decision does not grant package execution, package
+loading, deployment, registry publication, trust assignment, distribution
+authority, source merge authority, or capability issuance by implication.
+
+Unknown authority readings fail closed.
+
+## Runtime Acceptance Decision Mission
+
+The mission of the Phase-20 runtime acceptance decision model is to
+define an explicit, auditable governance decision path for bounded
+runtime authority consideration proposals that have already passed exact
+Runtime Decision Review conformance.
+
+Runtime acceptance decision exists so later RFCs can reason about:
+
+1. Runtime acceptance decision subjects.
+2. Exact Runtime Decision Review record prerequisites.
+3. Exact review result prerequisites.
+4. Reviewed bounded runtime authority consideration proposal binding.
+5. Runtime acceptance decision identity.
+6. Decision input sets.
+7. Runtime acceptance boundaries.
+8. Decision records and outcomes.
+9. Phase-19 runtime authority preservation.
+10. Post-decision exact-SHA verification.
+11. Later Runtime Activation Decision prerequisites, if ever authorized.
+
+The runtime acceptance decision model itself grants no runtime
+activation, execution authority, runtime state, general runtime
+authority, package authority, deployment, distribution, trust, registry,
+source merge, or capability issuance authority.
+
+Each later use requires its own reviewed RFC or decision path.
+
+## Runtime Acceptance Decision Definition
+
+Runtime acceptance decision is a governance decision record that
+determines whether a reviewed bounded runtime authority consideration
+proposal is accepted for the exact runtime decision review subject.
+
+A runtime acceptance decision may describe:
+
+1. The exact runtime acceptance decision subject.
+2. The exact Runtime Decision Review record.
+3. The exact review result.
+4. The exact bounded runtime authority consideration proposal.
+5. The exact Runtime Decision record.
+6. The exact Runtime Decision subject and identity.
+7. The exact accepted bounded implementation proposal context.
+8. Decision input records.
+9. Decision result.
+10. Post-decision verification requirements.
+11. Later Runtime Activation Decision dependency, if ever authorized.
+12. Non-authorization notice.
+
+A runtime acceptance decision is not runtime activation, execution
+authority, runtime state, general runtime authority, package
+installation, package loading, package execution, deployment, capability
+issuance, registry publication, distribution authority, trust
+assignment, source acceptance, source merge authority, or Semantic CLI,
+AI Runtime, or agent authority.
+
+## Runtime Acceptance Decision Scope
+
+This RFC defines only the runtime acceptance decision model.
+
+It does not define runtime activation, runtime implementation, code
+execution, runtime state creation, package installation, package loading,
+package execution, module loading, plugin loading, workspace runtime,
+deployment behavior, registry publication, distribution execution, trust
+assignment, capability issuance, source modification procedure, source
+acceptance, or source merge procedure.
+
+Runtime acceptance decision is a governance decision layer. It is not a
+runtime service, execution engine, package manager, installer, loader,
+deployment service, registry publisher, distribution engine, trust
+issuer, capability issuer, source merge engine, or source repository
+authority.
+
+Any activation-specific, execution-specific, state-specific,
+package-specific, loader-specific, deployment-specific,
+runtime-specific, publication-specific, distribution-specific,
+trust-specific, capability-issuance-specific, or source-merge-specific
+interpretation fails closed until later reviewed RFCs define exact
+behavior.
+
+## Runtime Acceptance Decision Subject
+
+A runtime acceptance decision subject is the exact reviewed bounded
+runtime authority consideration proposal being decided after one exact
+Runtime Decision Review record.
+
+A runtime acceptance decision subject must reference:
+
+1. Exact Runtime Decision Review record.
+2. Exact runtime decision review subject.
+3. Exact review result.
+4. Exact bounded runtime authority consideration proposal.
+5. Exact Runtime Decision record.
+6. Exact Runtime Decision subject.
+7. Exact Runtime Decision identity.
+8. Exact Implementation Acceptance Decision record.
+9. Exact accepted bounded implementation proposal.
+10. Exact reviewed Runtime Decision Review SHA.
+11. Phase-19 runtime authority records used as boundary context.
+12. Governing RFCs.
+13. Non-authorization notice.
+
+Runtime acceptance decision subject is not runtime activation.
+
+Runtime acceptance decision subject is not execution authority, runtime
+state, general runtime authority, package ownership, package execution,
+source repository ownership, source merge authority, module ownership,
+plugin ownership, registry publication, deployment target, process,
+workspace state, runtime handle, or capability token.
+
+Changing the Runtime Decision Review record, review subject, review
+result, bounded runtime authority consideration proposal, Runtime
+Decision record, Runtime Decision identity, accepted bounded
+implementation proposal, reviewed Runtime Decision Review SHA, Phase-19
+boundary context, or subject-defining context creates a different runtime
+acceptance decision subject unless a later reviewed RFC defines exact
+narrower behavior.
+
+## Exact Runtime Decision Review Record Requirement
+
+Runtime acceptance decision requires an exact Runtime Decision Review
+record.
+
+The reviewed runtime decision review record for this RFC is
+`PHASE20_RUNTIME_DECISION_REVIEW.md` at exact main SHA
+`d7428d553975767c3681bed613705dfedf9862dc`.
+
+Runtime acceptance decision must consume the exact reviewed Runtime
+Decision Review record.
+
+Runtime acceptance decision must never reconstruct Runtime Decision
+scope.
+
+Runtime acceptance decision must never reinterpret Runtime Decision
+intent.
+
+Runtime acceptance decision must never broaden Phase-19 runtime
+authority.
+
+Runtime acceptance decision must never expand Slice scope.
+
+Runtime acceptance decision must never infer runtime acceptance when the
+exact review result is missing.
+
+Runtime acceptance decision must never infer runtime activation,
+execution authority, or runtime state from a review result.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped Runtime Decision Review binding fails closed.
+
+## Review Result Requirement
+
+Runtime acceptance decision may accept only a reviewed bounded runtime
+authority consideration proposal with an exact review result of
+`conforms`.
+
+Review result `conforms` is necessary but not sufficient for runtime
+acceptance, and is not runtime acceptance by implication.
+
+Review results `does_not_conform`, `quarantined`, `deferred`, or
+`superseded` must not produce an accepted runtime acceptance decision
+result.
+
+Review result `conforms` is not runtime activation.
+
+Review result `conforms` is not execution authority.
+
+Review result `conforms` is not runtime state.
+
+Review result ambiguity fails closed.
+
+## Runtime Acceptance Decision Identity
+
+Runtime acceptance decision identity distinguishes one runtime acceptance
+decision record from another.
+
+Runtime acceptance decision identity is conceptually composed of:
+
+```text
+(runtime_acceptance_decision_domain, runtime_acceptance_decision_subject,
+ runtime_decision_review_record, review_result,
+ bounded_runtime_authority_consideration_proposal, decision_binding)
+```
+
+This tuple is conceptual. It is not a source path syntax, source
+ownership claim, package name, module name, crate name, repository
+branch, database schema, command, token, runtime handle, process handle,
+loader key, execution key, merge key, deployment key, or capability key.
+
+Runtime acceptance decision identity remains stable for the lifetime of
+that decision record. Changing identity-defining decision fields creates
+a different runtime acceptance decision record unless a later reviewed
+RFC defines exact narrower behavior.
+
+Runtime acceptance decision identity does not imply runtime activation,
+execution authority, runtime state, package authority, deployment
+authority, registry publication, distribution authority, trust
+assignment, source merge authority, or capability issuance.
+
+## Decision Input Set
+
+A decision input set is the exact set of records considered by one
+runtime acceptance decision.
+
+A decision input set must include:
+
+1. Exact runtime acceptance decision subject.
+2. Exact Runtime Decision Review record.
+3. Exact review result.
+4. Exact bounded runtime authority consideration proposal.
+5. Exact Runtime Decision record.
+6. Exact Runtime Decision subject and identity.
+7. Exact Implementation Acceptance Decision record.
+8. Exact accepted bounded implementation proposal.
+9. Exact reviewed Runtime Decision Review SHA.
+10. Reviewer findings considered.
+11. Phase-19 runtime authority boundary references.
+12. Non-authorization notice.
+
+One runtime acceptance decision decides one reviewed bounded runtime
+authority consideration proposal from one exact Runtime Decision Review
+record.
+
+Decision input presence is not runtime acceptance.
+
+Decision input completeness is not runtime activation.
+
+Decision input set must not silently include adjacent files, generated
+artifacts, dependency trees, build products, package outputs, runtime
+objects, deployment state, workspace state, process state, runtime
+handles, or capability tokens.
+
+## Exact-SHA Binding
+
+Runtime acceptance decision is exact-SHA bound.
+
+The conceptual decision chain is:
+
+```text
+Runtime Decision Record
+  -> Bounded Runtime Authority Consideration Proposal
+  -> Runtime Decision Review Record
+  -> Review Result
+  -> Runtime Acceptance Decision Record
+  -> later Runtime Activation Decision, if ever authorized
+```
+
+Every arrow is a governance dependency. No arrow implies runtime
+activation, execution authority, runtime state, code execution, package
+installation, package loading, package execution, deployment,
+distribution, capability issuance, registry publication, trust
+assignment, source acceptance, or source merge authority.
+
+Exact-SHA binding may use:
+
+1. Exact reviewed Runtime Decision Review SHA.
+2. Exact Runtime Decision Review record identifier.
+3. Exact review result identifier.
+4. Exact bounded runtime authority consideration proposal identifier.
+5. Exact Runtime Decision record identifier.
+6. Exact runtime acceptance decision record identifier.
+7. Exact runtime acceptance decision result identifier.
+
+This RFC does not define canonical hash construction, digest algorithm,
+artifact digest format, package digest format, source merge mechanics,
+diff format, runtime identity, process identity, runtime handle format,
+state format, execution key format, or signature format.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped decision binding fails closed.
+
+## Acceptance Boundary
+
+Acceptance boundary is the limit of what runtime acceptance decision may
+decide.
+
+Runtime acceptance decision may decide whether:
+
+1. Exact Runtime Decision Review record is present.
+2. Exact review result is `conforms`.
+3. Reviewed bounded runtime authority consideration proposal is exact and
+   stable.
+4. Proposal remains bound to the exact Runtime Decision record.
+5. Runtime Decision subject and identity remain preserved.
+6. Exact Implementation Acceptance Decision context remains preserved.
+7. Phase-19 runtime authority boundaries remain preserved.
+8. Runtime Decision scope is not reconstructed.
+9. Runtime Decision intent is not reinterpreted.
+10. Slice scope is not expanded.
+11. Non-authorization notices remain present.
+12. No unexpected runtime activation, execution, state, package,
+    deployment, issuance, registry, trust, distribution, source merge,
+    Semantic CLI, AI Runtime, or agent authority reading is introduced.
+
+Runtime acceptance decision must not decide:
+
+1. Runtime activation.
+2. Runtime readiness.
+3. Execution authority.
+4. Runtime state creation.
+5. Code execution.
+6. Package installation, loading, execution, scheduling, or publication.
+7. Deployment readiness.
+8. Capability issuance.
+9. Registry publication.
+10. Distribution execution.
+11. Trust assignment.
+12. Source merge authorization.
+13. Source repository state.
+14. Production readiness.
+
+Any decision reading that crosses the acceptance boundary fails closed.
+
+## Decision Evaluation Model
+
+Runtime acceptance decision evaluates whether a reviewed bounded runtime
+authority consideration proposal may receive a runtime acceptance
+governance result.
+
+Decision evaluation may compare:
+
+1. Review result against required `conforms` result.
+2. Proposal identity against the exact Runtime Decision Review record.
+3. Runtime Decision identity against the exact review record.
+4. Runtime Decision subject against the exact review record.
+5. Accepted bounded implementation proposal context against the Runtime
+   Decision record.
+6. Reviewer findings against the decision input set.
+7. Phase-19 runtime boundary claims against Phase-19 runtime authority
+   records.
+8. Review ambiguity against quarantine conditions.
+9. Non-authorization notices against governing RFCs.
+10. Relationship context against denied authority readings.
+
+Decision evaluation does not reconstruct Runtime Decision scope.
+
+Decision evaluation does not reinterpret Runtime Decision intent.
+
+Decision evaluation does not broaden Phase-19 runtime authority.
+
+Decision evaluation does not expand Slice scope.
+
+Decision evaluation does not activate runtime behavior.
+
+Decision evaluation does not grant execution authority.
+
+Decision evaluation does not create runtime state.
+
+Decision output records only a runtime acceptance governance result until
+a later Runtime Activation Decision defines separate activation
+authority, if ever authorized.
+
+## Decision Record
+
+A runtime acceptance decision record records the decision result for a
+reviewed bounded runtime authority consideration proposal.
+
+Allowed runtime acceptance decision results are:
+
+1. `accepted`
+2. `rejected`
+3. `quarantined`
+
+No other runtime acceptance decision result is defined by this RFC.
+
+A runtime acceptance decision record must identify the exact runtime
+acceptance decision subject, exact Runtime Decision Review record, exact
+review result, exact bounded runtime authority consideration proposal,
+exact Runtime Decision record, reviewer findings considered, decision
+result, reason for decision, exact-SHA binding, Phase-19 runtime
+authority preservation, non-authorization notice, and fail-closed
+handling for later ambiguity.
+
+Runtime acceptance decision records governance state only.
+
+Runtime acceptance decision record never activates runtime, grants
+execution authority, creates runtime state, executes code, installs
+packages, loads packages, executes packages, deploys artifacts, issues
+capabilities, publishes registry entries, assigns trust, accepts source,
+merges source, or authorizes distribution.
+
+## Runtime Acceptance Outcomes
+
+Runtime acceptance outcomes are governance outcomes only.
+
+This RFC defines:
+
+| Outcome | Meaning | Authority result |
+|---|---|---|
+| `accepted` | Reviewed bounded runtime authority consideration proposal is accepted for the exact decision subject | No runtime activation |
+| `rejected` | Reviewed bounded runtime authority consideration proposal is rejected for the exact decision subject | No deletion or revocation by itself |
+| `quarantined` | Proposal or decision input is held for unresolved ambiguity, conflict, or safety concern | No authority |
+| `deferred` | Decision is delayed before a runtime acceptance decision result can be recorded | No acceptance |
+| `superseded` | Decision is replaced by a later exact reviewed decision | No inheritance |
+
+`accepted`, `rejected`, and `quarantined` are runtime acceptance decision
+results.
+
+`deferred` and `superseded` are decision dispositions. They are not
+runtime acceptance decision results.
+
+Outcome presence must not be interpreted as runtime activation,
+execution authority, runtime state, trust assignment, registry
+publication, distribution authority, package execution, deployment
+authority, source merge authority, general runtime authority, or
+capability issuance.
+
+## Explicit Separation
+
+Runtime acceptance decision concepts do not imply authority-bearing
+runtime outcomes.
+
+| Runtime acceptance concept | Is not |
+|---|---|
+| Runtime accepted | Runtime activated |
+| Runtime accepted | Runtime enabled |
+| Runtime accepted | Execution authority |
+| Runtime accepted | Runtime state |
+| Runtime accepted | Package executable |
+| Runtime accepted | Capability issued |
+| Runtime accepted | Registry published |
+| Runtime accepted | Trust assigned |
+| Review result `conforms` | Runtime accepted |
+| Decision completed | Runtime activation decision |
+| Decision record | Runtime state |
+| Decision record | Execution authority |
+
+No concept in this table implies another by default.
+
+Unknown runtime, execution, source, issuance, publication, trust, or
+distribution readings fail closed.
+
+## Decision Disposition Handling
+
+Decision dispositions preserve audit history for rejection, quarantine,
+deferral, and supersession.
+
+Rejection records that a reviewed bounded runtime authority consideration
+proposal did not receive runtime acceptance for the exact decision
+subject. It does not delete history, revoke another record, transfer
+authority to a replacement, establish alias or supersession by itself,
+prove fault by itself, or block later resubmission by itself.
+
+Quarantine is the safe decision result for unresolved ambiguity,
+including decision subject ambiguity, Runtime Decision Review record
+ambiguity, review result ambiguity, bounded runtime authority
+consideration proposal ambiguity, Runtime Decision identity conflict,
+Phase-19 runtime boundary conflict, denied-reading concern, missing
+decision prerequisite, or incompatible interpretation across governing
+records.
+
+Deferral may record that later information is required before a runtime
+acceptance decision result can be made.
+
+Supersession may record that a later exact runtime acceptance decision
+replaces the current decision for decision purposes. Supersession
+inheritance is denied unless a later reviewed RFC defines exact narrower
+behavior.
+
+No disposition activates runtime, grants execution authority, creates
+runtime state, accepts source, merges source, assigns trust, publishes
+registry entries, authorizes distribution, issues capabilities, deploys
+artifacts, installs packages, loads packages, or executes packages.
+
+## Phase-19 Runtime Authority Relationship
+
+Phase-20 Runtime Acceptance Decision consumes Phase-20 Runtime Decision
+Review context and remains subordinate to Phase-19 runtime authority
+records.
+
+Phase-19 runtime records may be read as boundary context for:
+
+1. Runtime MVP planning boundaries.
+2. Runtime evidence expectations.
+3. Runtime non-goals and denials.
+4. Platform runtime constitutional constraints.
+5. Userspace-only runtime constraints.
+6. Frozen syscall and kernel ABI boundaries.
+7. Denied package, module, workspace, plugin, trust, capability, AI
+   Runtime, Semantic CLI, and agent authority readings.
+
+Phase-20 Runtime Acceptance Decision must not broaden, replace,
+supersede, weaken, or reinterpret Phase-19 runtime authority records.
+
+Phase-20 Runtime Acceptance Decision must not use an acceptance result to
+infer Phase-19 runtime authority.
+
+Any Phase-20 runtime acceptance decision reading that conflicts with
+Phase-19 runtime authority records fails closed.
+
+## Post-Decision Exact-SHA Verification
+
+Post-decision exact-SHA verification is a governance verification step
+after a runtime acceptance decision record has been recorded.
+
+The conceptual verification path is:
+
+```text
+runtime_decision_review
+  -> runtime_acceptance_decision
+  -> exact_runtime_acceptance_decision_sha
+  -> post_runtime_acceptance_decision_verification
+  -> later_runtime_activation_decision_input_if_authorized
+```
+
+Every arrow is a governance dependency. No arrow implies runtime
+activation, execution authority, runtime state, code execution, package
+execution, deployment, distribution, capability issuance, registry
+publication, trust assignment, source acceptance, or source merge
+authority.
+
+Post-decision verification may confirm the exact runtime acceptance
+decision record SHA, exact Runtime Decision Review record, exact review
+result, exact bounded runtime authority consideration proposal, expected
+non-authorization notices, expected governance check results, expected
+Phase-19 runtime boundary preservation, and no unexpected runtime or
+authority expansion.
+
+Post-decision verification result is not runtime activation.
+
+Post-decision verification result is not execution authority.
+
+Post-decision verification result is not runtime state.
+
+Post-decision verification records exact-SHA verification only. It never
+records activation authority, execution authority, or runtime state.
+
+## Relationship Boundaries
+
+Runtime acceptance decision may consume prior Phase-20 and Phase-19
+governance records as decision context only.
+
+| Previous record | Accepted reading | Denied reading |
+|---|---|---|
+| `PHASE20_RUNTIME_DECISION_REVIEW.md` | Exact review record and `conforms` result as decision prerequisite | Review result `conforms` is not runtime acceptance by implication |
+| `PHASE20_RUNTIME_DECISION.md` | Exact Runtime Decision record, Runtime Decision Subject, Runtime Decision Identity, and bounded runtime authority consideration as context | Runtime Decision does not activate runtime or grant execution authority |
+| `PHASE20_IMPLEMENTATION_ACCEPTANCE_DECISION.md` | Exact acceptance decision record and `accepted` result as context through Runtime Decision | Implementation accepted is not runtime enabled |
+| `PHASE20_IMPLEMENTATION_REVIEW.md` | Exact review record as context through acceptance decision | Review result is not runtime authority |
+| `PHASE20_IMPLEMENTATION_SLICE.md` | Exact Slice record, Slice Identity, and Bounded Source Scope as context | Slice scope is never reconstructed, expanded, or reinterpreted |
+| `PHASE20_IMPLEMENTATION_DECISION.md` | Eligible decision record as prerequisite context | Eligibility is not runtime authority |
+| `PHASE20_CAPABILITY_ACCEPTANCE_WORKFLOW.md` | Accepted workflow subject and acceptance decision record as context | Accepted workflow subject is not runtime enabled |
+| `PHASE20_CAPABILITY_EVIDENCE_MODEL.md` | Accepted evidence through acceptance workflow context | Accepted evidence is not runtime proof |
+| `PHASE20_REGISTRY_MODEL.md` and `PHASE20_REGISTRY_GOVERNANCE.md` | Registry context for subject consistency | Registry context is not publication, issuance, runtime activation, or runtime authority |
+| `PHASE20_TRUST_MODEL.md` | Trust context for decision context | Trust context is not trust assignment or runtime authority |
+| `PHASE20_DISTRIBUTION_POLICY.md` | Distribution policy context for decision context | Distribution eligibility is not distribution execution or runtime authority |
+| `PHASE19_RUNTIME_DECISION.md` and Phase-19 Runtime RFC set | Runtime boundary context and denied readings | Runtime Acceptance Decision does not broaden or replace Phase-19 runtime authority |
+
+Runtime acceptance decision does not modify prior governance records.
+
+Runtime acceptance decision does not modify Runtime Decision Review
+records.
+
+Runtime acceptance decision does not modify Runtime Decision records.
+
+Runtime acceptance decision does not modify implementation acceptance
+decision records.
+
+Runtime acceptance decision does not modify review records.
+
+Runtime acceptance decision does not modify Slice scope.
+
+Runtime acceptance decision does not modify acceptance state.
+
+Runtime acceptance decision does not modify evidence records.
+
+Runtime acceptance decision does not modify Phase-19 runtime authority
+records.
+
+Ambiguous, stale, inherited, unaccepted, or differently scoped
+relationship material fails closed for runtime acceptance decision.
+
+## Runtime Activation Decision Boundary
+
+Runtime acceptance decision is a prerequisite input for later Runtime
+Activation Decision records only if a separate reviewed activation RFC or
+decision path is ever authorized.
+
+Runtime acceptance decision does not define runtime activation authority.
+
+A later Runtime Activation Decision, if ever authorized, must define:
+
+1. Exact runtime activation decision subject.
+2. Exact Runtime Acceptance Decision record.
+3. Exact accepted bounded runtime authority consideration proposal.
+4. Exact Runtime Decision Review record.
+5. Exact Runtime Decision record.
+6. Exact runtime behavior being considered for activation.
+7. Exact denied runtime behaviors.
+8. Exact runtime boundary.
+9. Exact execution authority boundary.
+10. Exact runtime state boundary.
+11. Package, loader, deployment, issuance, publication, trust,
+    distribution, source, Semantic CLI, AI Runtime, agent, syscall,
+    kernel ABI, and Ring0 denials.
+12. Required activation review path.
+13. Required post-activation verification.
+14. Non-authorization notice for anything outside scope.
+
+Until such a reviewed Runtime Activation Decision exists, runtime
+activation remains denied.
+
+Runtime activation is not granted by runtime acceptance.
+
+Execution authority is not granted by runtime acceptance.
+
+Runtime state is not created by runtime acceptance.
+
+## Decision Validation Model
+
+Runtime acceptance decision validation is conceptual and fail-closed.
+
+Decision validation must never reconstruct Runtime Decision scope.
+
+Decision validation must never reinterpret Runtime Decision intent.
+
+Decision validation must never broaden Phase-19 runtime authority.
+
+Decision validation must never expand Slice scope.
+
+Decision validation must never activate runtime behavior.
+
+Decision validation must never grant execution authority.
+
+Decision validation must never create runtime state.
+
+Decision validation must never infer missing review material.
+
+Runtime acceptance decision material is invalid for governance review
+when:
+
+1. Runtime acceptance decision subject is missing or ambiguous.
+2. Runtime acceptance decision identity is missing or ambiguous.
+3. Exact Runtime Decision Review record is missing, stale, ambiguous,
+   inherited, or differently scoped.
+4. Reviewed Runtime Decision Review SHA is missing or ambiguous.
+5. Review result is missing, ambiguous, or not `conforms` for an
+   `accepted` decision result.
+6. Bounded runtime authority consideration proposal is missing or
+   ambiguous.
+7. Decision input set is missing or ambiguous.
+8. Runtime Decision record is missing, stale, ambiguous, inherited, or
+   differently scoped.
+9. Runtime Decision scope is reconstructed.
+10. Runtime Decision intent is reinterpreted.
+11. Phase-19 runtime authority is broadened, weakened, replaced,
+    superseded, or reinterpreted.
+12. Slice scope is expanded.
+13. Review result `conforms` is treated as runtime acceptance by
+    implication.
+14. Decision result is treated as runtime activation.
+15. Decision result is treated as execution authority.
+16. Decision result is treated as runtime state.
+17. Decision result is treated as package execution authority.
+18. Decision result is treated as registry publication.
+19. Decision result is treated as trust assignment.
+20. Decision result is treated as capability issuance.
+21. Decision material depends on runtime-observed state.
+22. Decision material relies on alias or supersession without accepted
+    rules.
+23. Decision material implies source merge authority.
+24. Decision material implies general runtime authority.
+25. Decision material implies Semantic CLI, AI Runtime, or agent
+    authority.
+
+Validation failure grants no authority. It requires correction, rejection,
+deferral, quarantine, supersession, dispute recording, or a later reviewed
+decision path.
+
+Runtime acceptance decision validation is not runtime activation.
+
+Validation produces only a validation result.
+
+Validation never produces runtime activation, execution authority,
+runtime state, package authority, deployment authority, source authority,
+merge authority, trust assignment, registry publication, distribution
+authority, or capability issuance.
+
+## Runtime Acceptance Decision Invariants
+
+Every later Phase-20 RFC must preserve these runtime acceptance decision
+invariants:
+
+1. Runtime Acceptance Decision consumes the exact Runtime Decision Review
+   record.
+2. Runtime Acceptance Decision requires exact review result binding.
+3. Runtime Acceptance Decision may accept only review result `conforms`.
+4. Review result `conforms` is necessary but not sufficient for runtime
+   acceptance.
+5. Review result `conforms` is not runtime accepted by implication.
+6. Runtime accepted is not runtime activated.
+7. Runtime accepted is not execution authority.
+8. Runtime accepted is not runtime state.
+9. Runtime Acceptance Decision does not activate runtime behavior.
+10. Runtime Acceptance Decision does not grant execution authority.
+11. Runtime Acceptance Decision does not create runtime state.
+12. Runtime Acceptance Decision is not general runtime authority.
+13. Runtime Acceptance Decision does not reconstruct Runtime Decision
+    scope.
+14. Runtime Acceptance Decision does not reinterpret Runtime Decision
+    intent.
+15. Runtime Acceptance Decision does not broaden Phase-19 runtime
+    authority.
+16. Runtime Acceptance Decision does not expand Slice scope.
+17. Runtime Acceptance Decision does not grant package installation.
+18. Runtime Acceptance Decision does not grant package loading.
+19. Runtime Acceptance Decision does not grant package execution.
+20. Runtime Acceptance Decision does not grant deployment authority.
+21. Runtime Acceptance Decision does not grant registry publication.
+22. Runtime Acceptance Decision does not grant trust assignment.
+23. Runtime Acceptance Decision does not grant distribution authority.
+24. Runtime Acceptance Decision does not grant capability issuance.
+25. Runtime Acceptance Decision does not grant source merge authority.
+26. One runtime acceptance decision decides one reviewed bounded runtime
+    authority consideration proposal.
+27. Runtime acceptance decision record is not runtime state.
+28. Runtime acceptance decision record is not execution authority.
+29. Runtime acceptance decision does not modify prior governance records.
+30. Runtime Activation Decision requires separate governance review, if
+    ever authorized.
+31. Post-decision verification result is not runtime activation.
+32. Post-decision verification result is not execution authority.
+33. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Later RFC Dependencies
+
+The runtime acceptance decision model is a prerequisite for later
+Phase-20 runtime activation decision paths only if separate runtime
+activation authority is ever reviewed and authorized.
+
+| Later record | Runtime acceptance decision relationship |
+|---|---|
+| Later reviewed Runtime Activation Decision RFC or decision path, if ever authorized | May consider activation only after separate reviewed activation authority and exact Runtime Acceptance Decision binding. |
+
+Later RFCs may narrow runtime acceptance decision use. They must not
+broaden this decision model into runtime activation, general runtime
+authority, execution authority, runtime state, package installation,
+package loading, package execution, deployment, trust assignment,
+registry publication, distribution authority, capability issuance, source
+merge authority, Semantic CLI authority, AI Runtime authority, agent
+authority, syscall expansion, kernel ABI expansion, or Ring0 authority
+without a separate reviewed decision.
+
+Runtime Acceptance Decision is the Phase-20 RFC in this chain that
+records governance acceptance for reviewed bounded runtime authority
+consideration proposals.
+
+Runtime Acceptance Decision does not activate runtime behavior.
+
+The current Phase-20 dependency chain is:
+
+```text
+Capability Model
+  -> Capability Identity
+  -> Capability Manifest Schema
+  -> Capability Lifecycle
+  -> Registry Model
+  -> Registry Governance
+  -> Trust Model
+  -> Distribution Policy
+  -> Capability Evidence Model
+  -> Capability Acceptance Workflow
+  -> Implementation Decision
+  -> Implementation Slice
+  -> Implementation Review
+  -> Implementation Acceptance Decision
+  -> Runtime Decision
+  -> Runtime Decision Review
+  -> Runtime Acceptance Decision
+  -> Runtime Activation Decision
+```
+
+Every arrow means a governance dependency. It does not imply runtime
+activation, source merge authority, publication, distribution,
+installation, loading, execution, issuance, deployment, execution
+authority, runtime state, or general runtime authority.
+
+Every dependency is explicit.
+
+No dependency is implied.
+
+Each RFC defines only its own layer. No RFC produces the authority of the
+next layer.
+
+## Explicit Non-Authorization
+
+This runtime acceptance decision RFC does not authorize:
+
+1. Runtime activation.
+2. Execution authority.
+3. Runtime state.
+4. General runtime authority.
+5. Runtime implementation.
+6. Code execution.
+7. Package installation, loading, execution, scheduling, or publication.
+8. Deployment behavior.
+9. Module loading.
+10. Workspace creation, workspace runtime, or real mounts.
+11. Plugin host, plugin loading, or plugin instantiation.
+12. Capability token minting or capability issuance.
+13. Trust assignment.
+14. Trust issuer authority.
+15. Registry authority.
+16. Registry publication.
+17. Publication authority.
+18. Distribution authority.
+19. Distribution execution.
+20. Source acceptance or source merge authority.
+21. Source repository authority.
+22. Semantic CLI execution or verdict authority.
+23. AI Runtime authority.
+24. Agent behavior.
+25. New syscalls.
+26. Kernel ABI expansion.
+27. Workflow-threshold, baseline, dependency, or Ring0 policy changes.
+28. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-20 RFC
+**Architecture status:** Draft RFC / pending architectural review
+**Authority notice:** This signature identifies the architectural
+authorship of this RFC. It grants no runtime activation authority,
+execution authority, runtime state authority, general runtime authority,
+implementation authority, implementation approval authority, source merge
+authority, trust authority, evidence authority, acceptance authority,
+proof authority, constitutional authority, registry authority,
+distribution authority, publication authority, capability issuance
+authority, package authority, deployment authority, module authority,
+plugin authority, Semantic CLI authority, AI Runtime authority, agent
+authority, or Ring0 authority.
+
+## Non-Goals
+
+This document does not define or authorize:
+
+1. Runtime activation or general runtime authority.
+2. Execution authority.
+3. Runtime state.
+4. Runtime implementation.
+5. Code execution.
+6. Package format, repository, installation, loading, or execution.
+7. Deployment behavior.
+8. Artifact storage or binary format.
+9. Module loading.
+10. Workspace creation, workspace runtime, or real mounts.
+11. Plugin host, plugin loading, or plugin instantiation.
+12. Capability token minting or capability issuance.
+13. Trust assignment or trust issuer authority.
+14. Registry authority or registry publication.
+15. Publication workflow or publication approval.
+16. Distribution authority or distribution execution.
+17. Source acceptance or source merge authority.
+18. Source repository authority.
+19. Repository branch protection.
+20. Proof verification, signature verification, or signature acceptance.
+21. Semantic CLI execution or verdict authority.
+22. AI Runtime authority.
+23. Agent behavior.
+24. New syscalls.
+25. Kernel ABI expansion.
+26. Workflow-threshold, baseline, dependency, or Ring0 policy changes.


### PR DESCRIPTION
This PR adds the Phase-20 runtime acceptance decision RFC.

The RFC defines a governance decision model for accepting, rejecting, or quarantining a reviewed bounded runtime authority consideration proposal after exact Runtime Decision Review conformance.

It is bound to the exact PHASE20_RUNTIME_DECISION_REVIEW.md record published at:
d7428d553975767c3681bed613705dfedf9862dc

It preserves:
- exact Runtime Decision Review record binding
- exact review result requirement
- review result `conforms` is necessary but not sufficient
- runtime accepted is not runtime activated
- runtime accepted is not execution authority
- runtime accepted is not runtime state
- no Runtime Decision scope reconstruction
- no Phase-19 runtime authority broadening
- no Slice scope expansion
- no package installation/loading/execution
- no deployment
- no capability issuance
- no registry publication
- no trust assignment
- no source merge authority
- no Semantic CLI / AI Runtime / agent authority

This PR changes only PHASE20_RUNTIME_ACCEPTANCE_DECISION.md.