### PR TITLE
Phase-20 runtime activation decision RFC

### DIFF
--- a/PHASE20_RUNTIME_ACTIVATION_DECISION.md
+++ b/PHASE20_RUNTIME_ACTIVATION_DECISION.md
@@ -1,0 +1,1100 @@
+# Phase-20 Runtime Activation Decision
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE20_POINTER_TRANSITION_DECISION.md`,
+`PHASE20_GOVERNANCE_OVERVIEW.md`,
+`PHASE20_CAPABILITY_MODEL.md`,
+`PHASE20_CAPABILITY_IDENTITY.md`,
+`PHASE20_CAPABILITY_MANIFEST_SCHEMA.md`,
+`PHASE20_CAPABILITY_LIFECYCLE.md`,
+`PHASE20_REGISTRY_MODEL.md`,
+`PHASE20_REGISTRY_GOVERNANCE.md`,
+`PHASE20_TRUST_MODEL.md`,
+`PHASE20_DISTRIBUTION_POLICY.md`,
+`PHASE20_CAPABILITY_EVIDENCE_MODEL.md`,
+`PHASE20_CAPABILITY_ACCEPTANCE_WORKFLOW.md`,
+`PHASE20_IMPLEMENTATION_DECISION.md`,
+`PHASE20_IMPLEMENTATION_SLICE.md`,
+`PHASE20_IMPLEMENTATION_REVIEW.md`,
+`PHASE20_IMPLEMENTATION_ACCEPTANCE_DECISION.md`,
+`PHASE20_RUNTIME_DECISION.md`,
+`PHASE20_RUNTIME_DECISION_REVIEW.md`, and
+`PHASE20_RUNTIME_ACCEPTANCE_DECISION.md`. In case of conflict, those
+documents prevail unless this runtime activation decision RFC is the
+narrower Phase-20 runtime activation decision record for the exact
+planning scope identified below.
+
+**Status:** PHASE-20 RUNTIME ACTIVATION DECISION RFC / BOUNDED RUNTIME
+ACTIVATION DECISION MODEL ONLY / NO ACTIVATION PROCEDURE / NO LOADER
+PROCEDURE / NO PROCESS START / NO RUNTIME IMPLEMENTATION / NO GENERAL
+RUNTIME AUTHORITY / NO UNBOUNDED EXECUTION AUTHORITY / NO PACKAGE
+AUTHORITY / NO PACKAGE INSTALLATION / NO PACKAGE LOADING / NO PACKAGE
+EXECUTION / NO DEPLOYMENT / NO CAPABILITY ISSUANCE / NO TRUST ASSIGNMENT
+/ NO REGISTRY PUBLICATION / NO DISTRIBUTION AUTHORITY / NO SOURCE MERGE
+AUTHORITY / NO SOURCE ACCEPTANCE
+**Runtime activation decision date:** 2026-06-30
+**Runtime activation decision id:** `ayken.phase20.runtime_activation_decision.v1`
+**Runtime activation decision base main SHA:** `82efaa8dbdf04e6d3b1f43aac40d51d250cfc4c2`
+**Reviewed runtime acceptance decision SHA:** `82efaa8dbdf04e6d3b1f43aac40d51d250cfc4c2`
+**Current phase pointer:** `CURRENT_PHASE=20`
+**Authority boundary:** Bounded runtime activation decision model only;
+not activation procedure, not loader procedure, not process start, not
+runtime implementation, not general runtime authority, not unbounded
+execution authority, not package authority, not package installation,
+not package loading, not package execution, not deployment, not source
+acceptance, not source merge authority, not source repository authority,
+not module loading, not workspace runtime, not plugin loading, not
+capability token minting, not capability issuance, not trust assignment,
+not trust issuer authority, not registry authority, not registry
+publication, not publication authority, not distribution authority, not
+distribution execution, not Semantic CLI authority, not AI Runtime
+authority, not agent authority, not syscall expansion, not kernel ABI
+expansion, not workflow-threshold, baseline, dependency, or Ring0
+authority.
+
+## Purpose
+
+`PHASE20_RUNTIME_ACTIVATION_DECISION.md` defines how a bounded runtime
+activation consideration may be evaluated after an exact Runtime
+Acceptance Decision record.
+
+It answers one question:
+
+```text
+How may a bounded runtime activation consideration be evaluated after an
+exact Runtime Acceptance Decision record?
+```
+
+It does not answer:
+
+```text
+How is code executed?
+How is a package installed, loaded, executed, deployed, or distributed?
+How is a module loaded?
+How is a plugin instantiated?
+How is a process started?
+How is runtime state created?
+How is a capability issued?
+How is trust assigned?
+How is a registry entry published?
+```
+
+Those questions belong to later reviewed RFCs or decision paths, if ever
+authorized.
+
+## Core Rule
+
+```text
+runtime activation decision != activation procedure
+runtime activation decision != loader procedure
+runtime activation decision != process start
+runtime activation decision != runtime implementation
+runtime activation decision != deployment
+runtime activation decision != general runtime authority
+runtime activation decision != unbounded execution authority
+runtime activation decision != package execution
+runtime activation decision != package loading
+runtime activation decision != module loading
+runtime activation decision != plugin loading
+runtime activation decision != workspace runtime
+runtime activation decision != capability issuance
+runtime activation decision != registry publication
+runtime activation decision != trust assignment
+runtime activation decision != source merge
+runtime accepted != runtime activated
+activation decision record != runtime state
+activation decision record != execution handle
+activation consideration != package execution by implication
+activation consideration != capability issuance by implication
+```
+
+Runtime Activation Decision consumes the exact Runtime Acceptance
+Decision record.
+
+Runtime Activation Decision may evaluate bounded runtime activation
+consideration as a governance question only.
+
+Runtime Activation Decision may record bounded activation governance
+consideration.
+
+Runtime Activation Decision does not define how runtime activation is
+implemented.
+
+Runtime Activation Decision does not grant general runtime authority.
+
+Runtime Activation Decision does not grant unbounded execution authority.
+
+Runtime Activation Decision does not expand Slice scope.
+
+Runtime Activation Decision does not broaden Phase-19 runtime authority.
+
+Runtime Activation Decision does not start code, load packages,
+instantiate plugins, create runtime state, issue capabilities, publish
+registry entries, or assign trust.
+
+Runtime Activation Decision does not grant package execution, capability
+issuance, registry publication, trust assignment, distribution authority,
+source merge authority, or deployment authority by implication.
+
+Unknown authority readings fail closed.
+
+## Runtime Activation Decision Mission
+
+The mission of the Phase-20 runtime activation decision model is to
+define an explicit, auditable governance decision path for bounded
+runtime activation consideration after an exact Runtime Acceptance
+Decision record.
+
+Runtime activation decision exists so later RFCs can reason about:
+
+1. Runtime activation decision subjects.
+2. Exact Runtime Acceptance Decision record prerequisites.
+3. Accepted bounded runtime authority consideration proposal binding.
+4. Bounded runtime activation consideration.
+5. Runtime activation decision identity.
+6. Decision input sets.
+7. Activation boundaries.
+8. Runtime implementation boundaries.
+9. Decision records and outcomes.
+10. Phase-19 runtime authority preservation.
+11. Post-decision exact-SHA verification.
+12. Later runtime implementation paths, if ever authorized.
+
+The runtime activation decision model itself grants no activation
+procedure, loader procedure, process start, runtime implementation,
+general runtime authority, unbounded execution authority, package
+authority, deployment, distribution, trust, registry, source merge, or
+capability issuance authority.
+
+Each later use requires its own reviewed RFC or decision path.
+
+## Runtime Activation Decision Definition
+
+Runtime activation decision is a governance decision record that
+evaluates bounded runtime activation consideration after an exact Runtime
+Acceptance Decision record.
+
+A runtime activation decision may describe:
+
+1. The exact runtime activation decision subject.
+2. The exact Runtime Acceptance Decision record.
+3. The exact accepted bounded runtime authority consideration proposal.
+4. The exact Runtime Decision Review record.
+5. The exact Runtime Decision record.
+6. The bounded runtime activation consideration.
+7. Exact denied activation, execution, loader, package, state, and
+   implementation readings.
+8. Decision input records.
+9. Decision result.
+10. Post-decision verification requirements.
+11. Later runtime implementation dependency, if ever authorized.
+12. Non-authorization notice.
+
+A runtime activation decision is not activation procedure, loader
+procedure, process start, runtime implementation, general runtime
+authority, unbounded execution authority, package installation, package
+loading, package execution, module loading, plugin loading, workspace
+runtime, deployment, capability issuance, registry publication,
+distribution authority, trust assignment, source acceptance, source merge
+authority, or Semantic CLI, AI Runtime, or agent authority.
+
+## Runtime Activation Decision Scope
+
+This RFC defines only the bounded runtime activation decision model.
+
+It does not define activation procedure, runtime implementation, code
+execution, process start, runtime state creation, package installation,
+package loading, package execution, module loading, plugin loading,
+workspace runtime, deployment behavior, registry publication,
+distribution execution, trust assignment, capability issuance, source
+modification procedure, source acceptance, or source merge procedure.
+
+Runtime activation decision is a governance decision layer. It is not a
+runtime service, execution engine, package manager, installer, loader,
+deployment service, registry publisher, distribution engine, trust
+issuer, capability issuer, source merge engine, or source repository
+authority.
+
+Any activation-procedure-specific, execution-specific, state-specific,
+package-specific, loader-specific, deployment-specific,
+runtime-implementation-specific, publication-specific,
+distribution-specific, trust-specific, capability-issuance-specific, or
+source-merge-specific interpretation fails closed until later reviewed
+RFCs define exact behavior.
+
+## Runtime Activation Decision Subject
+
+A runtime activation decision subject is the exact bounded runtime
+activation consideration being decided after one exact Runtime Acceptance
+Decision record.
+
+A runtime activation decision subject must reference:
+
+1. Exact Runtime Acceptance Decision record.
+2. Exact runtime acceptance decision subject.
+3. Exact runtime acceptance decision result.
+4. Exact accepted bounded runtime authority consideration proposal.
+5. Exact Runtime Decision Review record.
+6. Exact Runtime Decision record.
+7. Exact bounded runtime activation consideration.
+8. Exact reviewed Runtime Acceptance Decision SHA.
+9. Phase-19 runtime authority records used as boundary context.
+10. Governing RFCs.
+11. Non-authorization notice.
+
+Runtime activation decision subject is not activation procedure.
+
+Runtime activation decision subject is not loader procedure, process
+start, runtime implementation, general runtime authority, unbounded
+execution authority, package ownership, package execution, source
+repository ownership, source merge authority, module ownership, plugin
+ownership, registry publication, deployment target, process, workspace
+state, runtime handle, or capability token.
+
+Changing the Runtime Acceptance Decision record, acceptance subject,
+acceptance result, accepted bounded runtime authority consideration
+proposal, Runtime Decision Review record, Runtime Decision record,
+bounded runtime activation consideration, reviewed Runtime Acceptance
+Decision SHA, Phase-19 boundary context, or subject-defining context
+creates a different runtime activation decision subject unless a later
+reviewed RFC defines exact narrower behavior.
+
+## Exact Runtime Acceptance Decision Record Requirement
+
+Runtime activation decision requires an exact Runtime Acceptance Decision
+record.
+
+The reviewed runtime acceptance decision record for this RFC is
+`PHASE20_RUNTIME_ACCEPTANCE_DECISION.md` at exact main SHA
+`82efaa8dbdf04e6d3b1f43aac40d51d250cfc4c2`.
+
+Runtime activation decision must consume the exact reviewed Runtime
+Acceptance Decision record.
+
+Runtime activation decision must never reconstruct Runtime Decision
+scope.
+
+Runtime activation decision must never reinterpret Runtime Decision
+intent.
+
+Runtime activation decision must never broaden Phase-19 runtime
+authority.
+
+Runtime activation decision must never expand Slice scope.
+
+Runtime activation decision must never infer runtime activation when the
+exact runtime acceptance decision result is missing.
+
+Runtime activation decision must never infer activation procedure, loader
+procedure, process start, runtime implementation, package execution, or
+runtime state from a runtime acceptance decision result.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped Runtime Acceptance Decision binding fails closed.
+
+## Accepted Runtime Consideration Requirement
+
+Runtime activation decision may evaluate bounded runtime activation
+consideration only when the exact Runtime Acceptance Decision result is
+`accepted`.
+
+Runtime acceptance result `accepted` is necessary but not sufficient for
+bounded runtime activation consideration.
+
+Runtime acceptance result `accepted` is not runtime activation by
+implication.
+
+Runtime acceptance result `accepted` is not activation procedure.
+
+Runtime acceptance result `accepted` is not execution authority.
+
+Runtime acceptance result `accepted` is not runtime state.
+
+Runtime acceptance decision outcomes or dispositions of `rejected`,
+`quarantined`, `deferred`, or `superseded` must not produce an activation
+decision result that records bounded runtime activation consideration.
+
+Runtime acceptance result ambiguity fails closed.
+
+## Runtime Activation Decision Identity
+
+Runtime activation decision identity distinguishes one runtime activation
+decision record from another.
+
+Runtime activation decision identity is conceptually composed of:
+
+```text
+(runtime_activation_decision_domain, runtime_activation_decision_subject,
+ runtime_acceptance_decision_record,
+ accepted_bounded_runtime_authority_consideration_proposal,
+ bounded_runtime_activation_consideration, decision_binding)
+```
+
+This tuple is conceptual. It is not a source path syntax, source
+ownership claim, package name, module name, crate name, repository
+branch, database schema, command, token, runtime handle, process handle,
+loader key, execution key, merge key, deployment key, or capability key.
+
+Runtime activation decision identity remains stable for the lifetime of
+that decision record. Changing identity-defining decision fields creates
+a different runtime activation decision record unless a later reviewed
+RFC defines exact narrower behavior.
+
+Runtime activation decision identity does not imply activation procedure,
+loader procedure, process start, runtime implementation, general runtime
+authority, package authority, deployment authority, registry publication,
+distribution authority, trust assignment, source merge authority, or
+capability issuance.
+
+## Bounded Runtime Activation Consideration Requirement
+
+Bounded runtime activation consideration is the exact activation question
+that a Runtime Activation Decision may evaluate after an accepted runtime
+authority consideration proposal.
+
+Bounded runtime activation consideration may identify:
+
+1. Exact Runtime Acceptance Decision record.
+2. Exact accepted bounded runtime authority consideration proposal.
+3. Exact Runtime Decision Review record.
+4. Exact Runtime Decision record.
+5. Exact runtime activation boundary being considered.
+6. Exact denied activation, execution, loader, package, state, and
+   implementation readings.
+7. Exact Phase-19 runtime boundary references.
+8. Exact non-authorization notice.
+9. Later runtime implementation dependency, if ever authorized.
+
+Bounded runtime activation consideration is not activation procedure.
+
+Bounded runtime activation consideration is not code execution, process
+start, runtime implementation, runtime state creation, package
+installation, package loading, package execution, module loading, plugin
+loading, workspace runtime, deployment, registry publication, trust
+assignment, distribution execution, source merge authority, or capability
+issuance.
+
+Bounded runtime activation consideration must be exact, auditable, and
+bound to one runtime activation decision subject.
+
+Approximate, inherited, stale, implied, unbounded, or differently scoped
+activation consideration readings fail closed.
+
+## Decision Input Set
+
+A decision input set is the exact set of records considered by one
+runtime activation decision.
+
+A decision input set must include:
+
+1. Exact runtime activation decision subject.
+2. Exact Runtime Acceptance Decision record.
+3. Exact runtime acceptance decision result.
+4. Exact accepted bounded runtime authority consideration proposal.
+5. Exact Runtime Decision Review record.
+6. Exact Runtime Decision record.
+7. Exact bounded runtime activation consideration.
+8. Exact reviewed Runtime Acceptance Decision SHA.
+9. Phase-19 runtime authority boundary references.
+10. Denied activation, execution, loader, package, state, and
+    implementation readings.
+11. Non-authorization notice.
+
+One runtime activation decision evaluates one bounded runtime activation
+consideration for one accepted bounded runtime authority consideration
+proposal from one exact Runtime Acceptance Decision record.
+
+Decision input presence is not activation procedure.
+
+Decision input completeness is not runtime implementation.
+
+Decision input set must not silently include adjacent files, generated
+artifacts, dependency trees, build products, package outputs, runtime
+objects, deployment state, workspace state, process state, runtime
+handles, or capability tokens.
+
+## Exact-SHA Binding
+
+Runtime activation decision is exact-SHA bound.
+
+The conceptual decision chain is:
+
+```text
+Runtime Acceptance Decision Record
+  -> Accepted Bounded Runtime Authority Consideration Proposal
+  -> Bounded Runtime Activation Consideration
+  -> Runtime Activation Decision Record
+  -> later runtime implementation path, if ever authorized
+```
+
+Every arrow is a governance dependency. No arrow implies activation
+procedure, loader procedure, process start, runtime implementation,
+runtime state creation, code execution, package installation, package
+loading, package execution, deployment, distribution, capability
+issuance, registry publication, trust assignment, source acceptance, or
+source merge authority.
+
+Exact-SHA binding may use:
+
+1. Exact reviewed Runtime Acceptance Decision SHA.
+2. Exact Runtime Acceptance Decision record identifier.
+3. Exact accepted bounded runtime authority consideration proposal
+   identifier.
+4. Exact bounded runtime activation consideration identifier.
+5. Exact runtime activation decision record identifier.
+6. Exact runtime activation decision result identifier.
+
+This RFC does not define canonical hash construction, digest algorithm,
+artifact digest format, package digest format, source merge mechanics,
+diff format, runtime identity, process identity, runtime handle format,
+state format, activation procedure format, execution key format, or
+signature format.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped decision binding fails closed.
+
+## Activation Boundary
+
+Activation boundary is the limit of what runtime activation decision may
+decide.
+
+Runtime activation decision may decide whether:
+
+1. Exact Runtime Acceptance Decision record is present.
+2. Exact runtime acceptance decision result is `accepted`.
+3. Accepted bounded runtime authority consideration proposal is exact and
+   stable.
+4. Proposal remains bound to the exact Runtime Decision Review record.
+5. Proposal remains bound to the exact Runtime Decision record.
+6. Bounded runtime activation consideration is exact and stable.
+7. Phase-19 runtime authority boundaries remain preserved.
+8. Runtime Decision scope is not reconstructed.
+9. Runtime Decision intent is not reinterpreted.
+10. Slice scope is not expanded.
+11. Non-authorization notices remain present.
+12. No unexpected activation procedure, loader procedure, process start,
+    runtime implementation, unbounded execution, runtime state, package,
+    deployment, issuance, registry, trust, distribution, source merge,
+    Semantic CLI, AI Runtime, or agent authority reading is introduced.
+
+Runtime activation decision must not decide:
+
+1. Activation procedure.
+2. Loader procedure.
+3. Process start.
+4. Runtime implementation.
+5. General runtime authority.
+6. Unbounded execution authority.
+7. Runtime state creation.
+8. Code execution.
+9. Package installation, loading, execution, scheduling, or publication.
+10. Module loading.
+11. Plugin loading or instantiation.
+12. Workspace runtime or real mounts.
+13. Deployment readiness.
+14. Capability issuance.
+15. Registry publication.
+16. Distribution execution.
+17. Trust assignment.
+18. Source merge authorization.
+19. Source repository state.
+20. Production readiness.
+
+Any decision reading that crosses the activation boundary fails closed.
+
+## Decision Evaluation Model
+
+Runtime activation decision evaluates whether an accepted bounded runtime
+authority consideration proposal may receive a bounded activation
+governance result.
+
+Decision evaluation may compare:
+
+1. Runtime acceptance decision result against required `accepted` result.
+2. Accepted proposal identity against the exact Runtime Acceptance
+   Decision record.
+3. Runtime Decision Review identity against the exact acceptance decision
+   record.
+4. Runtime Decision identity against the exact acceptance decision
+   record.
+5. Bounded runtime activation consideration against the decision input
+   set.
+6. Phase-19 runtime boundary claims against Phase-19 runtime authority
+   records.
+7. Denied activation, execution, loader, package, state, and
+   implementation readings against the proposed consideration.
+8. Non-authorization notices against governing RFCs.
+9. Relationship context against denied authority readings.
+
+Decision evaluation does not reconstruct Runtime Decision scope.
+
+Decision evaluation does not reinterpret Runtime Decision intent.
+
+Decision evaluation does not broaden Phase-19 runtime authority.
+
+Decision evaluation does not expand Slice scope.
+
+Decision evaluation does not define activation procedure.
+
+Decision evaluation does not grant unbounded execution authority.
+
+Decision evaluation does not create runtime state.
+
+Decision output records only a bounded runtime activation decision
+governance result until a later runtime implementation RFC or decision
+path defines separate implementation behavior, if ever authorized.
+
+## Decision Record
+
+A runtime activation decision record records the decision result for
+bounded runtime activation consideration.
+
+Allowed runtime activation decision results are:
+
+1. `bounded_activation_consideration_recorded`
+2. `denied`
+3. `quarantined`
+
+No other runtime activation decision result is defined by this RFC.
+
+A runtime activation decision record must identify the exact runtime
+activation decision subject, exact Runtime Acceptance Decision record,
+exact runtime acceptance decision result, exact accepted bounded runtime
+authority consideration proposal, exact bounded runtime activation
+consideration, exact Phase-19 runtime boundary context, decision result,
+reason for decision, exact-SHA binding, denied activation and
+implementation readings, non-authorization notice, and fail-closed
+handling for later ambiguity.
+
+Runtime activation decision records governance state only.
+
+Runtime activation decision record never starts code, defines activation
+procedure, defines loader procedure, starts a process, implements
+runtime, creates runtime state, installs packages, loads packages,
+executes packages, deploys artifacts, issues capabilities, publishes
+registry entries, assigns trust, accepts source, merges source, or
+authorizes distribution.
+
+## Runtime Activation Outcomes
+
+Runtime activation outcomes are governance outcomes only.
+
+This RFC defines:
+
+| Outcome | Meaning | Authority result |
+|---|---|---|
+| `bounded_activation_consideration_recorded` | Bounded runtime activation consideration is recorded for the exact decision subject | No activation procedure |
+| `denied` | Bounded runtime activation consideration is denied for the exact decision subject | No deletion or revocation by itself |
+| `quarantined` | Activation consideration or decision input is held for unresolved ambiguity, conflict, or safety concern | No authority |
+| `deferred` | Decision is delayed before a runtime activation decision result can be recorded | No activation result |
+| `superseded` | Decision is replaced by a later exact reviewed decision | No inheritance |
+
+`bounded_activation_consideration_recorded`, `denied`, and `quarantined`
+are runtime activation decision results.
+
+`deferred` and `superseded` are decision dispositions. They are not
+runtime activation decision results.
+
+Outcome presence must not be interpreted as activation procedure, loader
+procedure, process start, runtime implementation, execution authority,
+runtime state, trust assignment, registry publication, distribution
+authority, package execution, deployment authority, source merge
+authority, general runtime authority, or capability issuance.
+
+## Explicit Separation
+
+Runtime activation decision concepts do not imply authority-bearing
+runtime outcomes.
+
+| Runtime activation decision concept | Is not |
+|---|---|
+| Bounded activation consideration recorded | Activation procedure |
+| Bounded activation consideration recorded | Process started |
+| Bounded activation consideration recorded | Code executed |
+| Bounded activation consideration recorded | Package executable |
+| Bounded activation consideration recorded | Runtime state created |
+| Bounded activation consideration recorded | Capability issued |
+| Bounded activation consideration recorded | Registry published |
+| Bounded activation consideration recorded | Trust assigned |
+| Runtime accepted | Runtime activated |
+| Activation decision record | Runtime state |
+| Activation decision record | Execution handle |
+
+No concept in this table implies another by default.
+
+Unknown activation, runtime, execution, source, issuance, publication,
+trust, or distribution readings fail closed.
+
+## Decision Disposition Handling
+
+Decision dispositions preserve audit history for denial, quarantine,
+deferral, and supersession.
+
+Denial records that bounded runtime activation consideration was not
+recorded for the exact decision subject. It does not delete history,
+revoke another record, transfer authority to a replacement, establish
+alias or supersession by itself, prove fault by itself, or block later
+resubmission by itself.
+
+Quarantine is the safe decision result for unresolved ambiguity,
+including runtime activation decision subject ambiguity, Runtime
+Acceptance Decision record ambiguity, acceptance result ambiguity,
+accepted proposal ambiguity, bounded runtime activation consideration
+ambiguity, Phase-19 runtime boundary conflict, denied-reading concern,
+missing decision prerequisite, or incompatible interpretation across
+governing records.
+
+Deferral may record that later information is required before a runtime
+activation decision result can be made.
+
+Supersession may record that a later exact runtime activation decision
+replaces the current decision for decision purposes. Supersession
+inheritance is denied unless a later reviewed RFC defines exact narrower
+behavior.
+
+No disposition starts code, defines activation procedure, defines loader
+procedure, starts a process, implements runtime, creates runtime state,
+accepts source, merges source, assigns trust, publishes registry entries,
+authorizes distribution, issues capabilities, deploys artifacts,
+installs packages, loads packages, or executes packages.
+
+## Phase-19 Runtime Authority Relationship
+
+Phase-20 Runtime Activation Decision consumes Phase-20 Runtime Acceptance
+Decision context and remains subordinate to Phase-19 runtime authority
+records.
+
+Phase-19 runtime records may be read as boundary context for:
+
+1. Runtime MVP planning boundaries.
+2. Runtime evidence expectations.
+3. Runtime non-goals and denials.
+4. Platform runtime constitutional constraints.
+5. Userspace-only runtime constraints.
+6. Frozen syscall and kernel ABI boundaries.
+7. Denied package, module, workspace, plugin, trust, capability, AI
+   Runtime, Semantic CLI, and agent authority readings.
+
+Phase-20 Runtime Activation Decision must not broaden, replace,
+supersede, weaken, or reinterpret Phase-19 runtime authority records.
+
+Phase-20 Runtime Activation Decision must not use an activation decision
+result to infer Phase-19 runtime authority.
+
+Any Phase-20 runtime activation decision reading that conflicts with
+Phase-19 runtime authority records fails closed.
+
+## Post-Decision Exact-SHA Verification
+
+Post-decision exact-SHA verification is a governance verification step
+after a runtime activation decision record has been recorded.
+
+The conceptual verification path is:
+
+```text
+runtime_acceptance_decision
+  -> runtime_activation_decision
+  -> exact_runtime_activation_decision_sha
+  -> post_runtime_activation_decision_verification
+  -> later_runtime_implementation_input_if_authorized
+```
+
+Every arrow is a governance dependency. No arrow implies activation
+procedure, loader procedure, process start, runtime implementation,
+execution authority, runtime state, code execution, package execution,
+deployment, distribution, capability issuance, registry publication,
+trust assignment, source acceptance, or source merge authority.
+
+Post-decision verification may confirm the exact runtime activation
+decision record SHA, exact Runtime Acceptance Decision record, exact
+accepted bounded runtime authority consideration proposal, exact bounded
+runtime activation consideration, expected non-authorization notices,
+expected governance check results, expected Phase-19 runtime boundary
+preservation, and no unexpected activation or authority expansion.
+
+Post-decision verification result is not activation procedure.
+
+Post-decision verification result is not execution authority.
+
+Post-decision verification result is not runtime state.
+
+Post-decision verification records exact-SHA verification only. It never
+records activation procedure, execution authority, runtime
+implementation, or runtime state.
+
+## Relationship Boundaries
+
+Runtime activation decision may consume prior Phase-20 and Phase-19
+governance records as decision context only.
+
+| Previous record | Accepted reading | Denied reading |
+|---|---|---|
+| `PHASE20_RUNTIME_ACCEPTANCE_DECISION.md` | Exact acceptance decision record and `accepted` result as decision prerequisite | Runtime accepted is not runtime activated by implication |
+| `PHASE20_RUNTIME_DECISION_REVIEW.md` | Exact review record and `conforms` result as context through acceptance decision | Review result `conforms` is not activation authority |
+| `PHASE20_RUNTIME_DECISION.md` | Exact Runtime Decision record, Runtime Decision Subject, Runtime Decision Identity, and bounded runtime authority consideration as context | Runtime Decision does not activate runtime or grant execution authority |
+| `PHASE20_IMPLEMENTATION_ACCEPTANCE_DECISION.md` | Exact acceptance decision record and `accepted` result as context through Runtime Decision | Implementation accepted is not runtime enabled |
+| `PHASE20_IMPLEMENTATION_REVIEW.md` | Exact review record as context through acceptance decision | Review result is not runtime authority |
+| `PHASE20_IMPLEMENTATION_SLICE.md` | Exact Slice record, Slice Identity, and Bounded Source Scope as context | Slice scope is never reconstructed, expanded, or reinterpreted |
+| `PHASE20_IMPLEMENTATION_DECISION.md` | Eligible decision record as prerequisite context | Eligibility is not runtime authority |
+| `PHASE20_CAPABILITY_ACCEPTANCE_WORKFLOW.md` | Accepted workflow subject and acceptance decision record as context | Accepted workflow subject is not runtime enabled |
+| `PHASE20_CAPABILITY_EVIDENCE_MODEL.md` | Accepted evidence through acceptance workflow context | Accepted evidence is not runtime proof |
+| `PHASE20_REGISTRY_MODEL.md` and `PHASE20_REGISTRY_GOVERNANCE.md` | Registry context for subject consistency | Registry context is not publication, issuance, runtime activation, or runtime authority |
+| `PHASE20_TRUST_MODEL.md` | Trust context for decision context | Trust context is not trust assignment or runtime authority |
+| `PHASE20_DISTRIBUTION_POLICY.md` | Distribution policy context for decision context | Distribution eligibility is not distribution execution or runtime authority |
+| `PHASE19_RUNTIME_DECISION.md` and Phase-19 Runtime RFC set | Runtime boundary context and denied readings | Runtime Activation Decision does not broaden or replace Phase-19 runtime authority |
+
+Runtime activation decision does not modify prior governance records.
+
+Runtime activation decision does not modify Runtime Acceptance Decision
+records.
+
+Runtime activation decision does not modify Runtime Decision Review
+records.
+
+Runtime activation decision does not modify Runtime Decision records.
+
+Runtime activation decision does not modify implementation acceptance
+decision records.
+
+Runtime activation decision does not modify review records.
+
+Runtime activation decision does not modify Slice scope.
+
+Runtime activation decision does not modify acceptance state.
+
+Runtime activation decision does not modify evidence records.
+
+Runtime activation decision does not modify Phase-19 runtime authority
+records.
+
+Ambiguous, stale, inherited, unaccepted, or differently scoped
+relationship material fails closed for runtime activation decision.
+
+## Runtime Implementation Boundary
+
+Runtime activation decision may record bounded activation governance
+consideration.
+
+Runtime activation decision does not define how runtime activation is
+implemented.
+
+Runtime activation decision does not start code, load packages,
+instantiate plugins, create runtime state, issue capabilities, publish
+registry entries, or assign trust.
+
+Runtime activation decision does not define an execution path, process
+lifecycle, scheduler behavior, loader behavior, package manager behavior,
+module loader behavior, plugin host behavior, workspace mount behavior,
+runtime state storage, activation API, runtime handle format, execution
+handle format, or capability token format.
+
+A later runtime implementation RFC or decision path, if ever authorized,
+must define exact implementation subject, exact Runtime Activation
+Decision record, exact bounded activation consideration, exact allowed
+implementation behavior, exact denied implementation behavior, exact
+runtime boundary, exact execution boundary, exact runtime state boundary,
+package, loader, deployment, issuance, publication, trust, distribution,
+source, Semantic CLI, AI Runtime, agent, syscall, kernel ABI, and Ring0
+denials, required implementation review path, required post-
+implementation verification, and non-authorization notice for anything
+outside scope.
+
+Until such a reviewed runtime implementation RFC or decision path exists,
+runtime implementation remains denied.
+
+## Decision Validation Model
+
+Runtime activation decision validation is conceptual and fail-closed.
+
+Decision validation must never define activation procedure.
+
+Decision validation must never define loader procedure.
+
+Decision validation must never start a process.
+
+Decision validation must never implement runtime behavior.
+
+Decision validation must never grant unbounded execution authority.
+
+Decision validation must never create runtime state.
+
+Decision validation must never reconstruct Runtime Decision scope.
+
+Decision validation must never reinterpret Runtime Decision intent.
+
+Decision validation must never broaden Phase-19 runtime authority.
+
+Decision validation must never expand Slice scope.
+
+Decision validation must never infer missing acceptance material.
+
+Runtime activation decision material is invalid for governance review
+when:
+
+1. Runtime activation decision subject is missing or ambiguous.
+2. Runtime activation decision identity is missing or ambiguous.
+3. Exact Runtime Acceptance Decision record is missing, stale, ambiguous,
+   inherited, or differently scoped.
+4. Reviewed Runtime Acceptance Decision SHA is missing or ambiguous.
+5. Runtime acceptance decision result is missing, ambiguous, or not
+   `accepted` for `bounded_activation_consideration_recorded`.
+6. Accepted bounded runtime authority consideration proposal is missing
+   or ambiguous.
+7. Bounded runtime activation consideration is missing or ambiguous.
+8. Decision input set is missing or ambiguous.
+9. Runtime Decision record is missing, stale, ambiguous, inherited, or
+   differently scoped.
+10. Runtime Decision scope is reconstructed.
+11. Runtime Decision intent is reinterpreted.
+12. Phase-19 runtime authority is broadened, weakened, replaced,
+    superseded, or reinterpreted.
+13. Slice scope is expanded.
+14. Runtime acceptance result `accepted` is treated as runtime activation
+    by implication.
+15. Decision result is treated as activation procedure.
+16. Decision result is treated as loader procedure.
+17. Decision result is treated as process start.
+18. Decision result is treated as runtime implementation.
+19. Decision result is treated as unbounded execution authority.
+20. Decision result is treated as runtime state creation.
+21. Decision result is treated as package execution authority.
+22. Decision result is treated as registry publication.
+23. Decision result is treated as trust assignment.
+24. Decision result is treated as capability issuance.
+25. Decision material depends on runtime-observed state.
+26. Decision material relies on alias or supersession without accepted
+    rules.
+27. Decision material implies source merge authority.
+28. Decision material implies general runtime authority.
+29. Decision material implies Semantic CLI, AI Runtime, or agent
+    authority.
+
+Validation failure grants no authority. It requires correction, denial,
+deferral, quarantine, supersession, dispute recording, or a later
+reviewed decision path.
+
+Runtime activation decision validation is not activation procedure.
+
+Validation produces only a validation result.
+
+Validation never produces activation procedure, loader procedure, process
+start, runtime implementation, unbounded execution authority, runtime
+state, package authority, deployment authority, source authority, merge
+authority, trust assignment, registry publication, distribution
+authority, or capability issuance.
+
+## Runtime Activation Decision Invariants
+
+Every later Phase-20 RFC must preserve these runtime activation decision
+invariants:
+
+1. Runtime Activation Decision consumes the exact Runtime Acceptance
+   Decision record.
+2. Runtime Activation Decision requires exact runtime acceptance result
+   binding.
+3. Runtime Activation Decision may evaluate bounded runtime activation
+   consideration only after runtime acceptance result `accepted`.
+4. Runtime acceptance result `accepted` is necessary but not sufficient
+   for bounded runtime activation consideration.
+5. Runtime accepted is not runtime activated by implication.
+6. Runtime Activation Decision may record bounded activation governance
+   consideration.
+7. Runtime Activation Decision does not define activation procedure.
+8. Runtime Activation Decision does not define loader procedure.
+9. Runtime Activation Decision does not start a process.
+10. Runtime Activation Decision does not implement runtime behavior.
+11. Runtime Activation Decision does not grant general runtime authority.
+12. Runtime Activation Decision does not grant unbounded execution
+    authority.
+13. Runtime Activation Decision does not create runtime state.
+14. Runtime Activation Decision does not reconstruct Runtime Decision
+    scope.
+15. Runtime Activation Decision does not reinterpret Runtime Decision
+    intent.
+16. Runtime Activation Decision does not broaden Phase-19 runtime
+    authority.
+17. Runtime Activation Decision does not expand Slice scope.
+18. Activation decision record is not runtime state.
+19. Activation decision record is not execution handle.
+20. Activation consideration is not package execution by implication.
+21. Runtime Activation Decision does not grant package installation.
+22. Runtime Activation Decision does not grant package loading.
+23. Runtime Activation Decision does not grant package execution.
+24. Runtime Activation Decision does not grant module loading.
+25. Runtime Activation Decision does not grant plugin loading.
+26. Runtime Activation Decision does not grant deployment authority.
+27. Runtime Activation Decision does not grant registry publication.
+28. Runtime Activation Decision does not grant trust assignment.
+29. Runtime Activation Decision does not grant distribution authority.
+30. Runtime Activation Decision does not grant capability issuance.
+31. Runtime Activation Decision does not grant source merge authority.
+32. One runtime activation decision evaluates one bounded runtime
+    activation consideration for one accepted bounded runtime authority
+    consideration proposal.
+33. Runtime Activation Decision does not modify prior governance records.
+34. Later runtime implementation requires separate governance review, if
+    ever authorized.
+35. Post-decision verification result is not activation procedure.
+36. Post-decision verification result is not execution authority.
+37. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Later RFC Dependencies
+
+The runtime activation decision model is a prerequisite for later
+Phase-20 runtime implementation paths only if separate runtime
+implementation authority is ever reviewed and authorized.
+
+| Later record | Runtime activation decision relationship |
+|---|---|
+| Later reviewed runtime implementation RFC or decision path, if ever authorized | May consider runtime implementation only after separate reviewed implementation authority and exact Runtime Activation Decision binding. |
+
+Later RFCs may narrow runtime activation decision use. They must not
+broaden this decision model into activation procedure, loader procedure,
+process start, runtime implementation, general runtime authority,
+unbounded execution authority, runtime state, package installation,
+package loading, package execution, module loading, plugin loading,
+deployment, trust assignment, registry publication, distribution
+authority, capability issuance, source merge authority, Semantic CLI
+authority, AI Runtime authority, agent authority, syscall expansion,
+kernel ABI expansion, or Ring0 authority without a separate reviewed
+decision.
+
+Runtime Activation Decision is the Phase-20 RFC in this chain that
+records bounded activation governance consideration for accepted bounded
+runtime authority consideration proposals.
+
+Runtime Activation Decision does not define runtime implementation.
+
+The current Phase-20 dependency chain is:
+
+```text
+Capability Model
+  -> Capability Identity
+  -> Capability Manifest Schema
+  -> Capability Lifecycle
+  -> Registry Model
+  -> Registry Governance
+  -> Trust Model
+  -> Distribution Policy
+  -> Capability Evidence Model
+  -> Capability Acceptance Workflow
+  -> Implementation Decision
+  -> Implementation Slice
+  -> Implementation Review
+  -> Implementation Acceptance Decision
+  -> Runtime Decision
+  -> Runtime Decision Review
+  -> Runtime Acceptance Decision
+  -> Runtime Activation Decision
+  -> Runtime Implementation
+```
+
+Every arrow means a governance dependency. It does not imply activation
+procedure, loader procedure, process start, runtime implementation,
+source merge authority, publication, distribution, installation, loading,
+execution, issuance, deployment, runtime state, or general runtime
+authority.
+
+Every dependency is explicit.
+
+No dependency is implied.
+
+Each RFC defines only its own layer. No RFC produces the authority of the
+next layer.
+
+## Explicit Non-Authorization
+
+This runtime activation decision RFC does not authorize:
+
+1. Activation procedure.
+2. Loader procedure.
+3. Process start.
+4. Runtime implementation.
+5. General runtime authority.
+6. Unbounded execution authority.
+7. Runtime state creation.
+8. Code execution.
+9. Package installation, loading, execution, scheduling, or publication.
+10. Module loading.
+11. Workspace creation, workspace runtime, or real mounts.
+12. Plugin host, plugin loading, or plugin instantiation.
+13. Deployment behavior.
+14. Capability token minting or capability issuance.
+15. Trust assignment.
+16. Trust issuer authority.
+17. Registry authority.
+18. Registry publication.
+19. Publication authority.
+20. Distribution authority.
+21. Distribution execution.
+22. Source acceptance or source merge authority.
+23. Source repository authority.
+24. Semantic CLI execution or verdict authority.
+25. AI Runtime authority.
+26. Agent behavior.
+27. New syscalls.
+28. Kernel ABI expansion.
+29. Workflow-threshold, baseline, dependency, or Ring0 policy changes.
+30. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-20 RFC
+**Architecture status:** Draft RFC / pending architectural review
+**Authority notice:** This signature identifies the architectural
+authorship of this RFC. It grants no activation procedure authority,
+loader procedure authority, process start authority, runtime
+implementation authority, general runtime authority, unbounded execution
+authority, runtime state authority, implementation authority,
+implementation approval authority, source merge authority, trust
+authority, evidence authority, acceptance authority, proof authority,
+constitutional authority, registry authority, distribution authority,
+publication authority, capability issuance authority, package authority,
+deployment authority, module authority, plugin authority, Semantic CLI
+authority, AI Runtime authority, agent authority, or Ring0 authority.
+
+## Non-Goals
+
+This document does not define or authorize:
+
+1. Activation procedure.
+2. Loader procedure.
+3. Process start.
+4. Runtime implementation or general runtime authority.
+5. Unbounded execution authority.
+6. Runtime state creation.
+7. Code execution.
+8. Package format, repository, installation, loading, or execution.
+9. Deployment behavior.
+10. Artifact storage or binary format.
+11. Module loading.
+12. Workspace creation, workspace runtime, or real mounts.
+13. Plugin host, plugin loading, or plugin instantiation.
+14. Capability token minting or capability issuance.
+15. Trust assignment or trust issuer authority.
+16. Registry authority or registry publication.
+17. Publication workflow or publication approval.
+18. Distribution authority or distribution execution.
+19. Source acceptance or source merge authority.
+20. Source repository authority.
+21. Repository branch protection.
+22. Proof verification, signature verification, or signature acceptance.
+23. Semantic CLI execution or verdict authority.
+24. AI Runtime authority.
+25. Agent behavior.
+26. New syscalls.
+27. Kernel ABI expansion.
+28. Workflow-threshold, baseline, dependency, or Ring0 policy changes.


### PR DESCRIPTION
This PR adds the Phase-20 runtime activation decision RFC.

The RFC defines a bounded runtime activation decision model for evaluating bounded runtime activation consideration after an exact Runtime Acceptance Decision record.

It is bound to the exact PHASE20_RUNTIME_ACCEPTANCE_DECISION.md record published at:
82efaa8dbdf04e6d3b1f43aac40d51d250cfc4c2

It preserves:
- exact Runtime Acceptance Decision record binding
- runtime accepted is not runtime activated
- no activation procedure
- no loader procedure
- no process start
- no runtime implementation
- no general runtime authority
- no unbounded execution authority
- no runtime state creation
- no package installation/loading/execution
- no module/plugin loading
- no deployment
- no capability issuance
- no registry publication
- no trust assignment
- no source merge authority
- no Phase-19 runtime authority broadening
- no Slice scope expansion
- no Semantic CLI / AI Runtime / agent authority

This PR changes only PHASE20_RUNTIME_ACTIVATION_DECISION.md.