### PR TITLE
Phase-20 runtime implementation decision RFC

### DIFF
--- a/PHASE20_RUNTIME_IMPLEMENTATION_DECISION.md
+++ b/PHASE20_RUNTIME_IMPLEMENTATION_DECISION.md
@@ -1,0 +1,1195 @@
+# Phase-20 Runtime Implementation Decision
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE20_POINTER_TRANSITION_DECISION.md`,
+`PHASE20_GOVERNANCE_OVERVIEW.md`,
+`PHASE20_CAPABILITY_MODEL.md`,
+`PHASE20_CAPABILITY_IDENTITY.md`,
+`PHASE20_CAPABILITY_MANIFEST_SCHEMA.md`,
+`PHASE20_CAPABILITY_LIFECYCLE.md`,
+`PHASE20_REGISTRY_MODEL.md`,
+`PHASE20_REGISTRY_GOVERNANCE.md`,
+`PHASE20_TRUST_MODEL.md`,
+`PHASE20_DISTRIBUTION_POLICY.md`,
+`PHASE20_CAPABILITY_EVIDENCE_MODEL.md`,
+`PHASE20_CAPABILITY_ACCEPTANCE_WORKFLOW.md`,
+`PHASE20_IMPLEMENTATION_DECISION.md`,
+`PHASE20_IMPLEMENTATION_SLICE.md`,
+`PHASE20_IMPLEMENTATION_REVIEW.md`,
+`PHASE20_IMPLEMENTATION_ACCEPTANCE_DECISION.md`,
+`PHASE20_RUNTIME_DECISION.md`,
+`PHASE20_RUNTIME_DECISION_REVIEW.md`,
+`PHASE20_RUNTIME_ACCEPTANCE_DECISION.md`, and
+`PHASE20_RUNTIME_ACTIVATION_DECISION.md`. In case of conflict, those
+documents prevail unless this runtime implementation decision RFC is the
+narrower Phase-20 runtime implementation decision record for the exact
+planning scope identified below.
+
+**Status:** PHASE-20 RUNTIME IMPLEMENTATION DECISION RFC / BOUNDED RUNTIME
+IMPLEMENTATION DECISION MODEL ONLY / NO RUNTIME IMPLEMENTATION PROCEDURE /
+NO SOURCE MODIFICATION / NO CODE IMPLEMENTATION / NO CODE EXECUTION / NO
+PROCESS START / NO RUNTIME STATE CREATION / NO PACKAGE AUTHORITY / NO
+PACKAGE INSTALLATION / NO PACKAGE LOADING / NO PACKAGE EXECUTION / NO
+DEPLOYMENT / NO CAPABILITY ISSUANCE / NO TRUST ASSIGNMENT / NO REGISTRY
+PUBLICATION / NO DISTRIBUTION AUTHORITY / NO SOURCE MERGE AUTHORITY / NO
+SOURCE ACCEPTANCE
+**Runtime implementation decision date:** 2026-07-01
+**Runtime implementation decision id:** `ayken.phase20.runtime_implementation_decision.v1`
+**Runtime implementation decision base main SHA:** `d433f1405d3abb62af69f9ff3a111592571ef18d`
+**Reviewed runtime activation decision SHA:** `d433f1405d3abb62af69f9ff3a111592571ef18d`
+**Current phase pointer:** `CURRENT_PHASE=20`
+**Authority boundary:** Bounded runtime implementation decision model
+only; not runtime implementation procedure, not source modification, not
+code implementation, not code execution, not process start, not runtime
+state creation, not general runtime authority, not unbounded execution
+authority, not package authority, not package installation, not package
+loading, not package execution, not deployment, not source acceptance,
+not source merge authority, not source repository authority, not module
+loading, not workspace runtime, not plugin loading, not capability token
+minting, not capability issuance, not trust assignment, not trust issuer
+authority, not registry authority, not registry publication, not
+publication authority, not distribution authority, not distribution
+execution, not Semantic CLI authority, not AI Runtime authority, not
+agent authority, not syscall expansion, not kernel ABI expansion, not
+workflow-threshold, baseline, dependency, or Ring0 authority.
+
+## Purpose
+
+`PHASE20_RUNTIME_IMPLEMENTATION_DECISION.md` defines how bounded runtime
+implementation consideration may be evaluated after an exact Runtime
+Activation Decision record.
+
+It answers one question:
+
+```text
+How may bounded runtime implementation consideration be evaluated after
+an exact Runtime Activation Decision record?
+```
+
+It does not answer:
+
+```text
+How is code implemented?
+How is code executed?
+How is a package installed, loaded, executed, deployed, or distributed?
+How is a process started?
+How is runtime state created?
+How is a module loaded?
+How is a plugin instantiated?
+How is a capability issued?
+How is trust assigned?
+How is a registry entry published?
+```
+
+Those questions belong to later reviewed RFCs or decision paths, if ever
+authorized.
+
+## Core Rule
+
+```text
+runtime implementation decision != runtime implementation procedure
+runtime implementation decision != source modification
+runtime implementation decision != code implementation
+runtime implementation decision != code execution
+runtime implementation decision != process start
+runtime implementation decision != runtime state creation
+runtime implementation decision != general runtime authority
+runtime implementation decision != unbounded execution authority
+runtime implementation decision != package loading
+runtime implementation decision != package execution
+runtime implementation decision != module loading
+runtime implementation decision != plugin loading
+runtime implementation decision != workspace runtime
+runtime implementation decision != deployment
+runtime implementation decision != capability issuance
+runtime implementation decision != registry publication
+runtime implementation decision != trust assignment
+runtime implementation decision != source merge
+runtime activation consideration recorded != runtime implemented
+runtime implementation decision record != runtime state
+runtime implementation decision record != execution handle
+implementation consideration != package loading by implication
+implementation consideration != package execution by implication
+implementation consideration != capability issuance by implication
+```
+
+Runtime Implementation Decision consumes the exact Runtime Activation
+Decision record.
+
+Runtime Implementation Decision may evaluate bounded runtime
+implementation consideration as a governance question only.
+
+Runtime Implementation Decision may record bounded runtime implementation
+governance consideration.
+
+Runtime Implementation Decision does not implement runtime behavior by
+itself.
+
+Runtime Implementation Decision does not start code.
+
+Runtime Implementation Decision does not create runtime state.
+
+Runtime Implementation Decision does not load or execute packages.
+
+Runtime Implementation Decision does not issue capabilities.
+
+Runtime Implementation Decision does not publish registry entries.
+
+Runtime Implementation Decision does not assign trust.
+
+Runtime Implementation Decision does not broaden Phase-19 runtime
+authority.
+
+Runtime Implementation Decision does not expand Slice scope.
+
+Runtime Implementation Decision does not grant package loading, package
+execution, capability issuance, registry publication, trust assignment,
+distribution authority, source merge authority, or deployment authority
+by implication.
+
+Unknown authority readings fail closed.
+
+## Runtime Implementation Decision Mission
+
+The mission of the Phase-20 runtime implementation decision model is to
+define an explicit, auditable governance decision path for bounded
+runtime implementation consideration after an exact Runtime Activation
+Decision record.
+
+Runtime implementation decision exists so later RFCs can reason about:
+
+1. Runtime implementation decision subjects.
+2. Exact Runtime Activation Decision record prerequisites.
+3. Bounded activation governance consideration binding.
+4. Bounded runtime implementation consideration.
+5. Runtime implementation decision identity.
+6. Decision input sets.
+7. Implementation consideration boundaries.
+8. Runtime behavior boundaries.
+9. Decision records and outcomes.
+10. Phase-19 runtime authority preservation.
+11. Post-decision exact-SHA verification.
+12. Later runtime implementation review or procedure paths, if ever
+    authorized.
+
+The runtime implementation decision model itself grants no runtime
+implementation procedure, source modification, code implementation, code
+execution, process start, runtime state creation, general runtime
+authority, unbounded execution authority, package authority, deployment,
+distribution, trust, registry, source merge, or capability issuance
+authority.
+
+Each later use requires its own reviewed RFC or decision path.
+
+## Runtime Implementation Decision Definition
+
+Runtime implementation decision is a governance decision record that
+evaluates bounded runtime implementation consideration after an exact
+Runtime Activation Decision record.
+
+A runtime implementation decision may describe:
+
+1. The exact runtime implementation decision subject.
+2. The exact Runtime Activation Decision record.
+3. The exact bounded activation governance consideration.
+4. The exact Runtime Acceptance Decision record.
+5. The exact Runtime Decision Review record.
+6. The exact Runtime Decision record.
+7. The bounded runtime implementation consideration.
+8. Exact denied implementation, source, execution, loader, package,
+   state, and behavior readings.
+9. Decision input records.
+10. Decision result.
+11. Post-decision verification requirements.
+12. Later runtime implementation review or procedure dependency, if ever
+    authorized.
+13. Non-authorization notice.
+
+A runtime implementation decision is not runtime implementation
+procedure, source modification, code implementation, code execution,
+process start, runtime state creation, general runtime authority,
+unbounded execution authority, package installation, package loading,
+package execution, module loading, plugin loading, workspace runtime,
+deployment, capability issuance, registry publication, distribution
+authority, trust assignment, source acceptance, source merge authority,
+or Semantic CLI, AI Runtime, or agent authority.
+
+## Runtime Implementation Decision Scope
+
+This RFC defines only the bounded runtime implementation decision model.
+
+It does not define runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, module loading, plugin loading, workspace runtime, deployment
+behavior, registry publication, distribution execution, trust
+assignment, capability issuance, source acceptance, or source merge
+procedure.
+
+Runtime implementation decision is a governance decision layer. It is
+not a runtime service, execution engine, package manager, installer,
+loader, deployment service, registry publisher, distribution engine,
+trust issuer, capability issuer, source merge engine, source repository
+authority, or code implementation mechanism.
+
+Any implementation-procedure-specific, source-modification-specific,
+execution-specific, state-specific, package-specific, loader-specific,
+deployment-specific, runtime-behavior-specific, publication-specific,
+distribution-specific, trust-specific, capability-issuance-specific, or
+source-merge-specific interpretation fails closed until later reviewed
+RFCs define exact behavior.
+
+## Runtime Implementation Decision Subject
+
+A runtime implementation decision subject is the exact bounded runtime
+implementation consideration being decided after one exact Runtime
+Activation Decision record.
+
+A runtime implementation decision subject must reference:
+
+1. Exact Runtime Activation Decision record.
+2. Exact runtime activation decision subject.
+3. Exact runtime activation decision result.
+4. Exact bounded activation governance consideration.
+5. Exact Runtime Acceptance Decision record.
+6. Exact Runtime Decision Review record.
+7. Exact Runtime Decision record.
+8. Exact bounded runtime implementation consideration.
+9. Exact reviewed Runtime Activation Decision SHA.
+10. Phase-19 runtime authority records used as boundary context.
+11. Governing RFCs.
+12. Non-authorization notice.
+
+Runtime implementation decision subject is not runtime implementation
+procedure.
+
+Runtime implementation decision subject is not source modification, code
+implementation, code execution, process start, runtime state creation,
+general runtime authority, unbounded execution authority, package
+ownership, package loading, package execution, source repository
+ownership, source merge authority, module ownership, plugin ownership,
+registry publication, deployment target, process, workspace state,
+runtime handle, execution handle, or capability token.
+
+Changing the Runtime Activation Decision record, activation subject,
+activation result, bounded activation governance consideration, Runtime
+Acceptance Decision record, Runtime Decision Review record, Runtime
+Decision record, bounded runtime implementation consideration, reviewed
+Runtime Activation Decision SHA, Phase-19 boundary context, or
+subject-defining context creates a different runtime implementation
+decision subject unless a later reviewed RFC defines exact narrower
+behavior.
+
+## Exact Runtime Activation Decision Record Requirement
+
+Runtime implementation decision requires an exact Runtime Activation
+Decision record.
+
+The reviewed runtime activation decision record for this RFC is
+`PHASE20_RUNTIME_ACTIVATION_DECISION.md` at exact main SHA
+`d433f1405d3abb62af69f9ff3a111592571ef18d`.
+
+Runtime implementation decision must consume the exact reviewed Runtime
+Activation Decision record.
+
+Runtime implementation decision must never reconstruct Runtime Decision
+scope.
+
+Runtime implementation decision must never reinterpret Runtime Decision
+intent.
+
+Runtime implementation decision must never broaden Phase-19 runtime
+authority.
+
+Runtime implementation decision must never expand Slice scope.
+
+Runtime implementation decision must never infer runtime implementation
+when the exact runtime activation decision result is missing.
+
+Runtime implementation decision must never infer source modification,
+code implementation, code execution, process start, runtime state
+creation, package loading, or package execution from a runtime
+activation decision result.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or
+differently scoped Runtime Activation Decision binding fails closed.
+
+## Recorded Activation Consideration Requirement
+
+Runtime implementation decision may evaluate bounded runtime
+implementation consideration only when the exact Runtime Activation
+Decision result is `bounded_activation_consideration_recorded`.
+
+Runtime activation decision result
+`bounded_activation_consideration_recorded` is necessary but not
+sufficient for bounded runtime implementation consideration.
+
+Runtime activation decision result
+`bounded_activation_consideration_recorded` is not runtime
+implementation by implication.
+
+Runtime activation decision result
+`bounded_activation_consideration_recorded` is not runtime
+implementation procedure.
+
+Runtime activation decision result
+`bounded_activation_consideration_recorded` is not code implementation.
+
+Runtime activation decision result
+`bounded_activation_consideration_recorded` is not code execution.
+
+Runtime activation decision result
+`bounded_activation_consideration_recorded` is not runtime state
+creation.
+
+Runtime activation decision outcomes or dispositions of `denied`,
+`quarantined`, `deferred`, or `superseded` must not produce a runtime
+implementation decision result that records bounded runtime
+implementation consideration.
+
+Runtime activation decision result ambiguity fails closed.
+
+## Runtime Implementation Decision Identity
+
+Runtime implementation decision identity distinguishes one runtime
+implementation decision record from another.
+
+Runtime implementation decision identity is conceptually composed of:
+
+```text
+(runtime_implementation_decision_domain,
+ runtime_implementation_decision_subject,
+ runtime_activation_decision_record,
+ bounded_activation_governance_consideration,
+ bounded_runtime_implementation_consideration, decision_binding)
+```
+
+This tuple is conceptual. It is not a source path syntax, source
+ownership claim, package name, module name, crate name, repository
+branch, database schema, command, token, runtime handle, process handle,
+loader key, execution key, merge key, deployment key, or capability key.
+
+Runtime implementation decision identity remains stable for the lifetime
+of that decision record. Changing identity-defining decision fields
+creates a different runtime implementation decision record unless a
+later reviewed RFC defines exact narrower behavior.
+
+Runtime implementation decision identity does not imply runtime
+implementation procedure, source modification, code implementation, code
+execution, process start, runtime state creation, general runtime
+authority, package authority, deployment authority, registry
+publication, distribution authority, trust assignment, source merge
+authority, or capability issuance.
+
+## Bounded Runtime Implementation Consideration Requirement
+
+Bounded runtime implementation consideration is the exact implementation
+question that a Runtime Implementation Decision may evaluate after a
+bounded activation governance consideration has been recorded.
+
+Bounded runtime implementation consideration may identify:
+
+1. Exact Runtime Activation Decision record.
+2. Exact bounded activation governance consideration.
+3. Exact Runtime Acceptance Decision record.
+4. Exact Runtime Decision Review record.
+5. Exact Runtime Decision record.
+6. Exact runtime implementation boundary being considered.
+7. Exact denied source, execution, loader, package, state, behavior, and
+   implementation readings.
+8. Exact Phase-19 runtime boundary references.
+9. Exact non-authorization notice.
+10. Later runtime implementation review or procedure dependency, if ever
+    authorized.
+
+Bounded runtime implementation consideration is not runtime
+implementation procedure.
+
+Bounded runtime implementation consideration is not source modification,
+code implementation, code execution, process start, runtime state
+creation, package installation, package loading, package execution,
+module loading, plugin loading, workspace runtime, deployment, registry
+publication, trust assignment, distribution execution, source merge
+authority, or capability issuance.
+
+Bounded runtime implementation consideration must be exact, auditable,
+and bound to one runtime implementation decision subject.
+
+Approximate, inherited, stale, implied, unbounded, or differently scoped
+implementation consideration readings fail closed.
+
+## Decision Input Set
+
+A decision input set is the exact set of records considered by one
+runtime implementation decision.
+
+A decision input set must include:
+
+1. Exact runtime implementation decision subject.
+2. Exact Runtime Activation Decision record.
+3. Exact runtime activation decision result.
+4. Exact bounded activation governance consideration.
+5. Exact Runtime Acceptance Decision record.
+6. Exact Runtime Decision Review record.
+7. Exact Runtime Decision record.
+8. Exact bounded runtime implementation consideration.
+9. Exact reviewed Runtime Activation Decision SHA.
+10. Phase-19 runtime authority boundary references.
+11. Denied source, execution, loader, package, state, behavior, and
+    implementation readings.
+12. Non-authorization notice.
+
+One runtime implementation decision evaluates one bounded runtime
+implementation consideration for one recorded bounded activation
+governance consideration from one exact Runtime Activation Decision
+record.
+
+Decision input presence is not runtime implementation procedure.
+
+Decision input completeness is not code implementation.
+
+Decision input set must not silently include adjacent files, generated
+artifacts, dependency trees, build products, package outputs, runtime
+objects, deployment state, workspace state, process state, runtime
+handles, execution handles, source modifications, or capability tokens.
+
+## Exact-SHA Binding
+
+Runtime implementation decision is exact-SHA bound.
+
+The conceptual decision chain is:
+
+```text
+Runtime Activation Decision Record
+  -> Bounded Activation Governance Consideration
+  -> Bounded Runtime Implementation Consideration
+  -> Runtime Implementation Decision Record
+  -> later runtime implementation review or procedure path, if ever authorized
+```
+
+Every arrow is a governance dependency. No arrow implies runtime
+implementation procedure, source modification, code implementation, code
+execution, process start, runtime state creation, package installation,
+package loading, package execution, deployment, distribution, capability
+issuance, registry publication, trust assignment, source acceptance, or
+source merge authority.
+
+Exact-SHA binding may use:
+
+1. Exact reviewed Runtime Activation Decision SHA.
+2. Exact Runtime Activation Decision record identifier.
+3. Exact bounded activation governance consideration identifier.
+4. Exact bounded runtime implementation consideration identifier.
+5. Exact runtime implementation decision record identifier.
+6. Exact runtime implementation decision result identifier.
+
+This RFC does not define canonical hash construction, digest algorithm,
+artifact digest format, package digest format, source merge mechanics,
+diff format, runtime identity, process identity, runtime handle format,
+state format, implementation procedure format, execution key format, or
+signature format.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or
+differently scoped decision binding fails closed.
+
+## Implementation Consideration Boundary
+
+Implementation consideration boundary is the limit of what runtime
+implementation decision may decide.
+
+Runtime implementation decision may decide whether:
+
+1. Exact Runtime Activation Decision record is present.
+2. Exact runtime activation decision result is
+   `bounded_activation_consideration_recorded`.
+3. Bounded activation governance consideration is exact and stable.
+4. Bounded activation governance consideration remains bound to the
+   exact Runtime Acceptance Decision record.
+5. Bounded activation governance consideration remains bound to the
+   exact Runtime Decision Review record.
+6. Bounded activation governance consideration remains bound to the
+   exact Runtime Decision record.
+7. Bounded runtime implementation consideration is exact and stable.
+8. Phase-19 runtime authority boundaries remain preserved.
+9. Runtime Decision scope is not reconstructed.
+10. Runtime Decision intent is not reinterpreted.
+11. Slice scope is not expanded.
+12. Non-authorization notices remain present.
+13. No unexpected runtime implementation procedure, source
+    modification, code implementation, code execution, process start,
+    runtime state creation, unbounded execution, package, deployment,
+    issuance, registry, trust, distribution, source merge, Semantic CLI,
+    AI Runtime, or agent authority reading is introduced.
+
+Runtime implementation decision must not decide:
+
+1. Runtime implementation procedure.
+2. Source modification.
+3. Code implementation.
+4. Code execution.
+5. Process start.
+6. Runtime state creation.
+7. General runtime authority.
+8. Unbounded execution authority.
+9. Package installation, loading, execution, scheduling, or publication.
+10. Module loading.
+11. Plugin loading or instantiation.
+12. Workspace runtime or real mounts.
+13. Deployment readiness.
+14. Capability issuance.
+15. Registry publication.
+16. Distribution execution.
+17. Trust assignment.
+18. Source merge authorization.
+19. Source repository state.
+20. Production readiness.
+
+Any decision reading that crosses the implementation consideration
+boundary fails closed.
+
+## Decision Evaluation Model
+
+Runtime implementation decision evaluates whether a recorded bounded
+activation governance consideration may receive a bounded runtime
+implementation governance result.
+
+Decision evaluation may compare:
+
+1. Runtime activation decision result against required
+   `bounded_activation_consideration_recorded` result.
+2. Bounded activation governance consideration identity against the exact
+   Runtime Activation Decision record.
+3. Runtime Acceptance Decision identity against the exact activation
+   decision record.
+4. Runtime Decision Review identity against the exact activation
+   decision record.
+5. Runtime Decision identity against the exact activation decision
+   record.
+6. Bounded runtime implementation consideration against the decision
+   input set.
+7. Phase-19 runtime boundary claims against Phase-19 runtime authority
+   records.
+8. Denied source, execution, loader, package, state, behavior, and
+   implementation readings against the proposed consideration.
+9. Non-authorization notices against governing RFCs.
+10. Relationship context against denied authority readings.
+
+Decision evaluation does not reconstruct Runtime Decision scope.
+
+Decision evaluation does not reinterpret Runtime Decision intent.
+
+Decision evaluation does not broaden Phase-19 runtime authority.
+
+Decision evaluation does not expand Slice scope.
+
+Decision evaluation does not define runtime implementation procedure.
+
+Decision evaluation does not modify source.
+
+Decision evaluation does not implement code.
+
+Decision evaluation does not start code.
+
+Decision evaluation does not load or execute packages.
+
+Decision evaluation does not create runtime state.
+
+Decision output records only a bounded runtime implementation decision
+governance result until a later runtime implementation review or
+procedure RFC defines separate behavior, if ever authorized.
+
+## Decision Record
+
+A runtime implementation decision record records the decision result for
+bounded runtime implementation consideration.
+
+Allowed runtime implementation decision results are:
+
+1. `bounded_implementation_consideration_recorded`
+2. `denied`
+3. `quarantined`
+
+No other runtime implementation decision result is defined by this RFC.
+
+A runtime implementation decision record must identify the exact runtime
+implementation decision subject, exact Runtime Activation Decision
+record, exact runtime activation decision result, exact bounded
+activation governance consideration, exact bounded runtime
+implementation consideration, exact Phase-19 runtime boundary context,
+decision result, reason for decision, exact-SHA binding, denied source,
+execution, loader, package, state, behavior, and implementation readings,
+non-authorization notice, and fail-closed handling for later ambiguity.
+
+Runtime implementation decision records governance state only.
+
+Runtime implementation decision record never modifies source, implements
+code, starts code, defines runtime implementation procedure, starts a
+process, creates runtime state, installs packages, loads packages,
+executes packages, deploys artifacts, issues capabilities, publishes
+registry entries, assigns trust, accepts source, merges source, or
+authorizes distribution.
+
+## Runtime Implementation Outcomes
+
+Runtime implementation outcomes are governance outcomes only.
+
+This RFC defines:
+
+| Outcome | Meaning | Authority result |
+|---|---|---|
+| `bounded_implementation_consideration_recorded` | Bounded runtime implementation consideration is recorded for the exact decision subject | No runtime implementation procedure |
+| `denied` | Bounded runtime implementation consideration is denied for the exact decision subject | No deletion or revocation by itself |
+| `quarantined` | Implementation consideration or decision input is held for unresolved ambiguity, conflict, or safety concern | No authority |
+| `deferred` | Decision is delayed before a runtime implementation decision result can be recorded | No implementation result |
+| `superseded` | Decision is replaced by a later exact reviewed decision | No inheritance |
+
+`bounded_implementation_consideration_recorded`, `denied`, and
+`quarantined` are runtime implementation decision results.
+
+`deferred` and `superseded` are decision dispositions. They are not
+runtime implementation decision results.
+
+Outcome presence must not be interpreted as runtime implementation
+procedure, source modification, code implementation, code execution,
+process start, runtime state creation, execution authority, trust
+assignment, registry publication, distribution authority, package
+loading, package execution, deployment authority, source merge
+authority, general runtime authority, or capability issuance.
+
+## Explicit Separation
+
+Runtime implementation decision concepts do not imply authority-bearing
+runtime outcomes.
+
+| Runtime implementation decision concept | Is not |
+|---|---|
+| Bounded implementation consideration recorded | Runtime implementation procedure |
+| Bounded implementation consideration recorded | Source modified |
+| Bounded implementation consideration recorded | Code implemented |
+| Bounded implementation consideration recorded | Code executed |
+| Bounded implementation consideration recorded | Process started |
+| Bounded implementation consideration recorded | Package loaded |
+| Bounded implementation consideration recorded | Package executable |
+| Bounded implementation consideration recorded | Runtime state created |
+| Bounded implementation consideration recorded | Capability issued |
+| Bounded implementation consideration recorded | Registry published |
+| Bounded implementation consideration recorded | Trust assigned |
+| Bounded activation consideration recorded | Runtime implemented |
+| Implementation decision record | Runtime state |
+| Implementation decision record | Execution handle |
+
+No concept in this table implies another by default.
+
+Unknown implementation, runtime, execution, source, issuance,
+publication, trust, or distribution readings fail closed.
+
+## Decision Disposition Handling
+
+Decision dispositions preserve audit history for denial, quarantine,
+deferral, and supersession.
+
+Denial records that bounded runtime implementation consideration was not
+recorded for the exact decision subject. It does not delete history,
+revoke another record, transfer authority to a replacement, establish
+alias or supersession by itself, prove fault by itself, or block later
+resubmission by itself.
+
+Quarantine is the safe decision result for unresolved ambiguity,
+including runtime implementation decision subject ambiguity, Runtime
+Activation Decision record ambiguity, activation result ambiguity,
+bounded activation governance consideration ambiguity, bounded runtime
+implementation consideration ambiguity, Phase-19 runtime boundary
+conflict, denied-reading concern, missing decision prerequisite, or
+incompatible interpretation across governing records.
+
+Deferral may record that later information is required before a runtime
+implementation decision result can be made.
+
+Supersession may record that a later exact runtime implementation
+decision replaces the current decision for decision purposes.
+Supersession inheritance is denied unless a later reviewed RFC defines
+exact narrower behavior.
+
+No disposition modifies source, implements code, starts code, defines
+runtime implementation procedure, starts a process, creates runtime
+state, accepts source, merges source, assigns trust, publishes registry
+entries, authorizes distribution, issues capabilities, deploys
+artifacts, installs packages, loads packages, or executes packages.
+
+## Phase-19 Runtime Authority Relationship
+
+Phase-20 Runtime Implementation Decision consumes Phase-20 Runtime
+Activation Decision context and remains subordinate to Phase-19 runtime
+authority records.
+
+Phase-19 runtime records may be read as boundary context for:
+
+1. Runtime MVP planning boundaries.
+2. Runtime evidence expectations.
+3. Runtime non-goals and denials.
+4. Platform runtime constitutional constraints.
+5. Userspace-only runtime constraints.
+6. Frozen syscall and kernel ABI boundaries.
+7. Denied package, module, workspace, plugin, trust, capability, AI
+   Runtime, Semantic CLI, and agent authority readings.
+
+Phase-20 Runtime Implementation Decision must not broaden, replace,
+supersede, weaken, or reinterpret Phase-19 runtime authority records.
+
+Phase-20 Runtime Implementation Decision must not use an implementation
+decision result to infer Phase-19 runtime authority.
+
+Any Phase-20 runtime implementation decision reading that conflicts with
+Phase-19 runtime authority records fails closed.
+
+## Post-Decision Exact-SHA Verification
+
+Post-decision exact-SHA verification is a governance verification step
+after a runtime implementation decision record has been recorded.
+
+The conceptual verification path is:
+
+```text
+runtime_activation_decision
+  -> runtime_implementation_decision
+  -> exact_runtime_implementation_decision_sha
+  -> post_runtime_implementation_decision_verification
+  -> later_runtime_implementation_review_or_procedure_input_if_authorized
+```
+
+Every arrow is a governance dependency. No arrow implies runtime
+implementation procedure, source modification, code implementation, code
+execution, process start, runtime state creation, execution authority,
+package loading, package execution, deployment, distribution, capability
+issuance, registry publication, trust assignment, source acceptance, or
+source merge authority.
+
+Post-decision verification may confirm the exact runtime implementation
+decision record SHA, exact Runtime Activation Decision record, exact
+bounded activation governance consideration, exact bounded runtime
+implementation consideration, expected non-authorization notices,
+expected governance check results, expected Phase-19 runtime boundary
+preservation, and no unexpected runtime implementation or authority
+expansion.
+
+Post-decision verification result is not runtime implementation
+procedure.
+
+Post-decision verification result is not source modification.
+
+Post-decision verification result is not code implementation.
+
+Post-decision verification result is not execution authority.
+
+Post-decision verification result is not runtime state.
+
+Post-decision verification records exact-SHA verification only. It never
+records runtime implementation procedure, source modification, code
+implementation, execution authority, runtime behavior, or runtime state.
+
+## Relationship Boundaries
+
+Runtime implementation decision may consume prior Phase-20 and Phase-19
+governance records as decision context only.
+
+| Previous record | Accepted reading | Denied reading |
+|---|---|---|
+| `PHASE20_RUNTIME_ACTIVATION_DECISION.md` | Exact activation decision record and `bounded_activation_consideration_recorded` result as decision prerequisite | Bounded activation consideration recorded is not runtime implemented by implication |
+| `PHASE20_RUNTIME_ACCEPTANCE_DECISION.md` | Exact acceptance decision record and `accepted` result as context through activation decision | Runtime accepted is not runtime implemented |
+| `PHASE20_RUNTIME_DECISION_REVIEW.md` | Exact review record and `conforms` result as context through acceptance decision | Review result `conforms` is not implementation authority |
+| `PHASE20_RUNTIME_DECISION.md` | Exact Runtime Decision record, Runtime Decision Subject, Runtime Decision Identity, and bounded runtime authority consideration as context | Runtime Decision does not implement runtime or grant execution authority |
+| `PHASE20_IMPLEMENTATION_ACCEPTANCE_DECISION.md` | Exact acceptance decision record and `accepted` result as context through Runtime Decision | Implementation accepted is not runtime enabled |
+| `PHASE20_IMPLEMENTATION_REVIEW.md` | Exact review record as context through acceptance decision | Review result is not runtime authority |
+| `PHASE20_IMPLEMENTATION_SLICE.md` | Exact Slice record, Slice Identity, and Bounded Source Scope as context | Slice scope is never reconstructed, expanded, or reinterpreted |
+| `PHASE20_IMPLEMENTATION_DECISION.md` | Eligible decision record as prerequisite context | Eligibility is not runtime authority |
+| `PHASE20_CAPABILITY_ACCEPTANCE_WORKFLOW.md` | Accepted workflow subject and acceptance decision record as context | Accepted workflow subject is not runtime enabled |
+| `PHASE20_CAPABILITY_EVIDENCE_MODEL.md` | Accepted evidence through acceptance workflow context | Accepted evidence is not runtime proof |
+| `PHASE20_REGISTRY_MODEL.md` and `PHASE20_REGISTRY_GOVERNANCE.md` | Registry context for subject consistency | Registry context is not publication, issuance, runtime implementation, or runtime authority |
+| `PHASE20_TRUST_MODEL.md` | Trust context for decision context | Trust context is not trust assignment or runtime authority |
+| `PHASE20_DISTRIBUTION_POLICY.md` | Distribution policy context for decision context | Distribution eligibility is not distribution execution or runtime authority |
+| `PHASE19_RUNTIME_DECISION.md` and Phase-19 Runtime RFC set | Runtime boundary context and denied readings | Runtime Implementation Decision does not broaden or replace Phase-19 runtime authority |
+
+Runtime implementation decision does not modify prior governance records.
+
+Runtime implementation decision does not modify Runtime Activation
+Decision records.
+
+Runtime implementation decision does not modify Runtime Acceptance
+Decision records.
+
+Runtime implementation decision does not modify Runtime Decision Review
+records.
+
+Runtime implementation decision does not modify Runtime Decision
+records.
+
+Runtime implementation decision does not modify implementation
+acceptance decision records.
+
+Runtime implementation decision does not modify review records.
+
+Runtime implementation decision does not modify Slice scope.
+
+Runtime implementation decision does not modify acceptance state.
+
+Runtime implementation decision does not modify evidence records.
+
+Runtime implementation decision does not modify Phase-19 runtime
+authority records.
+
+Ambiguous, stale, inherited, unaccepted, or differently scoped
+relationship material fails closed for runtime implementation decision.
+
+## Runtime Behavior Boundary
+
+Runtime implementation decision may record bounded runtime implementation
+governance consideration.
+
+Runtime implementation decision does not define how runtime behavior is
+implemented.
+
+Runtime implementation decision does not modify source, implement code,
+start code, load packages, instantiate plugins, create runtime state,
+issue capabilities, publish registry entries, or assign trust.
+
+Runtime implementation decision does not define an execution path,
+process lifecycle, scheduler behavior, loader behavior, package manager
+behavior, module loader behavior, plugin host behavior, workspace mount
+behavior, runtime state storage, implementation API, runtime handle
+format, execution handle format, source patch format, or capability
+token format.
+
+A later runtime implementation review or procedure RFC or decision path,
+if ever authorized, must define exact implementation subject, exact
+Runtime Implementation Decision record, exact bounded runtime
+implementation consideration, exact allowed implementation behavior, exact denied
+implementation behavior, exact source boundary, exact runtime boundary,
+exact execution boundary, exact runtime state boundary, package, loader,
+deployment, issuance, publication, trust, distribution, source, Semantic
+CLI, AI Runtime, agent, syscall, kernel ABI, and Ring0 denials, required
+implementation review path, required post-implementation verification,
+and non-authorization notice for anything outside scope.
+
+Until such a reviewed runtime implementation review or procedure RFC or
+decision path exists, runtime implementation procedure remains denied.
+
+## Decision Validation Model
+
+Runtime implementation decision validation is conceptual and fail-closed.
+
+Decision validation must never define runtime implementation procedure.
+
+Decision validation must never modify source.
+
+Decision validation must never implement code.
+
+Decision validation must never start code.
+
+Decision validation must never start a process.
+
+Decision validation must never grant unbounded execution authority.
+
+Decision validation must never create runtime state.
+
+Decision validation must never reconstruct Runtime Decision scope.
+
+Decision validation must never reinterpret Runtime Decision intent.
+
+Decision validation must never broaden Phase-19 runtime authority.
+
+Decision validation must never expand Slice scope.
+
+Decision validation must never infer missing activation material.
+
+Runtime implementation decision material is invalid for governance review
+when:
+
+1. Runtime implementation decision subject is missing or ambiguous.
+2. Runtime implementation decision identity is missing or ambiguous.
+3. Exact Runtime Activation Decision record is missing, stale,
+   ambiguous, inherited, or differently scoped.
+4. Reviewed Runtime Activation Decision SHA is missing or ambiguous.
+5. Runtime activation decision result is missing, ambiguous, or not
+   `bounded_activation_consideration_recorded` for
+   `bounded_implementation_consideration_recorded`.
+6. Bounded activation governance consideration is missing or ambiguous.
+7. Bounded runtime implementation consideration is missing or ambiguous.
+8. Decision input set is missing or ambiguous.
+9. Runtime Decision record is missing, stale, ambiguous, inherited, or
+   differently scoped.
+10. Runtime Decision scope is reconstructed.
+11. Runtime Decision intent is reinterpreted.
+12. Phase-19 runtime authority is broadened, weakened, replaced,
+    superseded, or reinterpreted.
+13. Slice scope is expanded.
+14. Runtime activation decision result
+    `bounded_activation_consideration_recorded` is treated as runtime
+    implementation by implication.
+15. Decision result is treated as runtime implementation procedure.
+16. Decision result is treated as source modification.
+17. Decision result is treated as code implementation.
+18. Decision result is treated as code execution.
+19. Decision result is treated as process start.
+20. Decision result is treated as runtime state creation.
+21. Decision result is treated as unbounded execution authority.
+22. Decision result is treated as package loading authority.
+23. Decision result is treated as package execution authority.
+24. Decision result is treated as registry publication.
+25. Decision result is treated as trust assignment.
+26. Decision result is treated as capability issuance.
+27. Decision material depends on runtime-observed state.
+28. Decision material relies on alias or supersession without accepted
+    rules.
+29. Decision material implies source merge authority.
+30. Decision material implies general runtime authority.
+31. Decision material implies Semantic CLI, AI Runtime, or agent
+    authority.
+
+Validation failure grants no authority. It requires correction, denial,
+deferral, quarantine, supersession, dispute recording, or a later
+reviewed decision path.
+
+Runtime implementation decision validation is not runtime implementation
+procedure.
+
+Validation produces only a validation result.
+
+Validation never produces runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+unbounded execution authority, runtime state, package authority,
+deployment authority, source authority, merge authority, trust
+assignment, registry publication, distribution authority, or capability
+issuance.
+
+## Runtime Implementation Decision Invariants
+
+Every later Phase-20 RFC must preserve these runtime implementation
+decision invariants:
+
+1. Runtime Implementation Decision consumes the exact Runtime Activation
+   Decision record.
+2. Runtime Implementation Decision requires exact runtime activation
+   decision result binding.
+3. Runtime Implementation Decision may evaluate bounded runtime
+   implementation consideration only after runtime activation decision
+   result `bounded_activation_consideration_recorded`.
+4. Runtime activation decision result
+   `bounded_activation_consideration_recorded` is necessary but not
+   sufficient for bounded runtime implementation consideration.
+5. Bounded activation consideration recorded is not runtime implemented
+   by implication.
+6. Runtime Implementation Decision may record bounded runtime
+   implementation governance consideration.
+7. Runtime Implementation Decision does not define runtime
+   implementation procedure.
+8. Runtime Implementation Decision does not modify source.
+9. Runtime Implementation Decision does not implement code.
+10. Runtime Implementation Decision does not start code.
+11. Runtime Implementation Decision does not start a process.
+12. Runtime Implementation Decision does not create runtime state.
+13. Runtime Implementation Decision does not grant general runtime
+    authority.
+14. Runtime Implementation Decision does not grant unbounded execution
+    authority.
+15. Runtime Implementation Decision does not reconstruct Runtime
+    Decision scope.
+16. Runtime Implementation Decision does not reinterpret Runtime
+    Decision intent.
+17. Runtime Implementation Decision does not broaden Phase-19 runtime
+    authority.
+18. Runtime Implementation Decision does not expand Slice scope.
+19. Runtime implementation decision record is not runtime state.
+20. Runtime implementation decision record is not execution handle.
+21. Implementation consideration is not package loading by implication.
+22. Implementation consideration is not package execution by implication.
+23. Runtime Implementation Decision does not grant package installation.
+24. Runtime Implementation Decision does not grant package loading.
+25. Runtime Implementation Decision does not grant package execution.
+26. Runtime Implementation Decision does not grant module loading.
+27. Runtime Implementation Decision does not grant plugin loading.
+28. Runtime Implementation Decision does not grant deployment authority.
+29. Runtime Implementation Decision does not grant registry publication.
+30. Runtime Implementation Decision does not grant trust assignment.
+31. Runtime Implementation Decision does not grant distribution
+    authority.
+32. Runtime Implementation Decision does not grant capability issuance.
+33. Runtime Implementation Decision does not grant source merge
+    authority.
+34. One runtime implementation decision evaluates one bounded runtime
+    implementation consideration for one recorded bounded activation
+    governance consideration.
+35. Runtime Implementation Decision does not modify prior governance
+    records.
+36. Later runtime implementation review or procedure requires separate
+    governance review, if ever authorized.
+37. Post-decision verification result is not runtime implementation
+    procedure.
+38. Post-decision verification result is not code implementation.
+39. Post-decision verification result is not execution authority.
+40. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Later RFC Dependencies
+
+The runtime implementation decision model is a prerequisite for later
+Phase-20 runtime implementation review or procedure paths only if
+separate runtime implementation procedure authority is ever reviewed and
+authorized.
+
+| Later record | Runtime implementation decision relationship |
+|---|---|
+| Later reviewed runtime implementation review RFC or decision path, if ever authorized | May review bounded runtime implementation consideration only after exact Runtime Implementation Decision binding. |
+| Later reviewed runtime implementation procedure RFC or decision path, if ever authorized | May consider runtime implementation procedure only after separate reviewed procedure authority and exact Runtime Implementation Decision binding. |
+
+Later RFCs may narrow runtime implementation decision use. They must not
+broaden this decision model into runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+general runtime authority, unbounded execution authority, runtime state,
+package installation, package loading, package execution, module
+loading, plugin loading, deployment, trust assignment, registry
+publication, distribution authority, capability issuance, source merge
+authority, Semantic CLI authority, AI Runtime authority, agent
+authority, syscall expansion, kernel ABI expansion, or Ring0 authority
+without a separate reviewed decision.
+
+Runtime Implementation Decision is the Phase-20 RFC in this chain that
+records bounded runtime implementation governance consideration for
+recorded bounded activation governance considerations.
+
+Runtime Implementation Decision does not define runtime implementation
+procedure.
+
+The current Phase-20 dependency chain is:
+
+```text
+Capability Model
+  -> Capability Identity
+  -> Capability Manifest Schema
+  -> Capability Lifecycle
+  -> Registry Model
+  -> Registry Governance
+  -> Trust Model
+  -> Distribution Policy
+  -> Capability Evidence Model
+  -> Capability Acceptance Workflow
+  -> Implementation Decision
+  -> Implementation Slice
+  -> Implementation Review
+  -> Implementation Acceptance Decision
+  -> Runtime Decision
+  -> Runtime Decision Review
+  -> Runtime Acceptance Decision
+  -> Runtime Activation Decision
+  -> Runtime Implementation Decision
+```
+
+Every arrow means a governance dependency. It does not imply runtime
+implementation procedure, source modification, code implementation, code
+execution, process start, source merge authority, publication,
+distribution, installation, loading, execution, issuance, deployment,
+runtime state, or general runtime authority.
+
+Every dependency is explicit.
+
+No dependency is implied.
+
+Each RFC defines only its own layer. No RFC produces the authority of the
+next layer.
+
+## Explicit Non-Authorization
+
+This runtime implementation decision RFC does not authorize:
+
+1. Runtime implementation procedure.
+2. Source modification.
+3. Code implementation.
+4. Code execution.
+5. Process start.
+6. Runtime state creation.
+7. General runtime authority.
+8. Unbounded execution authority.
+9. Package installation, loading, execution, scheduling, or publication.
+10. Module loading.
+11. Workspace creation, workspace runtime, or real mounts.
+12. Plugin host, plugin loading, or plugin instantiation.
+13. Deployment behavior.
+14. Capability token minting or capability issuance.
+15. Trust assignment.
+16. Trust issuer authority.
+17. Registry authority.
+18. Registry publication.
+19. Publication authority.
+20. Distribution authority.
+21. Distribution execution.
+22. Source acceptance or source merge authority.
+23. Source repository authority.
+24. Semantic CLI execution or verdict authority.
+25. AI Runtime authority.
+26. Agent behavior.
+27. New syscalls.
+28. Kernel ABI expansion.
+29. Workflow-threshold, baseline, dependency, or Ring0 policy changes.
+30. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-20 RFC
+**Architecture status:** Draft RFC / pending architectural review
+**Authority notice:** This signature identifies the architectural
+authorship of this RFC. It grants no runtime implementation procedure
+authority, source modification authority, code implementation authority,
+code execution authority, process start authority, general runtime
+authority, unbounded execution authority, runtime state authority,
+implementation authority, implementation approval authority, source
+merge authority, trust authority, evidence authority, acceptance
+authority, proof authority, constitutional authority, registry
+authority, distribution authority, publication authority, capability
+issuance authority, package authority, deployment authority, module
+authority, plugin authority, Semantic CLI authority, AI Runtime
+authority, agent authority, or Ring0 authority.
+
+## Non-Goals
+
+This document does not define or authorize:
+
+1. Runtime implementation procedure.
+2. Source modification.
+3. Code implementation.
+4. Code execution.
+5. Process start.
+6. Runtime state creation.
+7. General runtime authority.
+8. Unbounded execution authority.
+9. Package format, repository, installation, loading, or execution.
+10. Deployment behavior.
+11. Artifact storage or binary format.
+12. Module loading.
+13. Workspace creation, workspace runtime, or real mounts.
+14. Plugin host, plugin loading, or plugin instantiation.
+15. Capability token minting or capability issuance.
+16. Trust assignment or trust issuer authority.
+17. Registry authority or registry publication.
+18. Publication workflow or publication approval.
+19. Distribution authority or distribution execution.
+20. Source acceptance or source merge authority.
+21. Source repository authority.
+22. Repository branch protection.
+23. Proof verification, signature verification, or signature acceptance.
+24. Semantic CLI execution or verdict authority.
+25. AI Runtime authority.
+26. Agent behavior.
+27. New syscalls.
+28. Kernel ABI expansion.
+29. Workflow-threshold, baseline, dependency, or Ring0 policy changes.


### PR DESCRIPTION
This PR adds the Phase-20 runtime implementation decision RFC.

The RFC defines a bounded runtime implementation decision model for evaluating bounded runtime implementation consideration after an exact Runtime Activation Decision record.

It is bound to the exact PHASE20_RUNTIME_ACTIVATION_DECISION.md record published at:
d433f1405d3abb62af69f9ff3a111592571ef18d

It preserves:
- exact Runtime Activation Decision record binding
- bounded runtime implementation decision model only
- no runtime implementation procedure
- no source modification
- no code implementation
- no code execution
- no process start
- no runtime state creation
- no package installation/loading/execution
- no module/plugin loading
- no workspace runtime
- no deployment
- no capability issuance
- no registry publication
- no trust assignment
- no source merge authority
- no Phase-19 runtime authority broadening
- no Slice scope expansion
- no Semantic CLI / AI Runtime / agent authority

This PR changes only PHASE20_RUNTIME_IMPLEMENTATION_DECISION.md.