### PR TITLE
Phase-20 closure decision RFC

### DIFF
--- a/PHASE20_CLOSURE_DECISION.md
+++ b/PHASE20_CLOSURE_DECISION.md
@@ -1,0 +1,570 @@
+# Phase-20 Closure Decision
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE20_POINTER_TRANSITION_DECISION.md`,
+`PHASE20_GOVERNANCE_OVERVIEW.md`,
+`PHASE20_CAPABILITY_MODEL.md`,
+`PHASE20_CAPABILITY_IDENTITY.md`,
+`PHASE20_CAPABILITY_MANIFEST_SCHEMA.md`,
+`PHASE20_CAPABILITY_LIFECYCLE.md`,
+`PHASE20_REGISTRY_MODEL.md`,
+`PHASE20_REGISTRY_GOVERNANCE.md`,
+`PHASE20_TRUST_MODEL.md`,
+`PHASE20_DISTRIBUTION_POLICY.md`,
+`PHASE20_CAPABILITY_EVIDENCE_MODEL.md`,
+`PHASE20_CAPABILITY_ACCEPTANCE_WORKFLOW.md`,
+`PHASE20_IMPLEMENTATION_DECISION.md`,
+`PHASE20_IMPLEMENTATION_SLICE.md`,
+`PHASE20_IMPLEMENTATION_REVIEW.md`,
+`PHASE20_IMPLEMENTATION_ACCEPTANCE_DECISION.md`,
+`PHASE20_RUNTIME_DECISION.md`,
+`PHASE20_RUNTIME_DECISION_REVIEW.md`,
+`PHASE20_RUNTIME_ACCEPTANCE_DECISION.md`,
+`PHASE20_RUNTIME_ACTIVATION_DECISION.md`,
+`PHASE20_RUNTIME_IMPLEMENTATION_DECISION.md`,
+`PHASE20_RUNTIME_IMPLEMENTATION_REVIEW.md`, and
+`PHASE20_RUNTIME_IMPLEMENTATION_ACCEPTANCE_DECISION.md`. In case of
+conflict, those documents prevail unless this closure decision is the
+narrower Phase-20 closure decision for the exact subject identified
+below.
+
+**Status:** EXACT-SUBJECT PHASE-20 CLOSURE DECISION RFC / CLOSURE
+GRANTED FOR DECISION SUBJECT ONLY / NO RUNTIME IMPLEMENTATION PROCEDURE /
+NO SOURCE MODIFICATION / NO CODE IMPLEMENTATION / NO CODE EXECUTION / NO
+PROCESS START / NO RUNTIME STATE CREATION / NO PACKAGE AUTHORITY / NO
+PACKAGE INSTALLATION / NO PACKAGE LOADING / NO PACKAGE EXECUTION / NO
+DEPLOYMENT / NO CAPABILITY ISSUANCE / NO TRUST ASSIGNMENT / NO REGISTRY
+PUBLICATION / NO DISTRIBUTION AUTHORITY / NO SOURCE MERGE AUTHORITY / NO
+PHASE-21 POINTER TRANSITION
+**Closure decision date:** 2026-07-01
+**Closure decision id:** `ayken.phase20.closure_decision.v1`
+**Closure decision base main SHA:** `288c555b31a1af3cfa02030cff92c258280b76a9`
+**Decision subject SHA:** `288c555b31a1af3cfa02030cff92c258280b76a9`
+**Reviewed runtime implementation acceptance decision SHA:** `288c555b31a1af3cfa02030cff92c258280b76a9`
+**Current phase pointer:** `CURRENT_PHASE=20`
+**Authority boundary:** Phase-20 closure decision only; not Phase-21
+pointer transition, not runtime implementation procedure, not source
+modification, not code implementation, not code execution, not process
+start, not runtime state creation, not general runtime authority, not
+unbounded execution authority, not package authority, not package
+installation, not package loading, not package execution, not deployment,
+not source acceptance, not source merge authority, not source repository
+authority, not module loading, not workspace runtime, not plugin loading,
+not capability token minting, not capability issuance, not trust
+assignment, not trust issuer authority, not registry authority, not
+registry publication, not publication authority, not distribution
+authority, not distribution execution, not Semantic CLI authority, not AI
+Runtime authority, not agent authority, not syscall expansion, not kernel
+ABI expansion, not workflow-threshold, baseline, dependency, or Ring0
+authority.
+
+## Purpose
+
+This document records the Phase-20 closure decision for exact main
+subject:
+
+```text
+288c555b31a1af3cfa02030cff92c258280b76a9
+```
+
+It closes the Phase-20 capability-to-runtime implementation governance
+chain after the Runtime Implementation Acceptance Decision was published
+on exact main.
+
+It answers one question:
+
+```text
+Is Phase-20 closed after exact Runtime Implementation Acceptance Decision
+publication and post-merge exact-main verification?
+```
+
+It does not answer:
+
+```text
+How is runtime implementation procedure defined?
+How is source modified?
+How is code implemented?
+How is code executed?
+How is a process started?
+How is runtime state created?
+How is a package installed, loaded, executed, deployed, or distributed?
+How is a module loaded?
+How is a plugin instantiated?
+How is a capability issued?
+How is trust assigned?
+How is a registry entry published?
+How is Phase-21 opened?
+```
+
+Those questions belong to later reviewed RFCs or decision paths, if ever
+authorized.
+
+## Core Rule
+
+```text
+Phase-20 closed != runtime implementation procedure
+Phase-20 closed != source modification
+Phase-20 closed != code implementation
+Phase-20 closed != code execution
+Phase-20 closed != process start
+Phase-20 closed != runtime state creation
+Phase-20 closed != package loading
+Phase-20 closed != package execution
+Phase-20 closed != capability issuance
+Phase-20 closed != registry publication
+Phase-20 closed != trust assignment
+Phase-20 closed != source merge
+Phase-20 closed != Phase-21 pointer transition
+runtime implementation accepted != runtime implementation procedure
+runtime implementation accepted != source modified
+runtime implementation accepted != code implemented
+runtime implementation accepted != code executed
+runtime implementation accepted != process started
+runtime implementation accepted != runtime state created
+closure decision record != runtime state
+closure decision record != execution handle
+```
+
+Phase-20 closure consumes the exact Runtime Implementation Acceptance
+Decision record.
+
+Phase-20 closure records completion of the capability-to-runtime
+implementation governance chain.
+
+Phase-20 closure does not open runtime implementation procedure.
+
+Phase-20 closure does not modify source.
+
+Phase-20 closure does not implement code.
+
+Phase-20 closure does not execute code.
+
+Phase-20 closure does not start a process.
+
+Phase-20 closure does not create runtime state.
+
+Phase-20 closure does not load or execute packages.
+
+Phase-20 closure does not issue capabilities.
+
+Phase-20 closure does not publish registry entries.
+
+Phase-20 closure does not assign trust.
+
+Phase-20 closure does not broaden Phase-19 runtime authority.
+
+Phase-20 closure does not expand Slice scope.
+
+First bounded implementation is deferred to Phase-21 only if Phase-21 is
+separately opened by a reviewed pointer transition or equivalent
+authority path.
+
+Unknown authority readings fail closed.
+
+## Closure Decision Mission
+
+The mission of this closure decision is to publish the exact Phase-20
+closure boundary after the capability, registry, trust, distribution,
+evidence, acceptance, implementation, runtime, activation, runtime
+implementation, runtime implementation review, and runtime
+implementation acceptance governance layers have been recorded.
+
+The closure decision exists so later RFCs can reason about:
+
+1. Exact Phase-20 closure subject.
+2. Exact Runtime Implementation Acceptance Decision record.
+3. Exact capability-to-runtime implementation governance chain.
+4. Exact closed Phase-20 scope.
+5. Exact non-authorization boundary.
+6. Phase-19 runtime authority preservation.
+7. Slice scope preservation.
+8. Later Phase-21 dependency, if ever authorized.
+
+The closure decision itself grants no Phase-21 pointer transition,
+runtime implementation procedure, source modification, code
+implementation, code execution, process start, runtime state creation,
+general runtime authority, unbounded execution authority, package
+authority, deployment, distribution, trust, registry, source merge, or
+capability issuance authority.
+
+Each later use requires its own reviewed RFC or decision path.
+
+## Decision Inputs
+
+| Input | Recorded result |
+|---|---|
+| Decision subject | `288c555b31a1af3cfa02030cff92c258280b76a9` |
+| Runtime Implementation Acceptance Decision | `PHASE20_RUNTIME_IMPLEMENTATION_ACCEPTANCE_DECISION.md` |
+| Runtime Implementation Acceptance Decision PR | PR #221 |
+| PR #221 head | `858347a8b20b0b2a59636b38d1f134939bf06857` |
+| PR #221 review | Approved by `kenanay2020-hub` |
+| PR #221 merge method | Normal maintainer squash merge; no admin bypass recorded |
+| PR #221 changed file | `PHASE20_RUNTIME_IMPLEMENTATION_ACCEPTANCE_DECISION.md` |
+| PR #221 merge commit / decision subject | `288c555b31a1af3cfa02030cff92c258280b76a9` |
+
+The diff from `3fc85e9d8252c95d52a7418ff65d78e1e0166c2d` to
+`288c555b31a1af3cfa02030cff92c258280b76a9` changes exactly:
+
+```text
+PHASE20_RUNTIME_IMPLEMENTATION_ACCEPTANCE_DECISION.md
+```
+
+No runtime source, kernel source, package source, loader source, module
+source, plugin source, syscall metadata, ABI metadata, dependency,
+workflow, baseline, registry publication, capability issuance, trust
+assignment, deployment, or production runtime wiring changed in the PR
+#221 merge.
+
+## Phase-20 Governance Chain
+
+Phase-20 closed the following governance chain:
+
+```text
+Capability Model
+  -> Capability Identity
+  -> Capability Manifest Schema
+  -> Capability Lifecycle
+  -> Registry Model
+  -> Registry Governance
+  -> Trust Model
+  -> Distribution Policy
+  -> Capability Evidence Model
+  -> Capability Acceptance Workflow
+  -> Implementation Decision
+  -> Implementation Slice
+  -> Implementation Review
+  -> Implementation Acceptance Decision
+  -> Runtime Decision
+  -> Runtime Decision Review
+  -> Runtime Acceptance Decision
+  -> Runtime Activation Decision
+  -> Runtime Implementation Decision
+  -> Runtime Implementation Review
+  -> Runtime Implementation Acceptance Decision
+  -> Phase-20 Closure Decision
+```
+
+Every arrow means a governance dependency.
+
+No arrow implies runtime implementation procedure, source modification,
+code implementation, code execution, process start, runtime state
+creation, source merge authority, publication, distribution,
+installation, loading, execution, issuance, deployment, runtime state,
+or general runtime authority.
+
+Every dependency is explicit.
+
+No dependency is implied.
+
+Each RFC defines only its own layer. No RFC produces the authority of the
+next layer.
+
+## Closed Scope
+
+| Scope item | Closure result |
+|---|---|
+| Phase-20 pointer transition into Phase-20 | CLOSED AS GOVERNANCE INPUT |
+| Phase-20 governance overview | CLOSED |
+| Capability model | CLOSED |
+| Capability identity | CLOSED |
+| Capability manifest schema | CLOSED |
+| Capability lifecycle | CLOSED |
+| Registry model | CLOSED |
+| Registry governance | CLOSED |
+| Trust model | CLOSED |
+| Distribution policy | CLOSED |
+| Capability evidence model | CLOSED |
+| Capability acceptance workflow | CLOSED |
+| Implementation decision | CLOSED |
+| Implementation slice | CLOSED |
+| Implementation review | CLOSED |
+| Implementation acceptance decision | CLOSED |
+| Runtime decision | CLOSED |
+| Runtime decision review | CLOSED |
+| Runtime acceptance decision | CLOSED |
+| Runtime activation decision | CLOSED |
+| Runtime implementation decision | CLOSED |
+| Runtime implementation review | CLOSED |
+| Runtime implementation acceptance decision | CLOSED |
+| Decision subject post-merge verification | CLOSED FOR `288c555b31a1af3cfa02030cff92c258280b76a9` |
+
+The `CLOSED` statuses above are scoped governance closure results. They
+must not be read as runtime implementation procedure, source
+modification, code implementation, code execution, process start, runtime
+state creation, package loading, package execution, capability issuance,
+registry publication, trust assignment, source merge authority, general
+runtime authority, or Phase-21 pointer transition.
+
+## Runtime Implementation Acceptance Basis
+
+The Runtime Implementation Acceptance Decision published at exact main
+SHA `288c555b31a1af3cfa02030cff92c258280b76a9` records governance
+acceptance for reviewed bounded runtime implementation consideration
+proposals only.
+
+It preserves:
+
+1. Review result `conforms` is necessary but not sufficient for runtime
+   implementation acceptance.
+2. Runtime implementation accepted is not runtime implementation
+   procedure.
+3. Runtime implementation accepted is not source modification.
+4. Runtime implementation accepted is not code implementation.
+5. Runtime implementation accepted is not code execution.
+6. Runtime implementation accepted is not process start.
+7. Runtime implementation accepted is not runtime state creation.
+8. Runtime Implementation Acceptance Decision does not broaden Phase-19
+   runtime authority.
+9. Runtime Implementation Acceptance Decision does not expand Slice
+   scope.
+
+This closure decision accepts those records as closure-decision input. It
+does not extend, reinterpret, or replace them.
+
+## Exact-Subject Post-Merge Verification Input
+
+The following post-merge verification input is bound to decision subject:
+
+```text
+288c555b31a1af3cfa02030cff92c258280b76a9
+```
+
+| Evidence | Run / job | Result |
+|---|---|---|
+| Strict `ci-freeze` | run `28510944669`, job `84510838146` | PASS |
+| AykenOS Dev Loop CI smoke | run `28510944734`, job `84510838283` | PASS |
+| AykenOS Dev Loop CI contract | run `28510944734`, job `84511008168` | PASS |
+| AykenOS Dev Loop CI full | run `28510944734`, job `84511409675` | PASS |
+| AykenOS Dev Loop CI isolation | run `28510944734`, job `84511925556` | PASS |
+| AykenOS Dev Loop CI performance | run `28510944734`, job `84512436710` | PASS |
+| Dev Loop optimized | run `28510944752` | PASS |
+| Dev Loop validation | run `28510944665` | PASS |
+| Governance Summary | run `28510944686` | PASS |
+| Spec Purity | run `28510944680` | PASS |
+| Evidence Isolation | runs `28510944661` and `28510944725` | PASS |
+| Observation Boundary | run `28510944739` | PASS |
+| Naming Compliance | runs `28510944679` and `28510944706` | PASS |
+| Workspace boundary | run `28510944681` | PASS |
+| Semantic CLI contract boundary | run `28510944687` | PASS |
+| BCIB core boundary | run `28510944666` | PASS |
+| DSL BCIB contract boundary | run `28510944715` | PASS |
+| Data runtime BCIB boundary | run `28510944676` | PASS |
+| AI Runtime boundary | run `28510944753` | PASS |
+| Capability manager boundary | run `28510944668` | PASS |
+| Proofd observability boundary | run `28510944701` | PASS |
+| Toolchain opcode registry boundary | run `28510944698` | PASS |
+
+This table records closure-decision input only. It is not a new evidence
+package and does not grant runtime implementation procedure, source
+modification, code implementation, execution authority, runtime state, or
+Phase-21 pointer transition.
+
+## Closure Decision
+
+Phase-20 is closed for exact decision subject:
+
+```text
+288c555b31a1af3cfa02030cff92c258280b76a9
+```
+
+The closure is limited to the Phase-20 capability-to-runtime
+implementation governance chain and its exact recorded decision,
+review, acceptance, runtime, activation, runtime implementation, runtime
+implementation review, and runtime implementation acceptance records.
+
+The closure does not convert any Phase-20 capability, registry, trust,
+distribution, evidence, acceptance, implementation, runtime, activation,
+runtime implementation, runtime implementation review, or runtime
+implementation acceptance record into runtime implementation procedure
+or general runtime authority.
+
+## Phase-19 Runtime Authority Relationship
+
+Phase-20 closure remains subordinate to Phase-19 runtime authority
+records.
+
+Phase-20 closure must not broaden, replace, supersede, weaken, or
+reinterpret Phase-19 runtime authority records.
+
+Phase-20 closure must not use any Phase-20 closure result to infer
+Phase-19 runtime authority.
+
+Any Phase-20 closure reading that conflicts with Phase-19 runtime
+authority records fails closed.
+
+## Slice Scope Relationship
+
+Phase-20 closure does not reconstruct Slice scope.
+
+Phase-20 closure does not reinterpret Slice intent.
+
+Phase-20 closure does not expand bounded source scope.
+
+Phase-20 closure does not grant source modification, source acceptance,
+or source merge authority.
+
+Any closure reading that expands Slice scope fails closed.
+
+## Phase-21 Boundary
+
+First bounded implementation is deferred to Phase-21 only if Phase-21 is
+separately opened by a reviewed pointer transition or equivalent
+authority path.
+
+This closure decision does not open Phase-21.
+
+This closure decision does not authorize a Phase-21 pointer transition.
+
+This closure decision does not define Phase-21 scope.
+
+This closure decision does not authorize runtime implementation
+procedure in Phase-20 or Phase-21.
+
+A later Phase-21 pointer transition or implementation procedure decision,
+if ever authorized, must define its exact subject, exact input records,
+exact authority boundary, exact source boundary, exact execution
+boundary, exact runtime state boundary, package, loader, deployment,
+issuance, publication, trust, distribution, source, Semantic CLI, AI
+Runtime, agent, syscall, kernel ABI, and Ring0 denials, required review
+path, required post-decision verification, and non-authorization notice
+for anything outside scope.
+
+Until such a reviewed Phase-21 authority path exists, Phase-21 authority
+and runtime implementation procedure remain denied.
+
+## Explicit Non-Authorization
+
+This closure decision does not authorize:
+
+1. Phase-21 pointer transition.
+2. Phase-21 implementation authority.
+3. Runtime implementation procedure.
+4. Source modification.
+5. Code implementation.
+6. Code execution.
+7. Process start.
+8. Runtime state creation.
+9. General runtime authority.
+10. Unbounded execution authority.
+11. Package installation, loading, execution, scheduling, or publication.
+12. Module loading.
+13. Workspace creation, workspace runtime, or real mounts.
+14. Plugin host, plugin loading, or plugin instantiation.
+15. Deployment behavior.
+16. Capability token minting or capability issuance.
+17. Trust assignment.
+18. Trust issuer authority.
+19. Registry authority.
+20. Registry publication.
+21. Publication authority.
+22. Distribution authority.
+23. Distribution execution.
+24. Source acceptance or source merge authority.
+25. Source repository authority.
+26. Semantic CLI execution or verdict authority.
+27. AI Runtime authority.
+28. Agent behavior.
+29. New syscalls.
+30. Kernel ABI expansion.
+31. Workflow-threshold, baseline, dependency, or Ring0 policy changes.
+32. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this decision is merged, that merge publishes the Phase-20 closure
+decision. The landing SHA is the publication location of this decision
+record; it must not be read as a new Phase-20 implementation subject, a
+new runtime implementation procedure subject, a source modification
+subject, a runtime state subject, an execution subject, or an implicit
+Phase-21 pointer transition.
+
+The closure decision remains bound to:
+
+```text
+288c555b31a1af3cfa02030cff92c258280b76a9
+```
+
+The publication merge does not require a new Phase-20 runtime
+implementation acceptance decision merely because it publishes this
+closure decision.
+
+Any later technical change, authority expansion, pointer transition,
+source modification, code implementation, runtime implementation
+procedure, execution authority, runtime state, or Phase-21 activation
+still requires a separate reviewed decision path.
+
+## Closure Invariants
+
+Every later RFC must preserve these Phase-20 closure invariants:
+
+1. Phase-20 closure consumes the exact Runtime Implementation Acceptance
+   Decision record.
+2. Phase-20 closure closes only the exact Phase-20 governance chain.
+3. Phase-20 closure does not define runtime implementation procedure.
+4. Phase-20 closure does not modify source.
+5. Phase-20 closure does not implement code.
+6. Phase-20 closure does not execute code.
+7. Phase-20 closure does not start a process.
+8. Phase-20 closure does not create runtime state.
+9. Phase-20 closure does not load or execute packages.
+10. Phase-20 closure does not issue capabilities.
+11. Phase-20 closure does not publish registry entries.
+12. Phase-20 closure does not assign trust.
+13. Phase-20 closure does not grant source merge authority.
+14. Phase-20 closure does not broaden Phase-19 runtime authority.
+15. Phase-20 closure does not expand Slice scope.
+16. Phase-20 closure does not open Phase-21.
+17. Phase-20 closure does not authorize Phase-21 pointer transition.
+18. First bounded implementation requires a separate Phase-21 authority
+    path, if ever authorized.
+19. Closure decision record is not runtime state.
+20. Closure decision record is not execution handle.
+21. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-20 RFC
+**Architecture status:** Draft RFC / pending architectural review
+**Authority notice:** This signature identifies the architectural
+authorship of this RFC. It grants no Phase-21 pointer transition
+authority, runtime implementation procedure authority, source
+modification authority, code implementation authority, code execution
+authority, process start authority, general runtime authority, unbounded
+execution authority, runtime state authority, implementation authority,
+implementation approval authority, source merge authority, trust
+authority, evidence authority, acceptance authority, proof authority,
+constitutional authority, registry authority, distribution authority,
+publication authority, capability issuance authority, package authority,
+deployment authority, module authority, plugin authority, Semantic CLI
+authority, AI Runtime authority, agent authority, or Ring0 authority.
+
+## Decision Conclusion
+
+Phase-20 is closed for exact subject:
+
+```text
+288c555b31a1af3cfa02030cff92c258280b76a9
+```
+
+Phase-20 closure records completion of the capability-to-runtime
+implementation governance chain.
+
+Runtime implementation procedure, source modification, code
+implementation, code execution, process start, runtime state creation,
+package loading, package execution, capability issuance, registry
+publication, trust assignment, source merge authority, Phase-21 pointer
+transition, and all later-phase implementation authority remain pending
+and unauthorized until separately reviewed and decided.


### PR DESCRIPTION
This PR adds the Phase-20 closure decision RFC.

The closure decision is bound to the exact Runtime Implementation Acceptance Decision published at:

288c555b31a1af3cfa02030cff92c258280b76a9

It closes the Phase-20 capability-to-runtime implementation governance chain and preserves:
- no Phase-21 pointer transition
- no runtime implementation procedure
- no source modification
- no code implementation
- no code execution
- no process start
- no runtime state creation
- no package installation/loading/execution
- no capability issuance
- no registry publication
- no trust assignment
- no source merge authority
- no Phase-19 runtime authority broadening
- no Slice scope expansion

This PR changes only PHASE20_CLOSURE_DECISION.md.