### PR TITLE
Phase-21 first bounded implementation package decision RFC

### DIFF
--- a/PHASE21_FIRST_BOUNDED_IMPLEMENTATION_PACKAGE_DECISION.md
+++ b/PHASE21_FIRST_BOUNDED_IMPLEMENTATION_PACKAGE_DECISION.md
@@ -1,0 +1,862 @@
+# Phase-21 First Bounded Implementation Package Decision
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE20_POINTER_TRANSITION_DECISION.md`,
+`PHASE20_GOVERNANCE_OVERVIEW.md`,
+`PHASE20_CAPABILITY_MODEL.md`,
+`PHASE20_CAPABILITY_IDENTITY.md`,
+`PHASE20_CAPABILITY_MANIFEST_SCHEMA.md`,
+`PHASE20_CAPABILITY_LIFECYCLE.md`,
+`PHASE20_REGISTRY_MODEL.md`,
+`PHASE20_REGISTRY_GOVERNANCE.md`,
+`PHASE20_TRUST_MODEL.md`,
+`PHASE20_DISTRIBUTION_POLICY.md`,
+`PHASE20_CAPABILITY_EVIDENCE_MODEL.md`,
+`PHASE20_CAPABILITY_ACCEPTANCE_WORKFLOW.md`,
+`PHASE20_IMPLEMENTATION_DECISION.md`,
+`PHASE20_IMPLEMENTATION_SLICE.md`,
+`PHASE20_IMPLEMENTATION_REVIEW.md`,
+`PHASE20_IMPLEMENTATION_ACCEPTANCE_DECISION.md`,
+`PHASE20_RUNTIME_DECISION.md`,
+`PHASE20_RUNTIME_DECISION_REVIEW.md`,
+`PHASE20_RUNTIME_ACCEPTANCE_DECISION.md`,
+`PHASE20_RUNTIME_ACTIVATION_DECISION.md`,
+`PHASE20_RUNTIME_IMPLEMENTATION_DECISION.md`,
+`PHASE20_RUNTIME_IMPLEMENTATION_REVIEW.md`,
+`PHASE20_RUNTIME_IMPLEMENTATION_ACCEPTANCE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE21_POINTER_TRANSITION_DECISION.md`,
+`PHASE21_GOVERNANCE_OVERVIEW.md`, and
+`PHASE21_FIRST_BOUNDED_IMPLEMENTATION_SCOPE.md`. In case of conflict,
+those documents prevail unless this package decision RFC is the narrower
+Phase-21 first bounded implementation package decision record for the exact
+decision subject identified below.
+
+**Status:** PHASE-21 FIRST BOUNDED IMPLEMENTATION PACKAGE DECISION RFC /
+PACKAGE DECISION BOUNDARY ONLY / NO ACTUAL IMPLEMENTATION PACKAGE IN THIS
+RFC / NO VALIDATOR CODE / NO RECEIPT FILES / NO FIXTURE FILES / NO TESTS /
+NO CI WORKFLOW CHANGE / USERSPACE-ONLY FUTURE PACKAGE BOUNDARY /
+NON-EXECUTING FUTURE PACKAGE BOUNDARY / VALIDATOR, RECEIPT, FIXTURE, TEST,
+AND CI GATE ORIENTED FUTURE PACKAGE BOUNDARY / NO RUNTIME IMPLEMENTATION
+PROCEDURE / NO SOURCE MODIFICATION BY THIS RFC / NO CODE IMPLEMENTATION BY
+THIS RFC / NO CODE EXECUTION / NO PROCESS START / NO RUNTIME STATE CREATION /
+NO PACKAGE AUTHORITY / NO PACKAGE INSTALLATION / NO PACKAGE LOADING / NO
+PACKAGE EXECUTION / NO DEPLOYMENT / NO CAPABILITY ISSUANCE / NO TRUST
+ASSIGNMENT / NO REGISTRY PUBLICATION / NO DISTRIBUTION AUTHORITY / NO SOURCE
+MERGE AUTHORITY / NO SOURCE ACCEPTANCE
+**Decision date:** 2026-07-02
+**Decision id:** `ayken.phase21.first_bounded_implementation_package_decision.v1`
+**Decision base main SHA:** `d1790881ddc574ddc8359b29a778a53a1ed44b13`
+**Reviewed Phase-21 first bounded implementation scope SHA:**
+`d1790881ddc574ddc8359b29a778a53a1ed44b13`
+**Reviewed Phase-21 governance overview SHA:**
+`ae3f9f05cad36451e49a81e4ccfe593d7a9f9ec6`
+**Current phase pointer:** `CURRENT_PHASE=21`
+**Package decision theme:** First Bounded Implementation Package Boundary
+**Authority boundary:** Package decision boundary only; not an actual
+implementation package, not validator code, not receipt files, not fixture
+files, not tests, not CI workflow change, not runtime implementation
+procedure, not source modification, not code implementation, not code
+execution, not process start, not runtime state creation, not general runtime
+authority, not unbounded execution authority, not package authority, not
+package installation, not package loading, not package execution, not
+deployment, not source acceptance, not source merge authority, not source
+repository authority, not module loading, not workspace runtime, not plugin
+loading, not capability token minting, not capability issuance, not trust
+assignment, not trust issuer authority, not registry authority, not registry
+publication, not publication authority, not distribution authority, not
+distribution execution, not Semantic CLI authority, not AI Runtime authority,
+not agent authority, not syscall expansion, not kernel ABI expansion, not
+workflow-threshold, baseline, dependency, or Ring0 authority.
+
+## Purpose
+
+This document defines the decision boundary for a possible later Phase-21
+first bounded implementation package. It does not create the package, modify
+source, implement code, execute code, start a process, create runtime state,
+load packages, issue capabilities, publish registry entries, assign trust, or
+grant source merge authority.
+
+This decision answers what a later implementation package PR may be allowed
+to contain. It does not contain that package.
+
+It answers one question:
+
+```text
+What boundary must a later Phase-21 first bounded implementation package PR
+remain inside before that package can be reviewed?
+```
+
+It does not answer:
+
+```text
+What is the actual implementation package?
+What validator code is added?
+What receipt files are added?
+What fixture files are added?
+What tests are added?
+What CI workflow changes are made?
+How is runtime implementation procedure defined?
+How is source modified?
+How is code implemented?
+How is code executed?
+How is a process started?
+How is runtime state created?
+How is a package installed, loaded, executed, deployed, or distributed?
+How is a module loaded?
+How is a plugin instantiated?
+How is a capability issued?
+How is trust assigned?
+How is a registry entry published?
+How is source accepted or merged?
+```
+
+Those questions belong to later reviewed RFCs or decision paths, if ever
+authorized.
+
+## Exact Subject
+
+This package decision RFC is bound to the Phase-21 First Bounded
+Implementation Scope published at exact main SHA:
+
+```text
+d1790881ddc574ddc8359b29a778a53a1ed44b13
+```
+
+The exact subject records First Bounded Implementation Scope as:
+
+```text
+userspace-only
+non-executing
+validator / receipt / fixture / CI gate oriented
+fail-closed
+exact-SHA evidence oriented
+```
+
+The exact subject also records:
+
+1. No runtime implementation procedure.
+2. No source modification by that scope RFC.
+3. No code implementation by that scope RFC.
+4. No code execution.
+5. No process start.
+6. No runtime state creation.
+7. No package loading or package execution.
+8. No capability issuance.
+9. No registry publication.
+10. No trust assignment.
+11. No source merge authority.
+12. No Phase-19 runtime authority broadening.
+13. No Phase-20 reopening.
+14. No kernel ABI or syscall expansion.
+
+This package decision consumes that exact subject as governance input only.
+It does not replace, broaden, reinterpret, or supersede the Phase-21 First
+Bounded Implementation Scope.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped subject readings fail closed.
+
+## Package Decision Scope
+
+The Phase-21 first bounded implementation package decision is a governance
+decision boundary for a possible later implementation package.
+
+A later first bounded implementation package may be proposed only as a
+userspace-only, non-executing, validator / receipt / fixture / test / CI gate
+oriented package, and only through a separate reviewed PR with its own
+exact-SHA evidence.
+
+This package decision is not the actual package.
+
+This package decision is not validator code.
+
+This package decision is not receipt files.
+
+This package decision is not fixture files.
+
+This package decision is not tests.
+
+This package decision is not CI workflow change.
+
+This package decision is not runtime implementation procedure.
+
+This package decision is not source modification.
+
+This package decision is not code implementation.
+
+This package decision is not code execution.
+
+This package decision is not process start.
+
+This package decision is not runtime state creation.
+
+Unknown authority readings fail closed.
+
+## Core Rule
+
+```text
+package decision != implementation package
+package decision != validator code
+package decision != receipt files
+package decision != fixture files
+package decision != tests
+package decision != CI workflow change
+package decision != source modification
+package decision != code implementation
+package decision != code execution
+package decision != runtime implementation procedure
+package decision != process start
+package decision != runtime state creation
+package decision != package loading
+package decision != package execution
+package decision != capability issuance
+package decision != registry publication
+package decision != trust assignment
+package decision != source merge
+future package category != current file creation
+future file category != current file change
+allowed future category != accepted future package
+```
+
+The safe default remains no source modification, no implementation package,
+no runtime implementation procedure, no code execution, no process start, no
+runtime state, and no package, capability, registry, trust, distribution,
+deployment, or source merge authority unless a later reviewed Phase-21
+decision grants a specific bounded authority with its own exact-SHA evidence.
+
+## Allowed Future Package Categories
+
+This decision may identify only future package categories that a later
+implementation package PR may propose.
+
+Allowed future package categories are limited to:
+
+1. Userspace-only static validator package category.
+2. Receipt evidence category.
+3. Fixture category.
+4. Non-executing test category expectations.
+5. CI gate category expectations.
+6. Fail-closed validation behavior category.
+7. Exact-SHA evidence requirement category.
+8. Denied runtime, package, process, state, issuance, publication, trust, and
+   source-merge reading category.
+9. Post-merge verification category.
+
+Allowed future package categories are categories only.
+
+They do not create package files.
+
+They do not create validator code.
+
+They do not create receipt files.
+
+They do not create fixture files.
+
+They do not create tests.
+
+They do not create or modify CI workflows.
+
+They do not grant package loading or package execution.
+
+They do not grant runtime implementation procedure.
+
+## Allowed Future File Categories
+
+This decision may identify only future file categories for a later separately
+reviewed implementation package PR.
+
+Allowed future file categories may include only:
+
+1. Future package boundary documentation.
+2. Future userspace-only static validator source category.
+3. Future validator metadata or configuration category, if non-executing and
+   fail-closed.
+4. Future receipt schema, receipt template, or receipt evidence category.
+5. Future fixture category for static validation inputs.
+6. Future non-runtime test file category.
+7. Future CI gate descriptor or expectation category.
+8. Future exact-SHA evidence notes category.
+9. Future post-merge verification notes category.
+
+Allowed future file categories are not current file changes.
+
+Allowed future file categories do not create files in this RFC.
+
+Allowed future file categories do not authorize source modification by this
+RFC.
+
+Allowed future file categories do not authorize code implementation by this
+RFC.
+
+Allowed future file categories do not authorize test implementation by this
+RFC.
+
+Allowed future file categories do not authorize fixture creation by this RFC.
+
+Allowed future file categories do not authorize receipt creation by this RFC.
+
+Allowed future file categories do not authorize CI workflow changes by this
+RFC.
+
+Each future file category requires its own later reviewed PR, exact subject,
+evidence, and denied-reading boundary before any file is added or modified.
+
+## Denied Current Changes
+
+This package decision RFC does not authorize current changes to:
+
+1. Actual validator code.
+2. Actual receipt files.
+3. Actual fixture files.
+4. Actual tests.
+5. CI workflows.
+6. Source code.
+7. Runtime code.
+8. Kernel code.
+9. Package files.
+10. Module files.
+11. Workspace runtime files.
+12. Plugin host files.
+13. Semantic CLI implementation files.
+14. AI Runtime implementation files.
+15. Agent implementation files.
+16. Capability issuer files.
+17. Registry publication files.
+18. Trust assignment files.
+19. Baselines.
+20. Dependency files.
+21. Workflow-threshold files.
+
+This package decision RFC does not authorize current runtime implementation
+procedure, source modification, code implementation, code execution, process
+start, runtime state creation, package installation, package loading, package
+execution, capability issuance, registry publication, trust assignment,
+source acceptance, or source merge.
+
+Any current-change reading fails closed.
+
+## Denied Current File Changes
+
+This RFC may be published only as a package decision record.
+
+Denied current file changes include:
+
+1. Validator source files.
+2. Validator configuration files.
+3. Receipt files.
+4. Receipt schema files.
+5. Receipt evidence files.
+6. Fixture files.
+7. Test files.
+8. CI workflow files.
+9. CI gate implementation files.
+10. Runtime source files.
+11. Kernel source files.
+12. Package loader files.
+13. Module loader files.
+14. Workspace runtime files.
+15. Plugin host files.
+16. Capability issuer files.
+17. Registry publication files.
+18. Trust issuer or trust assignment files.
+19. Semantic CLI authority files.
+20. AI Runtime authority files.
+21. Agent authority files.
+22. Syscall metadata files.
+23. Kernel ABI metadata files.
+24. Baseline files.
+25. Dependency lock files.
+
+Denied current file changes remain denied until a later reviewed decision
+path authorizes a narrower exact file set.
+
+## Validator Boundary
+
+Validator boundary is future-category only in this package decision.
+
+A later package may propose a userspace-only static validator only if a
+separate reviewed PR defines its exact source boundary, non-execution
+boundary, input boundary, output boundary, failure model, evidence model, and
+post-merge verification.
+
+This package decision does not create validator code.
+
+This package decision does not modify validator code.
+
+This package decision does not execute a validator.
+
+This package decision does not accept validator output.
+
+This package decision does not treat validator presence as authority.
+
+Validator ambiguity fails closed.
+
+## Receipt Boundary
+
+Receipt boundary is future-category only in this package decision.
+
+A later package may propose receipt files, schemas, templates, or evidence
+notes only if a separate reviewed PR defines exact receipt meaning, exact
+non-authority readings, exact evidence binding, exact-SHA requirements, and
+post-merge verification.
+
+This package decision does not create receipt files.
+
+This package decision does not accept receipt evidence.
+
+This package decision does not issue proof.
+
+This package decision does not grant authority from receipt presence.
+
+Receipt ambiguity fails closed.
+
+## Fixture Boundary
+
+Fixture boundary is future-category only in this package decision.
+
+A later package may propose fixtures only if a separate reviewed PR defines
+exact fixture categories, exact fixture purpose, exact non-runtime readings,
+exact non-execution readings, exact denied loader readings, and exact-SHA
+evidence.
+
+This package decision does not create fixture files.
+
+This package decision does not load fixtures.
+
+This package decision does not execute fixtures.
+
+This package decision does not treat fixture presence as authority.
+
+Fixture ambiguity fails closed.
+
+## Test Boundary
+
+Test boundary is future-category only in this package decision.
+
+A later package may propose tests only if a separate reviewed PR defines
+exact test categories, exact test execution boundary, exact non-runtime
+boundary, exact fixture usage boundary, exact CI relationship, and exact-SHA
+evidence.
+
+This package decision does not create tests.
+
+This package decision does not execute tests.
+
+This package decision does not modify test infrastructure.
+
+This package decision does not grant runtime test authority.
+
+This package decision does not treat test presence as implementation
+acceptance.
+
+Test ambiguity fails closed.
+
+## CI Gate Boundary
+
+CI gate boundary is future-category only in this package decision.
+
+A later package may propose CI gate expectations only if a separate reviewed
+PR defines exact gate behavior, exact workflow boundary, exact threshold
+boundary, exact baseline boundary, exact dependency boundary, exact evidence
+requirements, and exact fail-closed handling.
+
+This package decision does not create CI workflows.
+
+This package decision does not modify CI workflows.
+
+This package decision does not change workflow thresholds.
+
+This package decision does not change baselines.
+
+This package decision does not change dependencies.
+
+This package decision does not bypass CI.
+
+This package decision does not weaken enforcement policy.
+
+CI gate ambiguity fails closed.
+
+## Source / Execution / Runtime State Boundary
+
+This package decision RFC is non-mutating.
+
+It does not modify source.
+
+It does not create implementation files.
+
+It does not create validator code.
+
+It does not create receipt files.
+
+It does not create fixture files.
+
+It does not create tests.
+
+It does not create CI workflows.
+
+It does not implement code.
+
+It does not execute code.
+
+It does not start a process.
+
+It does not create runtime state.
+
+It does not depend on runtime-observed state.
+
+It does not install, load, or execute packages.
+
+Any source, execution, process, runtime state, package, module, workspace,
+plugin, capability, registry, trust, distribution, deployment, or source
+merge reading fails closed.
+
+## Package / Module / Workspace / Plugin Boundary
+
+This package decision does not define package installation, package loading,
+package execution, module loading, workspace runtime, real mounts, plugin
+host behavior, plugin loading, or plugin instantiation.
+
+A later implementation package must remain non-loading and non-executing
+unless a separate reviewed decision path defines exact narrower behavior.
+
+This decision does not create package authority.
+
+This decision does not create module authority.
+
+This decision does not create workspace runtime authority.
+
+This decision does not create plugin authority.
+
+Any package, module, workspace, or plugin authority reading fails closed.
+
+## Capability / Registry / Trust Boundary
+
+This package decision does not issue capabilities.
+
+This package decision does not mint capability tokens.
+
+This package decision does not publish registry entries.
+
+This package decision does not create registry authority.
+
+This package decision does not assign trust.
+
+This package decision does not create trust issuer authority.
+
+This package decision does not authorize distribution.
+
+This package decision does not authorize deployment.
+
+Any capability, registry, trust, distribution, or deployment reading fails
+closed.
+
+## Relationship To First Bounded Implementation Scope
+
+This package decision consumes the Phase-21 First Bounded Implementation
+Scope as its exact governance prerequisite.
+
+The Phase-21 First Bounded Implementation Scope remains bound to:
+
+```text
+d1790881ddc574ddc8359b29a778a53a1ed44b13
+```
+
+This package decision preserves:
+
+1. Userspace-only boundary.
+2. Non-executing boundary.
+3. Validator, receipt, fixture, and CI gate orientation.
+4. Fail-closed behavior.
+5. Exact-SHA evidence orientation.
+6. No runtime implementation procedure.
+7. No source modification by this RFC.
+8. No code implementation by this RFC.
+9. No code execution.
+10. No process start.
+11. No runtime state creation.
+12. No package loading or package execution.
+13. No capability issuance.
+14. No registry publication.
+15. No trust assignment.
+16. No source merge authority.
+
+This package decision narrows the scope boundary into future package
+categories. It does not implement the package.
+
+Any reading that treats this package decision as the implementation package
+fails closed.
+
+## Relationship To Phase-21 Governance Overview
+
+This package decision remains subordinate to the Phase-21 Governance Overview.
+
+The Phase-21 Governance Overview remains bound to:
+
+```text
+ae3f9f05cad36451e49a81e4ccfe593d7a9f9ec6
+```
+
+This package decision does not replace, broaden, reinterpret, or supersede
+the Phase-21 Governance Overview.
+
+This package decision does not convert `CURRENT_PHASE=21` into
+implementation authority, execution authority, source authority, package
+authority, registry authority, trust authority, or source merge authority.
+
+Any Phase-21 governance overview conflict fails closed.
+
+## Relationship To Phase-20 Closure
+
+Phase-20 remains closed for exact subject:
+
+```text
+ee1f1c7f43fe478c8cbdab3fbeb2844365c9c5bc
+```
+
+This package decision does not reopen Phase-20.
+
+This package decision does not reinterpret Phase-20 closure.
+
+This package decision does not extend Phase-20 closure into Phase-21
+implementation package authority.
+
+This package decision does not convert Phase-20 Runtime Implementation
+Acceptance Decision, Phase-20 Closure Decision, or any Phase-20 governance
+record into runtime implementation procedure, source modification, code
+implementation, code execution, process start, runtime state creation,
+package loading, capability issuance, registry publication, trust assignment,
+or source merge authority.
+
+Any Phase-20 closure conflict fails closed.
+
+## Relationship To Phase-19 Runtime Authority
+
+This package decision remains subordinate to Phase-19 runtime authority
+records.
+
+Phase-19 runtime records may be read as boundary context for:
+
+1. Runtime MVP planning boundaries.
+2. Runtime evidence expectations.
+3. Runtime non-goals and denials.
+4. Platform runtime constitutional constraints.
+5. Userspace-only runtime constraints.
+6. Frozen syscall and kernel ABI boundaries.
+7. Denied package, module, workspace, plugin, trust, capability, AI Runtime,
+   Semantic CLI, and agent authority readings.
+
+This package decision must not broaden, replace, supersede, weaken, or
+reinterpret Phase-19 runtime authority records.
+
+This package decision must not use Phase-21 package decision scope to infer
+Phase-19 runtime authority.
+
+This package decision must not use `CURRENT_PHASE=21` to infer runtime
+authority.
+
+Any Phase-21 package decision reading that conflicts with Phase-19 runtime
+authority records fails closed.
+
+## Kernel And ABI Boundary
+
+The kernel ABI remains frozen.
+
+This package decision does not authorize:
+
+1. New syscalls.
+2. Kernel ABI expansion.
+3. Syscall ID changes.
+4. Syscall count changes.
+5. ABI version changes.
+6. Ring0 policy movement.
+7. Kernel source modification.
+8. Runtime source modification.
+9. Workflow-threshold changes.
+10. Baseline changes.
+11. Dependency changes.
+
+Any kernel, ABI, workflow-threshold, baseline, dependency, or Ring0 policy
+reading fails closed.
+
+## Later Implementation Package PR Dependency
+
+This package decision is a prerequisite governance input for a later actual
+first bounded implementation package PR only if that later PR is separately
+reviewed and authorized.
+
+A later actual implementation package PR, if ever authorized, must define:
+
+1. Exact package subject.
+2. Exact source file set.
+3. Exact validator file set.
+4. Exact receipt file set.
+5. Exact fixture file set.
+6. Exact test file set.
+7. Exact CI gate relationship.
+8. Exact non-execution boundary.
+9. Exact fail-closed behavior.
+10. Exact evidence requirements.
+11. Exact post-merge verification.
+12. Exact denied readings for runtime implementation procedure, code
+    execution, process start, runtime state creation, package loading,
+    package execution, module loading, workspace runtime, plugin loading,
+    capability issuance, registry publication, trust assignment, distribution
+    execution, deployment, source acceptance, and source merge authority.
+
+Until such a later reviewed PR exists, no actual implementation package
+authority is granted.
+
+Actual package presence is not runtime implementation procedure.
+
+Actual package presence is not code execution.
+
+Actual package presence is not process start.
+
+Actual package presence is not runtime state creation.
+
+Actual package presence is not package loading or package execution.
+
+## Decision Results
+
+This package decision may record only:
+
+1. `package_boundary_recorded`
+2. `package_boundary_rejected`
+3. `package_boundary_quarantined`
+4. `package_boundary_deferred`
+
+`package_boundary_recorded` means only that a future implementation package
+boundary has been recorded.
+
+`package_boundary_recorded` is not an implementation package.
+
+`package_boundary_recorded` is not source modification.
+
+`package_boundary_recorded` is not code implementation.
+
+`package_boundary_recorded` is not code execution.
+
+`package_boundary_recorded` is not runtime implementation procedure.
+
+`package_boundary_recorded` is not runtime state creation.
+
+No decision result grants package loading, package execution, capability
+issuance, registry publication, trust assignment, source acceptance, source
+merge authority, deployment authority, or general runtime authority.
+
+## Decision Invariants
+
+Every later Phase-21 RFC must preserve these first bounded implementation
+package decision invariants:
+
+1. Package decision is not actual implementation package.
+2. Package decision does not create validator code.
+3. Package decision does not create receipt files.
+4. Package decision does not create fixture files.
+5. Package decision does not create tests.
+6. Package decision does not create or modify CI workflows.
+7. Package decision does not modify source.
+8. Package decision does not implement code.
+9. Package decision does not execute code.
+10. Package decision does not define runtime implementation procedure.
+11. Package decision does not start a process.
+12. Package decision does not create runtime state.
+13. Package decision does not install packages.
+14. Package decision does not load packages.
+15. Package decision does not execute packages.
+16. Package decision does not issue capabilities.
+17. Package decision does not publish registry entries.
+18. Package decision does not assign trust.
+19. Package decision does not grant source merge authority.
+20. Package decision does not broaden Phase-19 runtime authority.
+21. Package decision does not reopen Phase-20.
+22. Package decision does not expand kernel ABI or syscalls.
+23. Future allowed file categories are not current file changes.
+24. Future package category is not accepted package authority.
+25. Later actual implementation package authority requires a separate
+    reviewed PR and exact-SHA evidence.
+26. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Publication Boundary
+
+If this package decision RFC is merged, the landing SHA publishes only this
+package decision record. The landing SHA must not be read as actual
+implementation package authority, validator code, receipt files, fixture
+files, tests, CI workflow change, runtime implementation procedure, source
+modification authority, code implementation authority, code execution
+authority, process start authority, runtime state authority, package loading
+authority, package execution authority, capability issuance authority,
+registry publication authority, trust assignment authority, source merge
+authority, implementation authority, or general runtime authority.
+
+The package decision remains bound to:
+
+```text
+d1790881ddc574ddc8359b29a778a53a1ed44b13
+```
+
+Any later technical change, authority expansion, implementation package
+proposal, procedure proposal, source modification, execution authority,
+runtime state, package behavior, capability behavior, registry behavior,
+trust behavior, distribution behavior, deployment behavior, Semantic CLI
+behavior, AI Runtime behavior, agent behavior, or source merge behavior
+requires a separate reviewed decision path.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-21 RFC
+**Architecture status:** Draft RFC / pending architectural review
+**Authority notice:** This signature identifies the architectural authorship
+of this RFC. It grants no actual implementation package authority, validator
+code authority, receipt file authority, fixture file authority, test
+authority, CI workflow authority, runtime implementation procedure authority,
+source modification authority, code implementation authority, code execution
+authority, process start authority, general runtime authority, unbounded
+execution authority, runtime state authority, implementation authority,
+implementation approval authority, source merge authority, trust authority,
+evidence authority, acceptance authority, proof authority, constitutional
+authority, registry authority, distribution authority, publication authority,
+capability issuance authority, package authority, deployment authority,
+module authority, plugin authority, Semantic CLI authority, AI Runtime
+authority, agent authority, or Ring0 authority.
+
+## Conclusion
+
+Phase-21 First Bounded Implementation Package Decision defines only the
+decision boundary for a possible later implementation package.
+
+A later first bounded implementation package may be proposed only as:
+
+```text
+userspace-only
+non-executing
+validator / receipt / fixture / test / CI gate oriented
+fail-closed
+exact-SHA evidence oriented
+```
+
+This decision does not contain that package.
+
+This decision does not create validator code, receipt files, fixture files,
+tests, CI workflow changes, source modification, code implementation, code
+execution, runtime implementation procedure, process start, runtime state
+creation, package loading, package execution, capability issuance, registry
+publication, trust assignment, source acceptance, source merge authority,
+Phase-19 runtime authority broadening, Phase-20 reopening, or kernel
+ABI/syscall expansion.
+
+Any later actual first bounded implementation package requires a separate
+reviewed PR and exact-SHA evidence.


### PR DESCRIPTION
This PR adds the Phase-21 first bounded implementation package decision RFC.

The package decision is bound to the Phase-21 First Bounded Implementation Scope exact-main SHA:

d1790881ddc574ddc8359b29a778a53a1ed44b13

It defines only the decision boundary for a possible later first bounded implementation package.

It does not add the actual package.

It preserves:
- no actual implementation package
- no validator code
- no receipt files
- no fixture files
- no tests
- no CI workflow changes
- no runtime implementation procedure
- no source modification by this RFC
- no code implementation by this RFC
- no code execution
- no process start
- no runtime state creation
- no package installation/loading/execution
- no capability issuance
- no registry publication
- no trust assignment
- no source merge authority
- no Phase-19 runtime authority broadening
- no Phase-20 reopening
- no kernel ABI/syscall expansion

This PR changes only PHASE21_FIRST_BOUNDED_IMPLEMENTATION_PACKAGE_DECISION.md.