### PR TITLE
Phase-21 actual skeleton

### DIFF
--- a/docs/specs/phase21-first-bounded-implementation/CI_GATE_EXPECTATIONS.md
+++ b/docs/specs/phase21-first-bounded-implementation/CI_GATE_EXPECTATIONS.md
@@ -1,0 +1,34 @@
+# Phase-21 First Bounded CI Gate Expectations
+
+This document records expected CI observation for the Phase-21 first bounded
+implementation skeleton.
+
+It does not create, modify, enable, bypass, or weaken CI workflows. It does
+not change workflow thresholds, baselines, dependency files, or enforcement
+policy.
+
+## Expected Existing Gates
+
+A later exact-subject skeleton PR is expected to collect:
+
+1. `ci-freeze` PASS.
+2. AykenOS Dev Loop CI PASS.
+3. smoke PASS.
+4. contract PASS.
+5. full PASS.
+6. isolation PASS.
+7. performance PASS.
+8. Governance Summary PASS.
+9. Spec Purity PASS.
+10. Evidence Isolation PASS.
+11. Naming Compliance PASS.
+12. Observation Boundary PASS.
+13. Workspace boundary PASS.
+14. Semantic CLI contract boundary PASS.
+15. BCIB, DSL BCIB, data runtime, AI Runtime, capability manager, proofd
+    observability, and toolchain opcode registry boundary PASS.
+
+Historical PASS results may be cited as context only. They cannot be
+inherited as evidence for a new exact SHA.
+
+CI expectation documentation is not CI workflow authority.

--- a/docs/specs/phase21-first-bounded-implementation/EVIDENCE_NOTES.md
+++ b/docs/specs/phase21-first-bounded-implementation/EVIDENCE_NOTES.md
@@ -1,0 +1,28 @@
+# Phase-21 First Bounded Evidence Notes
+
+This document records evidence expectations for the Phase-21 first bounded
+implementation skeleton.
+
+These notes are not accepted evidence, proof, package acceptance, source
+acceptance, source merge authority, runtime authority, package loading
+authority, capability issuance authority, registry publication authority, or
+trust assignment authority.
+
+## Exact-SHA Evidence Expectations
+
+A later exact-main skeleton subject must record:
+
+1. Exact merge SHA.
+2. Exact changed-file list.
+3. Exact category mapping.
+4. `ci-freeze` run and result.
+5. AykenOS Dev Loop CI run and result.
+6. smoke, contract, full, isolation, and performance results.
+7. Governance, spec, evidence, naming, observation, and boundary gate
+   results.
+8. Confirmation that no CI workflow, baseline, dependency, threshold, kernel
+   ABI, syscall, or Ring0 policy file changed.
+
+Historical PASS results are not inherited across SHAs.
+
+Planned evidence is not accepted evidence.

--- a/docs/specs/phase21-first-bounded-implementation/PACKAGE_BOUNDARY.md
+++ b/docs/specs/phase21-first-bounded-implementation/PACKAGE_BOUNDARY.md
@@ -1,0 +1,86 @@
+# Phase-21 First Bounded Implementation Package Boundary
+
+This document records the boundary for the Phase-21 first bounded
+implementation actual skeleton.
+
+The skeleton is limited to static, userspace-only, non-executing package
+shape material. It is not package acceptance, runtime implementation
+procedure, execution authority, process start authority, runtime state
+authority, package loading authority, capability issuance authority, registry
+publication authority, trust assignment authority, or source merge authority.
+
+## Exact Skeleton File Set
+
+The actual skeleton file set is limited to:
+
+```text
+docs/specs/phase21-first-bounded-implementation/PACKAGE_BOUNDARY.md
+tools/phase21_first_bounded_validator/README.md
+tools/phase21_first_bounded_validator/validator_skeleton.py
+docs/specs/phase21-first-bounded-implementation/receipts/RECEIPT_SCHEMA.md
+docs/specs/phase21-first-bounded-implementation/receipts/RECEIPT_TEMPLATE.md
+docs/specs/phase21-first-bounded-implementation/fixtures/README.md
+docs/specs/phase21-first-bounded-implementation/fixtures/minimal_valid_manifest.fixture.json
+docs/specs/phase21-first-bounded-implementation/fixtures/denied_runtime_authority.fixture.json
+tests/phase21_first_bounded_static/README.md
+tests/phase21_first_bounded_static/test_validator_skeleton_static.py
+docs/specs/phase21-first-bounded-implementation/CI_GATE_EXPECTATIONS.md
+docs/specs/phase21-first-bounded-implementation/EVIDENCE_NOTES.md
+```
+
+Any file outside this list is outside the actual skeleton boundary.
+
+## Category Mapping
+
+| File | Category |
+|---|---|
+| `PACKAGE_BOUNDARY.md` | Package boundary document |
+| `tools/phase21_first_bounded_validator/README.md` | Static validator skeleton |
+| `tools/phase21_first_bounded_validator/validator_skeleton.py` | Static validator skeleton |
+| `receipts/RECEIPT_SCHEMA.md` | Receipt schema/template |
+| `receipts/RECEIPT_TEMPLATE.md` | Receipt schema/template |
+| `fixtures/README.md` | Fixture input examples |
+| `fixtures/minimal_valid_manifest.fixture.json` | Fixture input examples |
+| `fixtures/denied_runtime_authority.fixture.json` | Fixture input examples |
+| `tests/phase21_first_bounded_static/README.md` | Non-runtime tests |
+| `tests/phase21_first_bounded_static/test_validator_skeleton_static.py` | Non-runtime tests |
+| `CI_GATE_EXPECTATIONS.md` | CI gate expectation documentation |
+| `EVIDENCE_NOTES.md` | Exact-SHA evidence notes |
+
+## Non-Authorization Boundary
+
+This skeleton does not authorize:
+
+1. Package acceptance.
+2. Package review result.
+3. Runtime implementation procedure.
+4. Code execution.
+5. Process start.
+6. Runtime state creation.
+7. Package installation, loading, or execution.
+8. Module loading.
+9. Workspace runtime or real mounts.
+10. Plugin loading or plugin instantiation.
+11. Capability issuance.
+12. Registry publication.
+13. Trust assignment.
+14. Distribution execution.
+15. Deployment.
+16. Source acceptance.
+17. Source merge authority.
+18. Syscall expansion.
+19. Kernel ABI expansion.
+20. Ring0 policy movement.
+
+Unknown authority readings fail closed.
+
+## Non-Executing Guarantee
+
+The skeleton has no runtime entrypoint, package loader entrypoint, module
+loader entrypoint, workspace mount behavior, plugin loader behavior, process
+spawning hook, runtime state writer, capability issuer, registry publisher,
+trust issuer, deployment hook, or distribution execution hook.
+
+Static inspection of the skeleton is not execution authority.
+
+Presence of the skeleton is not package acceptance.

--- a/docs/specs/phase21-first-bounded-implementation/fixtures/README.md
+++ b/docs/specs/phase21-first-bounded-implementation/fixtures/README.md
@@ -1,0 +1,21 @@
+# Phase-21 First Bounded Fixture Inputs
+
+This directory contains static fixture input examples for the Phase-21 first
+bounded implementation skeleton.
+
+Fixtures are examples only. They are not runtime fixtures, package manifests
+for loading, executable inputs, accepted evidence, registry entries, trust
+assignments, or source merge authority.
+
+## Boundary
+
+Fixture examples must remain:
+
+1. Static.
+2. Non-executing.
+3. Userspace-only.
+4. Not loaded by runtime behavior.
+5. Not treated as evidence acceptance.
+6. Not treated as package acceptance.
+
+Unknown fixture authority readings fail closed.

--- a/docs/specs/phase21-first-bounded-implementation/fixtures/denied_runtime_authority.fixture.json
+++ b/docs/specs/phase21-first-bounded-implementation/fixtures/denied_runtime_authority.fixture.json
@@ -1,0 +1,27 @@
+{
+  "fixture_id": "ayken.phase21.first_bounded.fixture.denied_runtime_authority.v1",
+  "fixture_type": "static_denied_authority_example",
+  "non_executing": true,
+  "runtime_authority": false,
+  "denied_request": {
+    "runtime_implementation_procedure": true,
+    "code_execution": true,
+    "process_start": true,
+    "runtime_state_creation": true,
+    "package_loading": true,
+    "package_execution": true
+  },
+  "expected_static_reading": "fail_closed",
+  "denied_authorities": [
+    "runtime_implementation_procedure",
+    "code_execution",
+    "process_start",
+    "runtime_state_creation",
+    "package_loading",
+    "package_execution",
+    "capability_issuance",
+    "registry_publication",
+    "trust_assignment",
+    "source_merge_authority"
+  ]
+}

--- a/docs/specs/phase21-first-bounded-implementation/fixtures/minimal_valid_manifest.fixture.json
+++ b/docs/specs/phase21-first-bounded-implementation/fixtures/minimal_valid_manifest.fixture.json
@@ -1,0 +1,24 @@
+{
+  "fixture_id": "ayken.phase21.first_bounded.fixture.minimal_valid_manifest.v1",
+  "fixture_type": "static_validation_input_example",
+  "non_executing": true,
+  "package_loading_authority": false,
+  "runtime_authority": false,
+  "manifest": {
+    "name": "phase21-minimal-static-example",
+    "version": "0.0.0",
+    "kind": "static-skeleton-example"
+  },
+  "denied_authorities": [
+    "runtime_implementation_procedure",
+    "code_execution",
+    "process_start",
+    "runtime_state_creation",
+    "package_loading",
+    "package_execution",
+    "capability_issuance",
+    "registry_publication",
+    "trust_assignment",
+    "source_merge_authority"
+  ]
+}

--- a/docs/specs/phase21-first-bounded-implementation/receipts/RECEIPT_SCHEMA.md
+++ b/docs/specs/phase21-first-bounded-implementation/receipts/RECEIPT_SCHEMA.md
@@ -1,0 +1,36 @@
+# Phase-21 First Bounded Receipt Schema
+
+This document describes the static shape of a possible later receipt for the
+Phase-21 first bounded implementation skeleton.
+
+The schema is documentation only. It is not evidence acceptance, proof,
+package acceptance, source acceptance, runtime authority, trust authority,
+registry authority, capability authority, or source merge authority.
+
+## Static Shape
+
+A future receipt may include:
+
+1. `subject_sha`: exact SHA under review.
+2. `changed_files`: exact changed-file list.
+3. `category_mapping`: file-to-category mapping.
+4. `non_executing_boundary`: recorded non-execution statement.
+5. `denied_authorities`: denied authority list.
+6. `evidence_runs`: exact CI run identifiers, if later accepted.
+7. `result`: later review result, if separately authorized.
+
+## Denials
+
+Receipt schema presence does not:
+
+1. Accept evidence.
+2. Issue proof.
+3. Accept a package.
+4. Accept source.
+5. Authorize code execution.
+6. Authorize package loading.
+7. Assign trust.
+8. Publish registry entries.
+9. Grant source merge authority.
+
+Unknown authority readings fail closed.

--- a/docs/specs/phase21-first-bounded-implementation/receipts/RECEIPT_TEMPLATE.md
+++ b/docs/specs/phase21-first-bounded-implementation/receipts/RECEIPT_TEMPLATE.md
@@ -1,0 +1,37 @@
+# Phase-21 First Bounded Receipt Template
+
+This template records the possible shape of a later exact-subject receipt.
+It is not a receipt instance and does not accept evidence.
+
+```text
+receipt_id: ayken.phase21.first_bounded.receipt.<exact-sha>
+subject_sha: <exact-sha>
+changed_files:
+  - <exact file path>
+category_mapping:
+  <exact file path>: <fileset category>
+non_executing_boundary: recorded
+denied_authorities:
+  - runtime_implementation_procedure
+  - code_execution
+  - process_start
+  - runtime_state_creation
+  - package_loading
+  - package_execution
+  - capability_issuance
+  - registry_publication
+  - trust_assignment
+  - source_merge_authority
+evidence_runs:
+  ci_freeze: <run-id>
+  dev_loop: <run-id>
+result: not_assigned_by_template
+```
+
+The template is not proof.
+
+The template is not package acceptance.
+
+The template is not source acceptance.
+
+The template is not source merge authority.

--- a/tests/phase21_first_bounded_static/README.md
+++ b/tests/phase21_first_bounded_static/README.md
@@ -1,0 +1,25 @@
+# Phase-21 First Bounded Static Tests
+
+This directory contains non-runtime static tests for the Phase-21 first
+bounded implementation skeleton.
+
+The tests are not package acceptance, implementation acceptance, runtime
+execution, process start authority, runtime state authority, package loading
+authority, source acceptance, or source merge authority.
+
+## Boundary
+
+Tests in this directory must not:
+
+1. Boot runtime behavior.
+2. Start a process.
+3. Create runtime state.
+4. Install, load, or execute packages.
+5. Load modules.
+6. Mount workspaces.
+7. Instantiate plugins.
+8. Issue capabilities.
+9. Publish registry entries.
+10. Assign trust.
+
+Any runtime test reading fails closed.

--- a/tests/phase21_first_bounded_static/test_validator_skeleton_static.py
+++ b/tests/phase21_first_bounded_static/test_validator_skeleton_static.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR = REPO_ROOT / "tools" / "phase21_first_bounded_validator" / "validator_skeleton.py"
+BOUNDARY = REPO_ROOT / "docs" / "specs" / "phase21-first-bounded-implementation" / "PACKAGE_BOUNDARY.md"
+
+
+def test_validator_skeleton_has_no_runtime_entrypoint():
+    text = VALIDATOR.read_text(encoding="utf-8")
+
+    denied_tokens = [
+        "if __name__",
+        "subprocess",
+        "socket",
+        "urllib",
+        "requests",
+        "open(",
+        "write(",
+        "Popen",
+        "exec(",
+        "eval(",
+        "import ayken",
+        "package_load",
+        "load_package",
+    ]
+
+    for token in denied_tokens:
+        assert token not in text
+
+
+def test_package_boundary_preserves_denied_authorities():
+    text = BOUNDARY.read_text(encoding="utf-8")
+
+    required_denials = [
+        "Runtime implementation procedure",
+        "Code execution",
+        "Process start",
+        "Runtime state creation",
+        "Package installation, loading, or execution",
+        "Capability issuance",
+        "Registry publication",
+        "Trust assignment",
+        "Source merge authority",
+    ]
+
+    for denial in required_denials:
+        assert denial in text

--- a/tools/phase21_first_bounded_validator/README.md
+++ b/tools/phase21_first_bounded_validator/README.md
@@ -1,0 +1,33 @@
+# Phase-21 First Bounded Static Validator Skeleton
+
+This directory contains only the static validator skeleton for the Phase-21
+first bounded implementation package.
+
+The skeleton is userspace-only and non-executing. It records shape and
+denied-authority boundaries for a possible later validator. It is not runtime
+implementation procedure, package acceptance, validator authority, evidence
+acceptance, package loading authority, source acceptance, or source merge
+authority.
+
+## Boundary
+
+The validator skeleton must preserve:
+
+1. No CLI entrypoint.
+2. No subprocess creation.
+3. No filesystem mutation.
+4. No network access.
+5. No package installation, loading, or execution.
+6. No AykenOS runtime import.
+7. No authoritative verdict.
+8. No process start.
+9. No runtime state creation.
+10. No capability, registry, or trust behavior.
+
+## File
+
+`validator_skeleton.py` is a static skeleton module. It may expose constants
+and shape-description helpers for static inspection, but it must not execute
+runtime behavior or produce authoritative acceptance.
+
+Any reading that treats this skeleton as validator authority fails closed.

--- a/tools/phase21_first_bounded_validator/validator_skeleton.py
+++ b/tools/phase21_first_bounded_validator/validator_skeleton.py
@@ -1,0 +1,46 @@
+"""Phase-21 first bounded implementation static validator skeleton.
+
+This module is intentionally non-executing and non-authoritative. It has no
+CLI entrypoint, no child-process use, no filesystem mutation, no network
+access, no package-load behavior, no AykenOS runtime import, and no
+authoritative verdict.
+"""
+
+SKELETON_ID = "ayken.phase21.first_bounded.static_validator_skeleton.v1"
+
+SKELETON_POSTURE = {
+    "userspace_only": True,
+    "non_executing": True,
+    "static_validation_only": True,
+    "authoritative_verdict": False,
+}
+
+DENIED_AUTHORITIES = (
+    "runtime_implementation_procedure",
+    "code_execution",
+    "process_start",
+    "runtime_state_creation",
+    "package_installation",
+    "package-load",
+    "package_execution",
+    "capability_issuance",
+    "registry_publication",
+    "trust_assignment",
+    "source_acceptance",
+    "source_merge_authority",
+)
+
+
+def describe_skeleton_contract():
+    """Return static contract metadata for inspection only.
+
+    The returned metadata is not a verdict, not proof, not evidence
+    acceptance, not package acceptance, and not source merge authority.
+    """
+
+    return {
+        "skeleton_id": SKELETON_ID,
+        "posture": dict(SKELETON_POSTURE),
+        "denied_authorities": tuple(DENIED_AUTHORITIES),
+        "verdict": "not_authoritative",
+    }


### PR DESCRIPTION
This PR adds the Phase-21 first bounded implementation actual skeleton.

The skeleton is bound to the Phase-21 Actual Skeleton Fileset RFC exact-main SHA:

c30951e388288c77e091061d960431fcd4b9369d

It adds only the exact skeleton file set:
- docs/specs/phase21-first-bounded-implementation/PACKAGE_BOUNDARY.md
- tools/phase21_first_bounded_validator/README.md
- tools/phase21_first_bounded_validator/validator_skeleton.py
- docs/specs/phase21-first-bounded-implementation/receipts/RECEIPT_SCHEMA.md
- docs/specs/phase21-first-bounded-implementation/receipts/RECEIPT_TEMPLATE.md
- docs/specs/phase21-first-bounded-implementation/fixtures/README.md
- docs/specs/phase21-first-bounded-implementation/fixtures/minimal_valid_manifest.fixture.json
- docs/specs/phase21-first-bounded-implementation/fixtures/denied_runtime_authority.fixture.json
- tests/phase21_first_bounded_static/README.md
- tests/phase21_first_bounded_static/test_validator_skeleton_static.py
- docs/specs/phase21-first-bounded-implementation/CI_GATE_EXPECTATIONS.md
- docs/specs/phase21-first-bounded-implementation/EVIDENCE_NOTES.md

It preserves:
- no package acceptance
- no package review result
- no runtime implementation procedure
- no code execution authority
- no process start
- no runtime state creation
- no package installation/loading/execution
- no capability issuance
- no registry publication
- no trust assignment
- no source merge authority
- no CI workflow changes
- no baseline changes
- no dependency changes
- no CURRENT_PHASE change
- no kernel ABI/syscall expansion

Validator skeleton boundary:
- no CLI entrypoint
- no subprocess token in validator skeleton
- no file mutation
- no network access
- no package loading
- no AykenOS runtime import
- no authoritative verdict

Local validation:
- git diff --cached --check: PASS before commit
- stdlib static skeleton checks: PASS
- pytest unavailable locally; no pytest-based result claimed.