### PR TITLE
Update CURRENT_PHASE to Phase-22

### DIFF
--- a/docs/roadmap/CURRENT_PHASE
+++ b/docs/roadmap/CURRENT_PHASE
@@ -1,15 +1,16 @@
-CURRENT_PHASE=21
-# Status authority synchronized: 2026-07-01 (Phase-21 pointer transition decision)
+CURRENT_PHASE=22
+# Status authority synchronized: 2026-07-03 (Phase-22 pointer transition decision)
 # Phase-16 OFFICIALLY CLOSED - 2026-04-25 - tag: phase16-official-closure
 # Phase-17 OFFICIALLY CLOSED - 2026-05-31 - tag: phase17-official-closure at 416a5392.
 # Phase-17 closure evidence remains bounded to the reviewed exact-SHA runtime/QEMU, freeze, and performance runs.
 # Phase-18 remains the accepted Platform Constitution reference set.
 # Phase-19 is CLOSED for the exact subject recorded by PHASE19_CLOSURE_DECISION.md.
 # Phase-20 is CLOSED for the exact subject recorded by PHASE20_CLOSURE_DECISION.md.
-# Phase-21 is ACTIVE only as pointer governance for a possible First Bounded Implementation authority path.
-# CURRENT_PHASE=21 does not authorize Phase-21 implementation scope, runtime implementation procedure, source modification, code implementation, code execution, process start, runtime state creation, package loading, package execution, capability issuance, registry publication, trust assignment, source merge authority, general runtime authority, or implementation authority.
+# Phase-21 is CLOSED for the exact subject recorded by PHASE21_CLOSURE_DECISION.md.
+# Phase-22 is ACTIVE only as bounded governance for Actual Skeleton Review And Static Package Acceptance Boundary.
+# CURRENT_PHASE=22 does not authorize package acceptance, package review result, actual skeleton review result, static package acceptance decision, receipt evidence acceptance, runtime implementation procedure, source modification, code implementation, code execution, process start, runtime state creation, package loading, package execution, capability issuance, registry publication, trust assignment, source merge authority, general runtime authority, or implementation authority.
 # Runtime source code, loader, installer, package execution, module loading, workspace runtime, plugin host, capability issuer, trust issuer, registry publication, Semantic CLI authority, AI Runtime authority, agent authority, new syscall, kernel ABI expansion, and Ring0 policy remain unauthorized.
 # Active execution roadmap: docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
 # Remote evidence: ci-freeze 26712333892, Performance Gate 26715068398, Phase-17 lifecycle/determinism/public-e2e/worker/timeout/performance lanes all PASS on 416a5392.
-# Immediate work package: maintain Phase-21 pointer-governance boundary; any Phase-21 implementation scope, runtime implementation procedure, source modification, code implementation, execution, process start, runtime state creation, package loading/execution, capability issuance, registry publication, trust assignment, or source merge remains a separate reviewed decision and evidence package.
+# Immediate work package: establish Phase-22 governance overview; any actual skeleton review result, static package acceptance decision, receipt evidence acceptance, runtime implementation procedure, source modification, code implementation, execution, process start, runtime state creation, package loading/execution, capability issuance, registry publication, trust assignment, or source merge remains a separate reviewed decision and evidence package.
 # Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu: Kenan AY (informational metadata only).


### PR DESCRIPTION
This PR updates docs/roadmap/CURRENT_PHASE from CURRENT_PHASE=21 to CURRENT_PHASE=22 after the Phase-22 pointer transition decision was fixed at exact-main SHA c04eaf9afcb1cd99961a3be84029c49d4cd1f9a0. It keeps the change limited to the current phase pointer record. It does not add a Phase-22 governance overview, accept packages, record a package review result, record an actual skeleton review result, define runtime implementation procedure, authorize execution, authorize package loading/execution, issue capabilities, publish registry entries, assign trust, or grant source merge authority. This PR changes only docs/roadmap/CURRENT_PHASE.