### PR TITLE
Phase-22 static package acceptance boundary

### DIFF
--- a/PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md
+++ b/PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md
@@ -1,0 +1,814 @@
+# Phase-22 Static Package Acceptance Boundary
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE21_POINTER_TRANSITION_DECISION.md`,
+`PHASE21_GOVERNANCE_OVERVIEW.md`,
+`PHASE21_FIRST_BOUNDED_IMPLEMENTATION_SCOPE.md`,
+`PHASE21_FIRST_BOUNDED_IMPLEMENTATION_PACKAGE_DECISION.md`,
+`PHASE21_FIRST_BOUNDED_IMPLEMENTATION_PACKAGE_REVIEW_PLAN.md`,
+`PHASE21_FIRST_BOUNDED_IMPLEMENTATION_PACKAGE_SKELETON_PLAN.md`,
+`PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_FILESET.md`,
+`PHASE21_ACTUAL_SKELETON_LANDING_RECORD.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`, and
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`. In case of conflict, those
+documents prevail unless this boundary is the narrower Phase-22 static
+package acceptance boundary for the exact subject identified below.
+
+**Status:** PHASE-22 STATIC PACKAGE ACCEPTANCE BOUNDARY RFC / BOUNDARY
+DEFINITION ONLY / NO PACKAGE ACCEPTANCE / NO PACKAGE REVIEW RESULT / NO
+STATIC PACKAGE ACCEPTANCE DECISION / NO RECEIPT EVIDENCE ACCEPTANCE / NO
+ACCEPTED EVIDENCE / NO VALIDATOR AUTHORITY / NO VALIDATOR OUTPUT
+ACCEPTANCE / NO RUNTIME IMPLEMENTATION PROCEDURE / NO SOURCE MODIFICATION
+/ NO CODE IMPLEMENTATION / NO CODE EXECUTION / NO PROCESS START / NO
+RUNTIME STATE CREATION / NO PACKAGE AUTHORITY / NO PACKAGE INSTALLATION /
+NO PACKAGE LOADING / NO PACKAGE EXECUTION / NO DEPLOYMENT / NO CAPABILITY
+ISSUANCE / NO TRUST ASSIGNMENT / NO REGISTRY PUBLICATION / NO DISTRIBUTION
+AUTHORITY / NO SOURCE MERGE AUTHORITY / NO SOURCE ACCEPTANCE / NO KERNEL
+ABI EXPANSION / NO SYSCALL EXPANSION
+**Boundary date:** 2026-07-04
+**Boundary id:** `ayken.phase22.static_package_acceptance_boundary.v1`
+**Boundary base main SHA:** `039f2e3f1b8c398f27b036f7069274ba993def6c`
+**Reviewed Phase-22 actual skeleton review result SHA:**
+`039f2e3f1b8c398f27b036f7069274ba993def6c`
+**Reviewed Phase-22 actual skeleton review plan SHA:**
+`d565cac4d2418180c125e25fc84d975bc6cf620d`
+**Reviewed Phase-22 governance overview SHA:**
+`7e0128fde9f25d4c93ade10b493f4f0de5d34709`
+**Reviewed Phase-21 actual skeleton landing record SHA:**
+`9eed18e0259e113c206547be9de589d0fbcf046a`
+**Reviewed Phase-21 actual skeleton landing SHA:**
+`a26a3270d130e8b7f22c3d643d48d37d72ad5eef`
+**Reviewed Phase-21 actual skeleton fileset SHA:**
+`c30951e388288c77e091061d960431fcd4b9369d`
+**Current phase pointer:** `CURRENT_PHASE=22`
+**Phase-22 governance theme:** Actual Skeleton Review And Static Package
+Acceptance Boundary
+**Authority boundary:** Static package acceptance boundary definition only;
+not package acceptance, not package review result, not static package
+acceptance decision, not receipt evidence acceptance, not accepted
+evidence, not validator authority, not validator output acceptance, not
+runtime implementation procedure, not source modification, not code
+implementation, not code execution, not process start, not runtime state
+creation, not general runtime authority, not unbounded execution authority,
+not package authority, not package installation, not package loading, not
+package execution, not deployment, not source acceptance, not source merge
+authority, not source repository authority, not module loading, not
+workspace runtime, not plugin loading, not capability token minting, not
+capability issuance, not trust assignment, not trust issuer authority, not
+registry authority, not registry publication, not publication authority,
+not distribution authority, not distribution execution, not Semantic CLI
+authority, not AI Runtime authority, not agent authority, not syscall
+expansion, not kernel ABI expansion, not workflow-threshold, baseline,
+dependency, or Ring0 authority.
+
+## Purpose
+
+This document defines the Phase-22 static package acceptance boundary for
+later reviewed evaluation.
+
+It consumes the Phase-22 Actual Skeleton Review Result fixed at exact main
+SHA:
+
+```text
+039f2e3f1b8c398f27b036f7069274ba993def6c
+```
+
+That review result records:
+
+```text
+Phase-21 actual skeleton reviewed: PASS for fileset boundary, static
+userspace-only non-runtime boundary, and denied-authority boundary.
+```
+
+This boundary answers:
+
+1. Within what boundary may static package acceptance later be evaluated?
+2. Which exact inputs would be required before a later acceptance decision
+   can be reviewed?
+3. Which inputs are context-only and cannot be treated as accepted evidence?
+4. Which inputs may become future acceptance inputs only after separate
+   review?
+5. Why validator output, receipts, fixtures, tests, and review PASS are not
+   package acceptance by themselves?
+6. What separate decision path is required for any later package acceptance?
+7. Which authority readings fail closed?
+
+It does not accept any package.
+
+It does not record any package review result.
+
+It does not define or grant a static package acceptance decision.
+
+It does not accept receipt evidence.
+
+It does not accept validator output.
+
+It does not define runtime implementation procedure.
+
+It does not authorize source modification, code implementation, code
+execution, process start, runtime state creation, package installation,
+package loading, package execution, capability issuance, registry
+publication, trust assignment, source acceptance, or source merge authority.
+
+## Exact Subject
+
+This boundary is bound to exact main SHA:
+
+```text
+039f2e3f1b8c398f27b036f7069274ba993def6c
+```
+
+That exact subject is the merged Phase-22 Actual Skeleton Review Result.
+
+The predecessor review result remains bound to:
+
+```text
+039f2e3f1b8c398f27b036f7069274ba993def6c
+```
+
+The reviewed Phase-21 actual skeleton landing remains bound to:
+
+```text
+a26a3270d130e8b7f22c3d643d48d37d72ad5eef
+```
+
+The reviewed Phase-21 actual skeleton landing record remains bound to:
+
+```text
+9eed18e0259e113c206547be9de589d0fbcf046a
+```
+
+The reviewed Phase-21 Actual Skeleton Fileset RFC remains bound to:
+
+```text
+c30951e388288c77e091061d960431fcd4b9369d
+```
+
+This boundary consumes those exact subjects as recorded input only. It does
+not replace, broaden, reinterpret, or supersede them.
+
+Missing, stale, ambiguous, inherited, aliased, superseded, or differently
+scoped subject readings fail closed.
+
+## Core Rule
+
+```text
+static package acceptance boundary != package acceptance
+static package acceptance boundary != static package acceptance decision
+static package acceptance boundary != package review result
+static package acceptance boundary != receipt evidence acceptance
+static package acceptance boundary != accepted evidence
+static package acceptance boundary != validator authority
+static package acceptance boundary != validator output acceptance
+static package acceptance boundary != runtime implementation procedure
+static package acceptance boundary != source modification
+static package acceptance boundary != code implementation
+static package acceptance boundary != code execution
+static package acceptance boundary != process start
+static package acceptance boundary != runtime state creation
+static package acceptance boundary != package loading
+static package acceptance boundary != package execution
+static package acceptance boundary != capability issuance
+static package acceptance boundary != registry publication
+static package acceptance boundary != trust assignment
+static package acceptance boundary != source acceptance
+static package acceptance boundary != source merge
+boundary definition != acceptance decision
+accepted input candidate != accepted evidence
+validator output != acceptance
+receipt template/schema != receipt evidence acceptance
+fixture presence != package loading
+test PASS != package acceptance
+review result PASS != package acceptance
+```
+
+The safe default remains no package acceptance, no package review result, no
+static package acceptance decision, no receipt evidence acceptance, no
+runtime behavior, no implementation procedure, no source modification, no
+code execution, no runtime state, and no package, capability, registry,
+trust, distribution, deployment, or source merge authority unless a later
+reviewed Phase-22 decision grants a specific bounded authority with its own
+exact-SHA evidence.
+
+Unknown authority readings fail closed.
+
+## Boundary Scope
+
+This boundary may define only the static package acceptance evaluation
+boundary.
+
+The boundary scope is:
+
+```text
+boundary-definition-only
+static
+userspace-only
+non-runtime
+non-executing
+exact-input-oriented
+exact-SHA evidence oriented
+fail-closed
+```
+
+This boundary may identify:
+
+1. Required exact inputs for a later acceptance decision path.
+2. Context-only inputs.
+3. Possible future acceptance input candidates.
+4. Denied readings for validator, receipt, fixture, test, and CI material.
+5. Required separation between boundary definition and acceptance decision.
+6. Required post-merge verification for this boundary record.
+
+This boundary must not:
+
+1. Accept packages.
+2. Record package review result.
+3. Grant static package acceptance decision.
+4. Accept receipt evidence.
+5. Accept validator output.
+6. Define runtime implementation procedure.
+7. Authorize source modification.
+8. Authorize code execution.
+9. Start processes.
+10. Create runtime state.
+11. Install, load, or execute packages.
+12. Issue capabilities.
+13. Publish registry entries.
+14. Assign trust.
+15. Accept source.
+16. Merge source.
+
+Any reading beyond boundary-definition scope fails closed.
+
+## Predecessor Review Result
+
+This boundary depends on the Phase-22 Actual Skeleton Review Result fixed at
+exact main SHA:
+
+```text
+039f2e3f1b8c398f27b036f7069274ba993def6c
+```
+
+The predecessor review result reviewed the Phase-21 actual skeleton landed
+at exact main SHA:
+
+```text
+a26a3270d130e8b7f22c3d643d48d37d72ad5eef
+```
+
+The predecessor review result found:
+
+```text
+Phase-21 actual skeleton reviewed: PASS for fileset boundary, static
+userspace-only non-runtime boundary, and denied-authority boundary.
+```
+
+That predecessor result is required context for this boundary.
+
+It is not package acceptance.
+
+It is not static package acceptance decision.
+
+It is not receipt evidence acceptance.
+
+It is not runtime implementation procedure.
+
+It is not execution authority.
+
+Review result PASS may become a governance input candidate for a later
+decision path only if that later path separately defines the exact subject,
+input rules, evidence rules, and denied-authority boundary.
+
+## Static Package Acceptance Boundary Definition
+
+The static package acceptance boundary is the narrow governance boundary in
+which a later reviewed decision may evaluate whether a specific static
+package subject satisfies static, non-runtime, non-executing acceptance
+criteria.
+
+The boundary is limited to:
+
+1. Exact subject identity.
+2. Exact changed-file list.
+3. Exact source SHA.
+4. Exact static package file set.
+5. Exact review result inputs.
+6. Exact validator-output treatment, if separately authorized.
+7. Exact receipt/evidence treatment, if separately authorized.
+8. Exact fixture and test treatment.
+9. Exact denied-authority preservation.
+10. Exact post-merge verification requirements.
+
+The boundary does not itself decide acceptance.
+
+The boundary does not itself accept evidence.
+
+The boundary does not itself authorize validator output as acceptance.
+
+The boundary does not itself authorize package installation, package
+loading, package execution, or runtime behavior.
+
+The boundary exists so a later package-specific acceptance decision can be
+reviewed without inheriting authority from ambiguous skeleton, validator,
+receipt, fixture, test, CI, or review-result readings.
+
+## Required Exact Inputs
+
+A later static package acceptance decision may be evaluated only if it
+defines and reviews all required exact inputs.
+
+Required exact inputs include:
+
+1. Exact decision subject SHA.
+2. Exact current main SHA at decision time.
+3. Exact package subject SHA.
+4. Exact package file set.
+5. Exact package boundary record.
+6. Exact actual skeleton review result:
+
+   ```text
+   039f2e3f1b8c398f27b036f7069274ba993def6c
+   ```
+
+7. Exact Phase-21 actual skeleton landing:
+
+   ```text
+   a26a3270d130e8b7f22c3d643d48d37d72ad5eef
+   ```
+
+8. Exact Phase-21 actual skeleton landing record:
+
+   ```text
+   9eed18e0259e113c206547be9de589d0fbcf046a
+   ```
+
+9. Exact Phase-21 actual skeleton fileset RFC:
+
+   ```text
+   c30951e388288c77e091061d960431fcd4b9369d
+   ```
+
+10. Exact validator-scope statement, if validator output is cited.
+11. Exact receipt/evidence-scope statement, if receipts are cited.
+12. Exact fixture/test-scope statement, if fixture or test material is
+    cited.
+13. Exact denied-authority list.
+14. Exact post-merge verification plan.
+
+Missing, stale, inherited, ambiguous, aliased, or differently scoped input
+readings fail closed.
+
+## Context-Only Inputs
+
+The following inputs may be cited as context only unless a later reviewed
+decision explicitly converts them into narrower accepted inputs:
+
+1. Phase-21 package decision records.
+2. Phase-21 package review plan.
+3. Phase-21 package skeleton plan.
+4. Phase-21 actual skeleton fileset RFC.
+5. Phase-21 actual skeleton landing record.
+6. Phase-22 governance overview.
+7. Phase-22 actual skeleton review plan.
+8. Phase-22 actual skeleton review result.
+9. Validator skeleton presence.
+10. Validator output, if any.
+11. Receipt schema/template presence.
+12. Fixture presence.
+13. Non-runtime test presence.
+14. Non-runtime test PASS.
+15. CI PASS.
+16. Historical PASS results.
+
+Context-only input is not accepted evidence.
+
+Context-only input is not package acceptance.
+
+Context-only input is not package review result.
+
+Context-only input is not runtime authority.
+
+Historical PASS results cannot be inherited across SHAs as authority.
+
+## Possible Future Acceptance Inputs
+
+A later reviewed decision may define possible future acceptance inputs only
+with exact subject, exact scope, and exact denied-authority boundaries.
+
+Possible future acceptance input candidates may include:
+
+1. Exact actual skeleton review result.
+2. Exact package boundary record.
+3. Exact static package manifest or manifest-shape record.
+4. Exact validator-output record, if separately authorized.
+5. Exact receipt evidence record, if separately authorized.
+6. Exact fixture static-inspection record, if separately authorized.
+7. Exact non-runtime test result record, if separately authorized.
+8. Exact CI result record for the decision subject.
+9. Exact changed-file list confirmation.
+10. Exact denied-file confirmation.
+11. Exact no-runtime/no-execution confirmation.
+
+Possible future acceptance input candidate is not accepted evidence.
+
+Possible future acceptance input candidate is not package acceptance.
+
+Possible future acceptance input candidate is not static package acceptance
+decision.
+
+Any conversion from candidate input to accepted input requires a separate
+reviewed decision path.
+
+## Validator / Receipt / Fixture / Test Boundary
+
+Validator, receipt, fixture, and test material remains bounded as follows.
+
+Validator boundary:
+
+1. Validator skeleton presence is not validator authority.
+2. Validator output is not package acceptance.
+3. Validator output is not package review result.
+4. Validator output is not accepted evidence unless separately reviewed.
+5. Validator output is not runtime implementation procedure.
+6. Validator output is not execution authority.
+
+Receipt boundary:
+
+1. Receipt schema/template presence is not receipt evidence acceptance.
+2. Receipt schema/template presence is not proof.
+3. Receipt template presence is not package acceptance.
+4. Receipt evidence, if later produced, requires exact subject review.
+5. Receipt evidence, if later accepted, requires separate acceptance path.
+
+Fixture boundary:
+
+1. Fixture presence is not fixture loading.
+2. Fixture presence is not package loading.
+3. Fixture presence is not runtime state.
+4. Fixture presence is not accepted evidence.
+5. Fixture presence is not package acceptance.
+
+Test boundary:
+
+1. Test presence is not test execution authority.
+2. Test PASS is not package acceptance.
+3. Test PASS is not package review result.
+4. Test PASS is not runtime implementation procedure.
+5. Test PASS is not execution authority.
+
+Any validator, receipt, fixture, or test reading beyond these boundaries
+fails closed.
+
+## Denied Authority Readings
+
+This boundary denies:
+
+1. Package acceptance.
+2. Package review result.
+3. Static package acceptance decision.
+4. Receipt evidence acceptance.
+5. Accepted evidence.
+6. Validator authority.
+7. Validator output acceptance.
+8. Runtime implementation procedure.
+9. Source modification.
+10. Source acceptance.
+11. Source merge.
+12. Code implementation.
+13. Code execution.
+14. Process start.
+15. Runtime state creation.
+16. Package installation.
+17. Package loading.
+18. Package execution.
+19. Module loading.
+20. Workspace runtime or real mounts.
+21. Plugin loading or plugin instantiation.
+22. Capability token minting.
+23. Capability issuance.
+24. Registry publication.
+25. Trust assignment.
+26. Distribution execution.
+27. Deployment.
+28. Semantic CLI authority.
+29. AI Runtime authority.
+30. Agent authority.
+31. Syscall expansion.
+32. Kernel ABI expansion.
+33. Ring0 policy movement.
+34. Workflow-threshold, baseline, or dependency changes.
+35. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Acceptance Decision Requirement
+
+Any actual package acceptance requires a later separate reviewed decision.
+
+That later decision must define:
+
+1. Exact package acceptance subject.
+2. Exact package file set.
+3. Exact accepted inputs.
+4. Exact context-only inputs.
+5. Exact evidence acceptance rule, if any.
+6. Exact validator-output rule, if any.
+7. Exact receipt evidence rule, if any.
+8. Exact non-runtime test rule, if any.
+9. Exact CI evidence rule.
+10. Exact denied-authority boundary.
+11. Exact changed-file list.
+12. Exact post-merge verification plan.
+
+This boundary does not pre-approve any later acceptance decision.
+
+This boundary does not decide that any package is acceptable.
+
+This boundary does not create acceptance criteria sufficient by itself.
+
+This boundary does not authorize package loading, package execution, or
+runtime behavior after any later acceptance decision unless another
+separate reviewed authority grants that narrower runtime authority.
+
+## Possible Later Decision Path
+
+Possible later Phase-22 decision records may include:
+
+1. `PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`.
+2. `PHASE22_STATIC_PACKAGE_ACCEPTANCE_EVIDENCE_PLAN.md`.
+3. `PHASE22_PACKAGE_SPECIFIC_ACCEPTANCE_DECISION.md`.
+
+Those names are possible later paths only.
+
+They are not created by this boundary.
+
+They are not accepted by this boundary.
+
+They are not pre-approved by this boundary.
+
+Any later path must preserve that package acceptance, evidence acceptance,
+runtime implementation procedure, execution authority, package loading,
+capability issuance, registry publication, trust assignment, source
+acceptance, and source merge authority require separate exact review.
+
+## Relationship To Actual Skeleton Review Result
+
+This boundary consumes the Phase-22 Actual Skeleton Review Result as its
+exact governance predecessor.
+
+The review result remains bound to:
+
+```text
+039f2e3f1b8c398f27b036f7069274ba993def6c
+```
+
+The review result records PASS only for:
+
+```text
+fileset boundary
+static userspace-only non-runtime boundary
+denied-authority boundary
+```
+
+This boundary does not convert that PASS into package acceptance, static
+package acceptance decision, receipt evidence acceptance, validator output
+acceptance, runtime implementation procedure, execution authority, package
+loading authority, source acceptance, or source merge authority.
+
+Any review-result conflict fails closed.
+
+## Relationship To Phase-22 Governance Overview
+
+The Phase-22 Governance Overview remains bound to:
+
+```text
+7e0128fde9f25d4c93ade10b493f4f0de5d34709
+```
+
+The overview records Phase-22 as active only for:
+
+```text
+Actual Skeleton Review And Static Package Acceptance Boundary
+```
+
+This boundary stays inside that governance theme.
+
+This boundary does not convert the governance overview into package
+acceptance, package review result, static package acceptance decision,
+receipt evidence acceptance, runtime implementation procedure, execution
+authority, package loading authority, capability issuance, registry
+publication, trust assignment, source acceptance, or source merge authority.
+
+Any governance overview conflict fails closed.
+
+## Relationship To Phase-21 Landing Record
+
+The Phase-21 Actual Skeleton Landing Record remains bound to:
+
+```text
+9eed18e0259e113c206547be9de589d0fbcf046a
+```
+
+The Phase-21 actual skeleton landing remains bound to:
+
+```text
+a26a3270d130e8b7f22c3d643d48d37d72ad5eef
+```
+
+The landing record confirms the exact 12-file actual skeleton subject and
+post-merge verification for the Phase-21 actual skeleton.
+
+This boundary does not reinterpret that landing as package acceptance,
+static package acceptance decision, receipt evidence acceptance, runtime
+implementation procedure, execution authority, package loading authority,
+source acceptance, or source merge authority.
+
+Any landing-record conflict fails closed.
+
+## Relationship To Phase-21 Closure, Phase-20 Closure, And Phase-19 Runtime Authority
+
+The Phase-21 Closure Decision remains bound to:
+
+```text
+9a32f3553637ab037346d843c07e38da79508a5b
+```
+
+Phase-21 remains closed only as:
+
+```text
+first bounded actual skeleton landed and recorded
+```
+
+Phase-20 remains closed for exact subject:
+
+```text
+ee1f1c7f43fe478c8cbdab3fbeb2844365c9c5bc
+```
+
+This boundary does not reopen Phase-20 or Phase-21.
+
+This boundary remains subordinate to Phase-19 runtime authority records.
+
+This boundary must not broaden, replace, supersede, weaken, or reinterpret
+Phase-19 runtime authority records.
+
+This boundary must not use `CURRENT_PHASE=22`, boundary status, review
+result PASS, or static package acceptance terminology to infer runtime
+authority.
+
+Any reading that conflicts with Phase-19 runtime authority records,
+Phase-20 closure, or Phase-21 closure fails closed.
+
+## Post-Merge Verification Expectations
+
+If this boundary is merged, post-merge exact-main verification must record:
+
+1. `ci-freeze` PASS.
+2. AykenOS Dev Loop CI PASS.
+3. smoke PASS.
+4. contract PASS.
+5. full PASS.
+6. isolation PASS.
+7. performance PASS.
+8. Exact changed-file list confirmation.
+9. No `docs/roadmap/CURRENT_PHASE` change.
+10. No CI workflow change.
+11. No baseline change.
+12. No dependency change.
+13. No runtime source or kernel source change.
+14. No syscall or kernel ABI change.
+15. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution change.
+
+Historical PASS results may be cited as context only.
+
+They cannot be inherited as evidence for this boundary publication subject.
+
+## Boundary Invariants
+
+Every later RFC must preserve these Phase-22 static package acceptance
+boundary invariants:
+
+1. Static package acceptance boundary is not package acceptance.
+2. Static package acceptance boundary is not package review result.
+3. Static package acceptance boundary is not static package acceptance
+   decision.
+4. Static package acceptance boundary is not receipt evidence acceptance.
+5. Static package acceptance boundary is not accepted evidence.
+6. Static package acceptance boundary is not validator authority.
+7. Static package acceptance boundary is not validator output acceptance.
+8. Static package acceptance boundary is not runtime implementation
+   procedure.
+9. Static package acceptance boundary is not source modification.
+10. Static package acceptance boundary is not code implementation.
+11. Static package acceptance boundary is not code execution.
+12. Static package acceptance boundary is not process start.
+13. Static package acceptance boundary is not runtime state creation.
+14. Static package acceptance boundary is not package loading.
+15. Static package acceptance boundary is not package execution.
+16. Static package acceptance boundary is not capability issuance.
+17. Static package acceptance boundary is not registry publication.
+18. Static package acceptance boundary is not trust assignment.
+19. Static package acceptance boundary is not source acceptance.
+20. Static package acceptance boundary is not source merge authority.
+21. Boundary definition is not acceptance decision.
+22. Accepted input candidate is not accepted evidence.
+23. Validator output is not acceptance.
+24. Receipt template/schema is not receipt evidence acceptance.
+25. Fixture presence is not package loading.
+26. Test PASS is not package acceptance.
+27. Review result PASS is not package acceptance.
+28. Phase-21 remains closed as first bounded actual skeleton landed and
+    recorded only.
+29. This boundary does not broaden Phase-19 runtime authority.
+30. This boundary does not reopen Phase-20.
+31. This boundary does not reopen Phase-21.
+32. This boundary does not expand kernel ABI or syscalls.
+33. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Publication Boundary
+
+If this boundary is merged, the landing SHA publishes only this Phase-22
+static package acceptance boundary record. The landing SHA must not be read
+as package acceptance, package review result, static package acceptance
+decision, receipt evidence acceptance, accepted evidence, validator
+authority, validator output acceptance, runtime implementation procedure,
+source modification authority, code implementation authority, code
+execution authority, process start authority, runtime state authority,
+package loading authority, package execution authority, capability
+issuance, registry publication, trust assignment, source merge authority,
+implementation acceptance, general runtime authority, or kernel ABI/syscall
+expansion.
+
+Any later package acceptance, package review result, static package
+acceptance decision, receipt evidence acceptance, runtime implementation
+procedure, execution authority, package loading authority, capability,
+registry, trust, source acceptance, or source merge authority requires a
+separate reviewed decision path.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-22 RFC
+**Architecture status:** Draft boundary / pending architectural review
+**Authority notice:** This signature identifies the architectural authorship
+of this boundary. It grants no package acceptance authority, package review
+result authority, static package acceptance decision authority, receipt
+evidence acceptance authority, accepted evidence authority, validator
+authority, runtime implementation procedure authority, source modification
+authority, code implementation authority, code execution authority, process
+start authority, general runtime authority, unbounded execution authority,
+runtime state authority, package loading authority, package execution
+authority, source merge authority, trust authority, registry authority,
+distribution authority, publication authority, capability issuance
+authority, deployment authority, module authority, plugin authority,
+Semantic CLI authority, AI Runtime authority, agent authority, or Ring0
+authority.
+
+## Conclusion
+
+This Phase-22 static package acceptance boundary is bound to exact main SHA:
+
+```text
+039f2e3f1b8c398f27b036f7069274ba993def6c
+```
+
+It consumes the Phase-22 Actual Skeleton Review Result fixed at exact main
+SHA:
+
+```text
+039f2e3f1b8c398f27b036f7069274ba993def6c
+```
+
+This boundary defines how static package acceptance may be evaluated later.
+
+This boundary does not accept packages, record package review result, define
+static package acceptance decision, accept receipt evidence, accept
+validator output, define runtime implementation procedure, authorize source
+modification, authorize code execution, authorize process start, create
+runtime state, authorize package loading, authorize package execution,
+issue capabilities, publish registry entries, assign trust, accept source,
+grant source merge authority, broaden Phase-19 runtime authority, reopen
+Phase-20, reopen Phase-21, expand kernel ABI, or expand syscalls.
+
+Any later package acceptance, static package acceptance decision,
+receipt/evidence acceptance, runtime implementation procedure, execution
+authority, package loading authority, capability, registry, trust, source
+acceptance, or source merge authority requires a separate reviewed decision
+path and exact-SHA evidence.


### PR DESCRIPTION
This PR adds the Phase-22 static package acceptance boundary.

The boundary is bound to exact-main subject:

```text
039f2e3f1b8c398f27b036f7069274ba993def6c
```

It consumes the Phase-22 actual skeleton review result fixed at:

```text
039f2e3f1b8c398f27b036f7069274ba993def6c
```

It records:
- static package acceptance boundary definition only
- required exact inputs for any later acceptance decision path
- context-only inputs
- possible future acceptance input candidates
- validator / receipt / fixture / test boundaries
- denied authority readings
- separate acceptance decision requirement

It does not introduce:
- package acceptance
- package review result
- static package acceptance decision
- receipt evidence acceptance
- accepted evidence
- validator authority
- validator output acceptance
- runtime implementation procedure
- execution authority
- package installation/loading/execution
- capability issuance
- registry publication
- trust assignment
- source acceptance
- source merge authority
- kernel ABI/syscall expansion

This PR changes only PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md.