### PR TITLE
Phase-23 current phase pointer update

### DIFF
--- a/docs/roadmap/CURRENT_PHASE
+++ b/docs/roadmap/CURRENT_PHASE
@@ -1,5 +1,5 @@
-CURRENT_PHASE=22
-# Status authority synchronized: 2026-07-03 (Phase-22 pointer transition decision)
+CURRENT_PHASE=23
+# Status authority synchronized: 2026-07-05 (Phase-23 bounded current-phase pointer update after pointer transition decision)
 # Phase-16 OFFICIALLY CLOSED - 2026-04-25 - tag: phase16-official-closure
 # Phase-17 OFFICIALLY CLOSED - 2026-05-31 - tag: phase17-official-closure at 416a5392.
 # Phase-17 closure evidence remains bounded to the reviewed exact-SHA runtime/QEMU, freeze, and performance runs.
@@ -7,10 +7,16 @@ CURRENT_PHASE=22
 # Phase-19 is CLOSED for the exact subject recorded by PHASE19_CLOSURE_DECISION.md.
 # Phase-20 is CLOSED for the exact subject recorded by PHASE20_CLOSURE_DECISION.md.
 # Phase-21 is CLOSED for the exact subject recorded by PHASE21_CLOSURE_DECISION.md.
-# Phase-22 is ACTIVE only as bounded governance for Actual Skeleton Review And Static Package Acceptance Boundary.
-# CURRENT_PHASE=22 does not authorize package acceptance, package review result, actual skeleton review result, static package acceptance decision, receipt evidence acceptance, runtime implementation procedure, source modification, code implementation, code execution, process start, runtime state creation, package loading, package execution, capability issuance, registry publication, trust assignment, source merge authority, general runtime authority, or implementation authority.
+# Phase-22 is CLOSED for the exact subject recorded by PHASE22_CLOSURE_DECISION.md and its publication-status sync.
+# Phase-22 closure decision subject: 9b19c94a01170d105bd7a7e9fb198df05be17fdf.
+# Phase-22 closure publication-status sync subject: 6c0a0c878d54ebc6a768e1c708a68d7eb5898b15.
+# Phase-23 pointer transition candidate subject: 77fd954607ad076cdea888047f19e4fed60bfb65.
+# Phase-23 pointer transition decision subject: 16ac421a40ce93641ccccc28fb5ad869f2b8984e.
+# Phase-23 is ACTIVE only as bounded current-phase pointer state after the Phase-23 pointer transition decision.
+# Phase-23 governance overview remains pending separate reviewed publication.
+# CURRENT_PHASE=23 does not authorize Phase-23 governance overview, runtime implementation procedure, source modification, code implementation, code execution, process start, runtime state creation, package installation, package loading, package execution, accepted evidence authority, receipt evidence acceptance, validator output acceptance, capability issuance, registry publication, trust assignment, deployment, distribution, source acceptance, source merge authority, kernel ABI expansion, syscall expansion, general runtime authority, or implementation authority.
 # Runtime source code, loader, installer, package execution, module loading, workspace runtime, plugin host, capability issuer, trust issuer, registry publication, Semantic CLI authority, AI Runtime authority, agent authority, new syscall, kernel ABI expansion, and Ring0 policy remain unauthorized.
 # Active execution roadmap: docs/roadmap/CONSTITUTIONAL_STABILIZATION_ROADMAP_2026_05_23.md
 # Remote evidence: ci-freeze 26712333892, Performance Gate 26715068398, Phase-17 lifecycle/determinism/public-e2e/worker/timeout/performance lanes all PASS on 416a5392.
-# Immediate work package: establish Phase-22 governance overview; any actual skeleton review result, static package acceptance decision, receipt evidence acceptance, runtime implementation procedure, source modification, code implementation, execution, process start, runtime state creation, package loading/execution, capability issuance, registry publication, trust assignment, or source merge remains a separate reviewed decision and evidence package.
+# Immediate work package: establish Phase-23 governance overview; any runtime implementation procedure, source modification, code implementation, execution, process start, runtime state creation, package loading/execution, accepted evidence authority, receipt evidence acceptance, validator output acceptance, capability issuance, registry publication, trust assignment, deployment, distribution, kernel ABI/syscall expansion, or source merge remains a separate reviewed decision and evidence package.
 # Duzenleyen / Gelistiren / Olusturan / Mimari Sorumlu: Kenan AY (informational metadata only).


### PR DESCRIPTION
This PR changes only docs/roadmap/CURRENT_PHASE from CURRENT_PHASE=22 to CURRENT_PHASE=23 after the clean-fixed publication of PHASE23_POINTER_TRANSITION_DECISION.md at 16ac421a40ce93641ccccc28fb5ad869f2b8984e.

It does not publish a Phase-23 governance overview and does not authorize runtime implementation, package loading, package execution, accepted-evidence authority, source merge, registry/trust/capability authority, deployment, distribution, kernel ABI expansion, or syscall expansion.

Scope guard:
- Changed files intended: 1
- File: docs/roadmap/CURRENT_PHASE
- PHASE23_POINTER_TRANSITION_DECISION.md is referenced as prior clean-fixed decision subject only
- PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md remains untracked / PR-disjoint / not input