### PR TITLE
Phase-23 accepted-evidence set decision candidate

### DIFF
--- a/PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md
+++ b/PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md
@@ -1,0 +1,1103 @@
+# Phase-23 Accepted-Evidence Set Decision Candidate
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY_CLEAN_RECOVERY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_FIRST_BOUNDED_IMPLEMENTATION.md`,
+`PHASE22_CLOSURE_DECISION.md`,
+`PHASE23_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE23_POINTER_TRANSITION_DECISION.md`,
+`docs/roadmap/CURRENT_PHASE`,
+`PHASE23_GOVERNANCE_OVERVIEW.md`,
+`PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`,
+`PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`,
+`PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`, and
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`. In case of conflict, those
+documents prevail unless this document is the narrower Phase-23
+accepted-evidence set decision candidate for the exact governance-only
+accepted-evidence-set-candidate scope identified below.
+
+**Status:** PHASE-23 ACCEPTED-EVIDENCE SET DECISION CANDIDATE / LOCAL
+DRAFT / GOVERNANCE-ONLY ACCEPTED-EVIDENCE SET DECISION CANDIDATE ONLY /
+NO ACCEPTED-EVIDENCE SET / NO ACCEPTED-EVIDENCE SET MEMBERSHIP / NO
+ACCEPTED EVIDENCE / NO EVIDENCE ITEM ACCEPTANCE / NO VALIDATOR OUTPUT
+ACCEPTANCE / NO RECEIPT EVIDENCE ACCEPTANCE / NO RUNTIME IMPLEMENTATION
+PROCEDURE / NO SOURCE MODIFICATION / NO CODE IMPLEMENTATION / NO CODE
+EXECUTION / NO PROCESS START / NO RUNTIME STATE CREATION / NO PACKAGE
+INSTALLATION / NO PACKAGE LOADING / NO PACKAGE EXECUTION / NO DEPLOYMENT
+/ NO CAPABILITY ISSUANCE / NO TRUST ASSIGNMENT / NO REGISTRY PUBLICATION
+/ NO DISTRIBUTION AUTHORITY / NO SOURCE ACCEPTANCE / NO SOURCE MERGE
+AUTHORITY / NO KERNEL ABI EXPANSION / NO SYSCALL EXPANSION / NO
+WORKFLOW-THRESHOLD CHANGE / NO BASELINE CHANGE / NO DEPENDENCY CHANGE /
+NO RING0 AUTHORITY
+**Candidate date:** 2026-07-08
+**Candidate id:**
+`ayken.phase23.accepted_evidence_set_decision_candidate.v1`
+**Candidate drafting base main SHA:**
+`1fe089b141af09e9f98be2a153589e68ab015c18`
+**Candidate publication subject:** pending separate reviewed publication
+**Reviewed Phase-23 evidence acceptance decision publication subject:**
+`1fe089b141af09e9f98be2a153589e68ab015c18`
+**Reviewed Phase-23 evidence acceptance decision PR:** PR #271
+**Reviewed Phase-23 evidence acceptance decision exact-main ci-freeze
+run:** `28935407122`
+**Reviewed Phase-23 evidence acceptance decision exact-main ci-freeze
+attempt:** attempt 1
+**Reviewed Phase-23 evidence acceptance decision exact-main ci-freeze
+job:** `freeze / 85844420791`
+**Reviewed Phase-23 evidence acceptance decision exact-main ci-freeze
+result:** PASS
+**Reviewed Phase-23 evidence acceptance decision exact-main Dev Loop CI
+run:** `28935407227`
+**Reviewed Phase-23 evidence acceptance decision exact-main Dev Loop CI
+attempt:** attempt 1
+**Reviewed Phase-23 evidence acceptance decision exact-main Dev Loop CI
+result:** PASS
+**Reviewed Phase-23 evidence acceptance decision exact-main smoke job:**
+`smoke / 85844421060`
+**Reviewed Phase-23 evidence acceptance decision exact-main smoke
+result:** PASS
+**Reviewed Phase-23 evidence acceptance decision exact-main contract
+job:** `contract / 85844595291`
+**Reviewed Phase-23 evidence acceptance decision exact-main contract
+result:** PASS
+**Reviewed Phase-23 evidence acceptance decision exact-main full job:**
+`full / 85844964285`
+**Reviewed Phase-23 evidence acceptance decision exact-main full result:**
+PASS
+**Reviewed Phase-23 evidence acceptance decision exact-main isolation
+job:** `isolation / 85845408870`
+**Reviewed Phase-23 evidence acceptance decision exact-main isolation
+result:** PASS
+**Reviewed Phase-23 evidence acceptance decision exact-main performance
+job:** `performance / 85845889319`
+**Reviewed Phase-23 evidence acceptance decision exact-main performance
+result:** PASS
+**Phase-23 evidence acceptance decision candidate publication subject:**
+`7d90f2c195afecfb4875876f1ea832df3d9b6528`
+**Phase-23 accepted-evidence authority decision publication subject:**
+`d9ac910c24601002971e7d06cf94463d739b1358`
+**Phase-23 accepted-evidence authority decision candidate publication
+subject:** `72d5234654a5af4fa84b52f3ba3753b9104a4dce`
+**Phase-23 accepted-evidence decision publication subject:**
+`0f6da8e9abe8d354e98c5243b3300cf9a75f697a`
+**Phase-23 accepted-evidence decision candidate publication subject:**
+`a895f3ae5eeebe5848e52a1d75874b0b75518137`
+**Phase-23 validator-output boundary planning publication-status sync
+subject:** `d225b2b5ffcd83fe12c70bf0150b60f8f288f329`
+**Phase-23 validator-output boundary planning publication subject:**
+`08585f64b6088ed9f76a8027daecec6dc70da885`
+**Phase-23 receipt-evidence boundary planning publication-status sync
+subject:** `9153d858c8ca99b09beb2fa60c6c7bcc565445a9`
+**Phase-23 receipt-evidence boundary planning publication subject:**
+`e6d21b2bfabfd9658a748d69fddcede3d88af401`
+**Phase-23 accepted-evidence boundary planning publication-status sync
+subject:** `40aba477d35902193fca9c75e4042ea1cf8539e5`
+**Phase-23 accepted-evidence boundary planning publication subject:**
+`bc56d0baada3becdc3c820c4a5a167d7859abbbd`
+**Phase-23 exact-SHA evidence expectation boundary publication-status
+sync subject:** `1c6148a7dd1655d6281cdc20489026871c6e3975`
+**Phase-23 exact-SHA evidence expectation boundary publication subject:**
+`22f3f134eb9fd9a0da4d11f9b523ff6ea8c781a2`
+**Phase-23 initial governance boundary publication-status sync subject:**
+`97aab9383e76fcbdc1dfcf0c3520f7de9e0e7692`
+**Phase-23 initial governance boundary publication subject:**
+`3db9a2e740a414b040daa30ee70a54850fdbeb1f`
+**Phase-23 governance overview publication-status sync subject:**
+`1c34b754a07d4eed1493a4b5d456bf870681362f`
+**Phase-23 governance overview publication subject:**
+`bfd4b07d5332f16b5d0295f3170f795629ca7ca8`
+**Phase-23 current phase pointer update subject:**
+`9b70ee20707023709e906d0200a80a1ac69fa698`
+**Phase-23 pointer transition decision subject:**
+`16ac421a40ce93641ccccc28fb5ad869f2b8984e`
+**Phase-23 pointer transition candidate subject:**
+`77fd954607ad076cdea888047f19e4fed60bfb65`
+**Phase-22 closure publication-status sync subject:**
+`6c0a0c878d54ebc6a768e1c708a68d7eb5898b15`
+**Phase-22 closure decision publication subject:**
+`9b19c94a01170d105bd7a7e9fb198df05be17fdf`
+**Current phase pointer:** `CURRENT_PHASE=23`
+**Candidate theme:** Governance-only decision-candidate boundary for
+whether a later accepted-evidence set decision path may be evaluated
+after the bounded evidence acceptance decision exists
+**Authority boundary:** Accepted-evidence set decision candidate only;
+not an accepted-evidence set, not accepted-evidence set membership, not
+accepted evidence, not evidence item acceptance, not validator output
+acceptance, not receipt evidence acceptance, not runtime implementation
+procedure, not source modification, not code implementation, not code
+execution, not process start, not runtime state creation, not general
+runtime authority, not unbounded execution authority, not package
+authority, not package installation, not package loading, not package
+execution, not source acceptance, not source merge authority, not source
+repository authority, not module loading, not workspace runtime, not
+plugin loading, not capability token minting, not capability issuance,
+not trust assignment, not trust issuer authority, not registry authority,
+not registry publication, not publication authority, not deployment
+authority, not distribution authority, not distribution execution, not
+Semantic CLI authority, not AI Runtime authority, not agent authority,
+not syscall expansion, not kernel ABI expansion, not workflow-threshold,
+baseline, dependency, or Ring0 authority.
+
+## Purpose
+
+This document records a Phase-23 governance-only accepted-evidence set
+decision candidate after the clean-fixed Phase-23 Evidence Acceptance
+Decision publication.
+
+It answers one question:
+
+```text
+After the clean-fixed Phase-23 evidence acceptance decision, may a later
+bounded accepted-evidence set decision path be evaluated without creating
+accepted evidence or defining accepted-evidence membership?
+```
+
+It maps only the fail-closed decision-candidate prerequisites for that
+future accepted-evidence set decision path.
+
+It does not create an accepted-evidence set.
+
+It does not define accepted-evidence set membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not convert CI PASS results, receipts, validator output, package
+review output, source review output, historical results, or clean-fixed
+claims into accepted evidence or an accepted-evidence set.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, source acceptance, source merge, registry publication, trust
+assignment, capability issuance, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+It does not answer:
+
+```text
+Which evidence belongs to an accepted-evidence set?
+Which evidence is accepted?
+How is accepted evidence created?
+How is accepted-evidence membership assigned?
+How is validator output accepted?
+How is receipt evidence accepted?
+How is runtime implementation procedure defined?
+How is source modified?
+How is code implemented or executed?
+How is a process started?
+How is runtime state created?
+How is a package installed, loaded, executed, deployed, or distributed?
+How is source accepted or merged?
+How is a capability issued?
+How is trust assigned?
+How is a registry entry published?
+How is kernel ABI or syscall surface expanded?
+How are workflow thresholds, baselines, or dependencies changed?
+```
+
+Those questions require later reviewed decision paths, if ever authorized.
+
+## Exact Subject
+
+This decision candidate is based on exact main SHA:
+
+```text
+1fe089b141af09e9f98be2a153589e68ab015c18
+```
+
+That subject is the squash merge of PR #271:
+
+```text
+Phase-23 evidence acceptance decision
+```
+
+PR #271 changed only:
+
+```text
+PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md
+```
+
+PR #271 produced post-merge exact-main verification:
+
+| Evidence | Run / job | Result |
+|---|---|---|
+| `ci-freeze` | run `28935407122`, attempt 1, job `freeze / 85844420791` | PASS |
+| AykenOS Dev Loop CI | run `28935407227`, attempt 1 | PASS |
+| smoke | job `85844421060` | PASS |
+| contract | job `85844595291` | PASS |
+| full | job `85844964285` | PASS |
+| isolation | job `85845408870` | PASS |
+| performance | job `85845889319` | PASS |
+
+The Phase-23 Evidence Acceptance Decision remains bound to:
+
+```text
+1fe089b141af09e9f98be2a153589e68ab015c18
+```
+
+That decision accepted only the bounded evidence acceptance decision
+boundary.
+
+That decision did not create accepted evidence.
+
+That decision did not create an accepted-evidence set.
+
+That decision did not define accepted-evidence membership.
+
+That decision did not accept validator output.
+
+That decision did not accept receipt evidence.
+
+This decision candidate consumes that exact subject as governance input
+only. It does not replace, broaden, reinterpret, or supersede the
+evidence acceptance decision or any earlier Phase-23 governance boundary.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped subject readings fail closed.
+
+## Core Rule
+
+```text
+accepted-evidence set decision candidate != accepted-evidence set
+accepted-evidence set decision candidate != accepted-evidence set membership
+accepted-evidence set decision candidate != accepted evidence
+accepted-evidence set decision candidate != evidence item acceptance
+accepted-evidence set decision candidate != validator output acceptance
+accepted-evidence set decision candidate != receipt evidence acceptance
+accepted-evidence set decision candidate != runtime implementation procedure
+accepted-evidence set decision candidate != source modification
+accepted-evidence set decision candidate != package loading
+accepted-evidence set decision candidate != package execution
+accepted-evidence set decision candidate != source acceptance
+accepted-evidence set decision candidate != source merge
+decision candidate != decision
+decision candidate != authority grant
+accepted-evidence set != accepted evidence unless separately reviewed
+accepted-evidence set != evidence item acceptance unless separately reviewed
+accepted-evidence set != validator output acceptance unless separately reviewed
+accepted-evidence set != receipt evidence acceptance unless separately reviewed
+evidence acceptance decision != accepted-evidence set
+evidence acceptance decision != accepted evidence
+bounded evidence acceptance decision boundary != accepted-evidence set
+bounded evidence acceptance decision boundary != accepted evidence
+bounded accepted evidence authority != accepted-evidence set
+bounded accepted evidence authority != accepted evidence
+bounded accepted evidence authority != validator output acceptance
+bounded accepted evidence authority != receipt evidence acceptance
+accepted evidence authority != accepted-evidence set
+accepted evidence authority != accepted evidence
+accepted evidence authority != validator output acceptance
+accepted evidence authority != receipt evidence acceptance
+accepted evidence != validator output unless separately reviewed
+accepted evidence != receipt evidence unless separately reviewed
+validator output != accepted evidence
+receipt evidence != accepted evidence
+receipt evidence != validator output
+CI PASS != accepted-evidence set
+CI PASS != accepted evidence
+ci-freeze PASS != accepted-evidence set
+ci-freeze PASS != accepted evidence
+Dev Loop PASS != accepted-evidence set
+Dev Loop PASS != accepted evidence
+AykenOS Dev Loop CI PASS != accepted-evidence set
+AykenOS Dev Loop CI PASS != accepted evidence
+post-merge exact-main verification != accepted-evidence set
+post-merge exact-main verification != accepted evidence
+clean-fixed != accepted-evidence set
+clean-fixed != accepted evidence
+publication-status sync != accepted-evidence set
+publication-status sync != accepted evidence
+CURRENT_PHASE=23 != accepted-evidence set
+CURRENT_PHASE=23 != accepted evidence
+CURRENT_PHASE=23 != validator output acceptance
+CURRENT_PHASE=23 != receipt evidence acceptance
+CURRENT_PHASE=23 != runtime implementation procedure
+CURRENT_PHASE=23 != source modification
+CURRENT_PHASE=23 != execution authority
+CURRENT_PHASE=23 != package loading
+CURRENT_PHASE=23 != source merge authority
+CURRENT_PHASE=23 != kernel ABI expansion
+CURRENT_PHASE=23 != syscall expansion
+historical PASS != inherited evidence
+previous PR evidence != later PR evidence
+```
+
+The safe default remains no accepted-evidence set, no accepted-evidence
+set membership, no accepted evidence, no evidence item acceptance, no
+validator output acceptance, no receipt evidence acceptance, no runtime
+behavior, no implementation procedure, no source modification, no code
+execution, no runtime state, and no package, capability, registry, trust,
+distribution, deployment, source acceptance, source merge, kernel ABI,
+syscall, workflow-threshold, baseline, dependency, or Ring0 authority
+unless a later reviewed Phase-23 decision grants a specific bounded
+authority with its own exact-SHA evidence.
+
+Unknown authority readings fail closed.
+
+## Accepted-Evidence Set Decision-Candidate Boundary
+
+This decision candidate may be used only to evaluate whether a later
+accepted-evidence set decision path can be reviewed.
+
+The only later-evaluable boundary is:
+
+```text
+bounded accepted-evidence set decision path as a future reviewed record
+```
+
+This candidate does not create an accepted-evidence set.
+
+This candidate does not define accepted-evidence set membership.
+
+This candidate does not create accepted evidence.
+
+This candidate does not accept any specific evidence item.
+
+This candidate does not accept validator output.
+
+This candidate does not accept receipt evidence.
+
+This candidate does not make a later accepted-evidence set decision
+inevitable.
+
+Any later accepted-evidence set decision requires a separate reviewed
+decision path with its own exact subject, changed-file scope,
+non-authorization boundary, and post-merge exact-main verification.
+
+## Candidate Scope
+
+This candidate scope is limited to:
+
+1. Mapping accepted-evidence set creation as a later decision-candidate
+   topic.
+2. Binding this candidate to PR #271 as the clean-fixed evidence
+   acceptance decision input.
+3. Preserving the distinction between evidence acceptance and an
+   accepted-evidence set.
+4. Preserving the distinction between an accepted-evidence set and
+   accepted evidence.
+5. Preserving separation from evidence item acceptance.
+6. Preserving separation from validator output acceptance and receipt
+   evidence acceptance.
+7. Establishing post-merge exact-main verification expectations for this
+   decision-candidate record.
+
+Candidate scope is governance text only.
+
+Candidate scope is not an accepted-evidence set.
+
+Candidate scope is not accepted-evidence set membership.
+
+Candidate scope is not accepted evidence.
+
+Candidate scope is not evidence item acceptance.
+
+Candidate scope is not validator output acceptance.
+
+Candidate scope is not receipt evidence acceptance.
+
+Candidate scope is not runtime implementation procedure.
+
+Candidate scope is not package loading authority.
+
+Candidate scope is not execution authority.
+
+Candidate scope is not source merge authority.
+
+## Current Phase Pointer Boundary
+
+The current phase pointer remains:
+
+```text
+CURRENT_PHASE=23
+```
+
+This decision candidate does not modify:
+
+```text
+docs/roadmap/CURRENT_PHASE
+```
+
+This decision candidate does not change the active phase pointer.
+
+`CURRENT_PHASE=23` does not authorize an accepted-evidence set,
+accepted-evidence set membership, accepted evidence, validator output
+acceptance, receipt evidence acceptance, runtime implementation
+procedure, source modification, code implementation, code execution,
+process start, runtime state creation, package loading, package
+execution, capability issuance, registry publication, trust assignment,
+deployment, distribution, source acceptance, source merge, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+## Evidence Acceptance Decision Input
+
+This decision candidate consumes the clean-fixed Phase-23 Evidence
+Acceptance Decision as its exact governance prerequisite.
+
+The evidence acceptance decision remains bound to:
+
+```text
+1fe089b141af09e9f98be2a153589e68ab015c18
+```
+
+The evidence acceptance decision accepted only the bounded evidence
+acceptance decision boundary.
+
+This decision candidate does not reinterpret that bounded decision
+boundary as an accepted-evidence set, accepted-evidence set membership,
+accepted evidence, evidence item acceptance, validator output
+acceptance, receipt evidence acceptance, runtime implementation
+procedure, execution authority, package loading authority, source
+acceptance, source merge authority, capability issuance, registry
+publication, trust assignment, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold change, baseline change,
+dependency change, or Ring0 authority.
+
+Any evidence acceptance decision conflict fails closed.
+
+## Relationship To Accepted Evidence And Set Membership
+
+An accepted-evidence set remains separate from accepted evidence unless a
+separate reviewed decision explicitly grants that narrower authority.
+
+An accepted-evidence set remains separate from set membership unless a
+separate reviewed decision explicitly defines exact membership.
+
+This decision candidate does not create an accepted-evidence set.
+
+This decision candidate does not define accepted-evidence membership.
+
+This decision candidate does not create accepted evidence.
+
+This decision candidate does not identify accepted evidence.
+
+This decision candidate does not accept any specific evidence item.
+
+This decision candidate does not make accepted evidence inevitable.
+
+This decision candidate does not make accepted-evidence set membership
+inevitable.
+
+Any attempt to treat this candidate as accepted evidence, an
+accepted-evidence set, or accepted-evidence membership fails closed.
+
+## Relationship To Validator Output And Receipt Evidence
+
+This decision candidate consumes the clean-fixed Phase-23
+Validator-Output Boundary Planning and Receipt-Evidence Boundary Planning
+records as exact governance prerequisites only.
+
+The Phase-23 Validator-Output Boundary Planning publication-status sync
+remains bound to:
+
+```text
+d225b2b5ffcd83fe12c70bf0150b60f8f288f329
+```
+
+The Phase-23 Receipt-Evidence Boundary Planning publication-status sync
+remains bound to:
+
+```text
+9153d858c8ca99b09beb2fa60c6c7bcc565445a9
+```
+
+This decision candidate does not convert validator output into accepted
+evidence.
+
+This decision candidate does not convert receipt evidence into accepted
+evidence.
+
+This decision candidate does not place validator output in an
+accepted-evidence set.
+
+This decision candidate does not place receipt evidence in an
+accepted-evidence set.
+
+This decision candidate does not accept validator output.
+
+This decision candidate does not accept receipt evidence.
+
+This decision candidate does not grant accepted-evidence membership over
+validator output, receipt evidence, package review output, source review
+output, historical PASS results, or clean-fixed claims.
+
+Any validator-output or receipt-evidence boundary conflict fails closed.
+
+## Relationship To Phase-23 Accepted-Evidence Authority Decision
+
+This decision candidate consumes the clean-fixed Phase-23
+Accepted-Evidence Authority Decision as an exact governance prerequisite.
+
+The Phase-23 Accepted-Evidence Authority Decision remains bound to:
+
+```text
+d9ac910c24601002971e7d06cf94463d739b1358
+```
+
+The accepted-evidence authority decision accepted only bounded accepted
+evidence authority as a governance authority class.
+
+This accepted-evidence set decision candidate does not convert that
+bounded authority class into accepted evidence.
+
+This accepted-evidence set decision candidate does not convert that
+bounded authority class into an accepted-evidence set.
+
+This accepted-evidence set decision candidate does not broaden the
+accepted-evidence authority decision record.
+
+Any accepted-evidence authority decision conflict fails closed.
+
+## Relationship To Phase-23 Accepted-Evidence Boundary Planning
+
+This decision candidate consumes the clean-fixed Phase-23
+Accepted-Evidence Boundary Planning record and its clean-fixed
+publication-status sync as exact governance prerequisites.
+
+The Phase-23 Accepted-Evidence Boundary Planning publication-status sync
+remains bound to:
+
+```text
+40aba477d35902193fca9c75e4042ea1cf8539e5
+```
+
+The Phase-23 Accepted-Evidence Boundary Planning publication remains
+bound to:
+
+```text
+bc56d0baada3becdc3c820c4a5a167d7859abbbd
+```
+
+This decision candidate does not convert accepted-evidence boundary
+planning into accepted evidence.
+
+This decision candidate does not convert accepted-evidence boundary
+planning into an accepted-evidence set.
+
+This decision candidate does not define accepted-evidence membership.
+
+This decision candidate does not broaden the accepted-evidence boundary
+planning record.
+
+Any accepted-evidence boundary planning conflict fails closed.
+
+## Relationship To Phase-23 Exact-SHA Evidence Expectation Boundary
+
+This decision candidate consumes the clean-fixed Phase-23 Exact-SHA
+Evidence Expectation Boundary and its clean-fixed publication-status sync
+as exact governance prerequisites.
+
+The Phase-23 Exact-SHA Evidence Expectation Boundary publication-status
+sync remains bound to:
+
+```text
+1c6148a7dd1655d6281cdc20489026871c6e3975
+```
+
+The Phase-23 Exact-SHA Evidence Expectation Boundary publication remains
+bound to:
+
+```text
+22f3f134eb9fd9a0da4d11f9b523ff6ea8c781a2
+```
+
+This decision candidate uses those expectations only as prerequisites for
+a later accepted-evidence set decision-candidate boundary.
+
+This decision candidate does not convert exact-SHA expectations into
+accepted evidence.
+
+This decision candidate does not convert exact-SHA expectations into an
+accepted-evidence set.
+
+This decision candidate does not define accepted-evidence membership.
+
+Any exact-SHA evidence expectation boundary conflict fails closed.
+
+## Relationship To Phase-23 Governance Overview And Initial Boundary
+
+This decision candidate consumes the clean-fixed Phase-23 Governance
+Overview, Phase-23 Initial Governance Boundary, and their
+publication-status syncs as exact governance prerequisites.
+
+The Phase-23 Governance Overview publication-status sync remains bound
+to:
+
+```text
+1c34b754a07d4eed1493a4b5d456bf870681362f
+```
+
+The Phase-23 Initial Governance Boundary publication-status sync remains
+bound to:
+
+```text
+97aab9383e76fcbdc1dfcf0c3520f7de9e0e7692
+```
+
+This decision candidate does not broaden the Phase-23 governance
+overview.
+
+This decision candidate does not broaden the Phase-23 initial governance
+boundary.
+
+Any overview or initial-boundary conflict fails closed.
+
+## Relationship To Phase-22 Closure
+
+This decision candidate consumes the Phase-22 Closure Decision and the
+Phase-22 closure publication-status sync as exact governance
+prerequisites.
+
+The Phase-22 Closure Decision remains bound to:
+
+```text
+9b19c94a01170d105bd7a7e9fb198df05be17fdf
+```
+
+The latest Phase-22 closure publication-status sync remains bound to:
+
+```text
+6c0a0c878d54ebc6a768e1c708a68d7eb5898b15
+```
+
+Phase-22 remains closed only as:
+
+```text
+actual skeleton reviewed;
+static package acceptance boundary defined and clean-recovered;
+Phase-21 First Bounded Implementation actual skeleton exact 12-file set
+accepted as a static package subject only.
+```
+
+This decision candidate does not reopen Phase-22.
+
+This decision candidate does not reinterpret Phase-22 closure as Phase-23
+accepted evidence, an accepted-evidence set, accepted-evidence
+membership, validator output acceptance, receipt evidence acceptance,
+runtime implementation procedure, package loading, package execution,
+source acceptance, source merge authority, capability issuance, registry
+publication, trust assignment, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Any Phase-22 closure conflict fails closed.
+
+## Relationship To Phase-19 Runtime Authority
+
+This decision candidate remains subordinate to Phase-19 runtime authority
+records.
+
+This decision candidate must not broaden, replace, supersede, weaken, or
+reinterpret Phase-19 runtime authority records.
+
+This decision candidate must not use accepted-evidence set candidate
+planning to infer runtime authority.
+
+This decision candidate must not use evidence acceptance decision records
+to infer runtime authority.
+
+This decision candidate must not use accepted-evidence authority to infer
+runtime authority.
+
+This decision candidate must not use accepted-evidence boundary planning
+to infer runtime authority.
+
+This decision candidate must not use validator-output planning to infer
+runtime authority.
+
+This decision candidate must not use receipt-evidence planning to infer
+runtime authority.
+
+This decision candidate must not use exact-SHA evidence expectations to
+infer runtime authority.
+
+This decision candidate must not use `CURRENT_PHASE=23` to infer runtime
+authority.
+
+Any Phase-23 accepted-evidence set decision-candidate reading that
+conflicts with Phase-19 runtime authority records fails closed.
+
+## Not Authorized By This Decision Candidate
+
+This decision candidate does not authorize:
+
+1. Accepted-evidence set creation.
+2. Accepted-evidence set membership.
+3. Accepted evidence.
+4. Evidence item acceptance.
+5. Validator output acceptance.
+6. Receipt evidence acceptance.
+7. Runtime implementation procedure.
+8. Source modification.
+9. Source acceptance.
+10. Source merge.
+11. Code implementation.
+12. Code execution.
+13. Process start.
+14. Runtime state creation.
+15. Package installation.
+16. Package loading.
+17. Package execution.
+18. Module loading.
+19. Workspace runtime or real mounts.
+20. Plugin loading or plugin instantiation.
+21. Capability token minting.
+22. Capability issuance.
+23. Registry publication.
+24. Trust assignment.
+25. Distribution execution.
+26. Deployment.
+27. Semantic CLI authority.
+28. AI Runtime authority.
+29. Agent authority.
+30. Syscall expansion.
+31. Kernel ABI expansion.
+32. Ring0 policy movement.
+33. Workflow-threshold changes.
+34. Baseline changes.
+35. Dependency changes.
+36. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this decision candidate is published, the publication may change only
+this file:
+
+```text
+PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md
+```
+
+The publication must not change:
+
+1. `docs/roadmap/CURRENT_PHASE`.
+2. `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`.
+3. `PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`.
+4. `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`.
+5. `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`.
+6. `PHASE23_ACCEPTED_EVIDENCE_DECISION.md`.
+7. `PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`.
+8. `PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`.
+9. `PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`.
+10. `PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`.
+11. `PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`.
+12. `PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`.
+13. `PHASE23_GOVERNANCE_OVERVIEW.md`.
+14. CI workflows.
+15. Baselines.
+16. Dependencies.
+17. Runtime source or kernel source.
+18. Syscalls or kernel ABI.
+19. Package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution paths.
+20. `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md`.
+
+Any changed-file expansion beyond this decision candidate requires
+separate review and fails this candidate scope.
+
+## Post-Merge Exact-Main Evidence Rule
+
+If this decision candidate is later published, the candidate publication
+subject must receive its own post-merge exact-main verification:
+
+1. `ci-freeze` PASS for the exact candidate publication SHA.
+2. AykenOS Dev Loop CI PASS for the exact candidate publication SHA.
+3. smoke PASS.
+4. contract PASS.
+5. full PASS.
+6. isolation PASS.
+7. performance PASS.
+8. Exact changed-file list confirmation.
+9. No `docs/roadmap/CURRENT_PHASE` change.
+10. No `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md` change.
+11. No `PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md` change.
+12. No `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md` change.
+13. No `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`
+    change.
+14. No `PHASE23_ACCEPTED_EVIDENCE_DECISION.md` change.
+15. No `PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md` change.
+16. No `PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md` change.
+17. No `PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md` change.
+18. No `PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md` change.
+19. No `PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md` change.
+20. No `PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md` change.
+21. No `PHASE23_GOVERNANCE_OVERVIEW.md` change.
+22. No CI workflow change.
+23. No baseline change.
+24. No dependency change.
+25. No runtime source or kernel source change.
+26. No syscall or kernel ABI change.
+27. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution change.
+
+Until that exact-main post-merge verification exists, this decision
+candidate must not be recorded as clean-fixed.
+
+Historical PASS results may be cited as context only.
+
+Failed attempts may be cited as transparent non-clean context only.
+
+They cannot be inherited as an accepted-evidence set,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime authority, package loading authority, package execution
+authority, source merge authority, capability authority, registry
+authority, trust authority, kernel ABI authority, syscall authority,
+workflow-threshold authority, baseline authority, dependency authority,
+or Ring0 authority.
+
+## Later Accepted-Evidence Set Decision Dependency
+
+This decision candidate is a prerequisite input for a possible later
+bounded accepted-evidence set decision.
+
+A later accepted-evidence set decision, if ever proposed, must define:
+
+1. Exact accepted-evidence set decision subject.
+2. Exact Phase-23 accepted-evidence set decision-candidate prerequisite.
+3. Exact changed-file boundary.
+4. Exact accepted-evidence set boundary, if any.
+5. Exact accepted-evidence set membership scope, if any.
+6. Exact evidence item acceptance denial or separate evidence item
+   acceptance scope.
+7. Exact accepted-evidence denial or separate accepted-evidence scope.
+8. Exact validator-output acceptance denial or separate validator-output
+   acceptance scope.
+9. Exact receipt-evidence acceptance denial or separate receipt-evidence
+   acceptance scope.
+10. Exact runtime implementation procedure denial.
+11. Exact package loading and package execution denials.
+12. Exact source acceptance and source merge denials.
+13. Exact capability, registry, trust, deployment, distribution, kernel
+    ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+    denials.
+14. Exact post-merge verification requirements.
+
+Until such a later reviewed accepted-evidence set decision is published,
+no accepted-evidence set exists from this decision candidate.
+
+Until such a later reviewed accepted-evidence membership record is
+published, no accepted-evidence set membership exists from this decision
+candidate.
+
+Until such a later reviewed accepted-evidence record is published, no
+accepted evidence exists from this decision candidate.
+
+Until such a later reviewed evidence item acceptance record is published,
+no evidence item acceptance exists from this decision candidate.
+
+Until such a later reviewed validator-output acceptance record is
+published, no validator output acceptance exists from this decision
+candidate.
+
+Until such a later reviewed receipt-evidence acceptance record is
+published, no receipt evidence acceptance exists from this decision
+candidate.
+
+## Excluded Local Draft
+
+This decision candidate does not consume:
+
+```text
+PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md
+```
+
+If that file exists locally as an untracked file, it remains:
+
+```text
+untracked
+PR-disjoint
+not decision input
+not evidence input
+not accepted-evidence set
+not accepted-evidence set membership
+not accepted evidence
+not validator output
+not receipt evidence
+not source authority
+not package acceptance
+not runtime authority
+```
+
+It must not be staged, committed, or included in any Phase-23
+accepted-evidence set decision-candidate PR unless a separate reviewed
+scope explicitly authorizes that file.
+
+## Governance Boundary Invariants
+
+Every later RFC must preserve these Phase-23 accepted-evidence set
+decision candidate invariants:
+
+1. This decision candidate is not an accepted-evidence set.
+2. This decision candidate is not accepted-evidence set membership.
+3. This decision candidate is not accepted evidence.
+4. This decision candidate is not evidence item acceptance.
+5. This decision candidate is not validator output acceptance.
+6. This decision candidate is not receipt evidence acceptance.
+7. This decision candidate is not a decision.
+8. This decision candidate is not an authority grant.
+9. Accepted-evidence set is not accepted evidence unless separately
+   reviewed.
+10. Accepted-evidence set is not evidence item acceptance unless
+    separately reviewed.
+11. Evidence acceptance decision is not accepted-evidence set.
+12. Bounded evidence acceptance decision boundary is not accepted-evidence
+    set.
+13. Bounded accepted evidence authority is not accepted-evidence set.
+14. This decision candidate is not runtime implementation procedure.
+15. This decision candidate is not source modification.
+16. This decision candidate is not code implementation.
+17. This decision candidate is not code execution.
+18. This decision candidate is not process start.
+19. This decision candidate is not runtime state creation.
+20. This decision candidate is not package installation.
+21. This decision candidate is not package loading.
+22. This decision candidate is not package execution.
+23. This decision candidate is not capability issuance.
+24. This decision candidate is not registry publication.
+25. This decision candidate is not trust assignment.
+26. This decision candidate is not deployment.
+27. This decision candidate is not distribution authority.
+28. This decision candidate is not source acceptance.
+29. This decision candidate is not source merge authority.
+30. This decision candidate does not modify `docs/roadmap/CURRENT_PHASE`.
+31. This decision candidate does not modify
+    `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`.
+32. This decision candidate does not modify
+    `PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`.
+33. This decision candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`.
+34. This decision candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`.
+35. This decision candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_DECISION.md`.
+36. This decision candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`.
+37. This decision candidate does not modify
+    `PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`.
+38. This decision candidate does not modify
+    `PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`.
+39. This decision candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`.
+40. This decision candidate does not modify
+    `PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`.
+41. This decision candidate does not modify
+    `PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`.
+42. This decision candidate does not modify `PHASE23_GOVERNANCE_OVERVIEW.md`.
+43. `CURRENT_PHASE=23` is not an accepted-evidence set.
+44. `CURRENT_PHASE=23` is not accepted-evidence set membership.
+45. `CURRENT_PHASE=23` is not accepted evidence.
+46. `CURRENT_PHASE=23` is not validator output acceptance.
+47. `CURRENT_PHASE=23` is not receipt evidence acceptance.
+48. `CURRENT_PHASE=23` is not runtime implementation procedure.
+49. `CURRENT_PHASE=23` is not source modification.
+50. `CURRENT_PHASE=23` is not execution authority.
+51. `CURRENT_PHASE=23` is not package loading.
+52. `CURRENT_PHASE=23` is not source merge authority.
+53. This decision candidate does not broaden Phase-19 runtime authority.
+54. This decision candidate does not reopen Phase-20.
+55. This decision candidate does not reopen Phase-21.
+56. This decision candidate does not reopen Phase-22.
+57. This decision candidate does not expand kernel ABI or syscalls.
+58. This decision candidate does not change workflow thresholds,
+    baselines, or dependencies.
+59. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-23 accepted-evidence set decision candidate
+**Architecture status:** Local draft accepted-evidence set decision
+candidate / pending separate reviewed publication
+**Authority notice:** This signature identifies the architectural
+authorship of this decision candidate. It grants no accepted-evidence set
+authority, accepted-evidence set membership authority, accepted evidence
+status, evidence item acceptance authority, validator output acceptance
+authority, receipt evidence acceptance authority, runtime implementation
+procedure authority, source modification authority, code implementation
+authority, code execution authority, process start authority, general
+runtime authority, unbounded execution authority, runtime state
+authority, package installation authority, package loading authority,
+package execution authority, source merge authority, trust authority,
+registry authority, distribution authority, publication authority,
+capability issuance authority, deployment authority, module authority,
+plugin authority, Semantic CLI authority, AI Runtime authority, agent
+authority, kernel ABI authority, syscall authority, workflow-threshold
+authority, baseline authority, dependency authority, or Ring0 authority.
+
+## Conclusion
+
+This Phase-23 accepted-evidence set decision candidate is based on the
+clean-fixed Phase-23 Evidence Acceptance Decision publication subject:
+
+```text
+1fe089b141af09e9f98be2a153589e68ab015c18
+```
+
+It defines only the governance-only candidate boundary for whether a
+later accepted-evidence set decision path may be evaluated after the
+bounded evidence acceptance decision exists.
+
+It does not create an accepted-evidence set.
+
+It does not define accepted-evidence set membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize accepted-evidence set creation, accepted-evidence
+set membership, accepted evidence, evidence item acceptance, validator
+output acceptance, receipt evidence acceptance, runtime implementation
+procedure, source modification, code implementation, code execution,
+process start, runtime state creation, package installation, package
+loading, package execution, capability issuance, registry publication,
+trust assignment, deployment, distribution, source acceptance, source
+merge, kernel ABI expansion, syscall expansion, workflow-threshold
+changes, baseline changes, dependency changes, or Ring0 authority.
+
+Any later Phase-23 accepted-evidence set, accepted-evidence membership,
+accepted-evidence, validator-output, receipt-evidence, package-review,
+source-review, runtime-implementation-procedure, or non-authorization
+boundary record requires its own exact-SHA evidence, changed-file scope,
+non-authorization boundary, and reviewed decision path.


### PR DESCRIPTION
This PR changes only PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md.

It adds a governance-only accepted-evidence set decision candidate based on PR #271 at 1fe089b141af09e9f98be2a153589e68ab015c18.

This candidate does not create an accepted-evidence set, does not define accepted-evidence set membership, does not create accepted evidence, does not accept any evidence item, does not accept validator output, does not accept receipt evidence, and grants no runtime/source/package/source-merge/registry/trust/capability/deployment/distribution/kernel-ABI/syscall/workflow-threshold/baseline/dependency/Ring0 authority.