### PR TITLE
Phase-23 accepted-evidence set membership decision

### DIFF
--- a/PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md
+++ b/PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md
@@ -1,0 +1,1206 @@
+# Phase-23 Accepted-Evidence Set Membership Decision
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY_CLEAN_RECOVERY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_FIRST_BOUNDED_IMPLEMENTATION.md`,
+`PHASE22_CLOSURE_DECISION.md`,
+`PHASE23_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE23_POINTER_TRANSITION_DECISION.md`,
+`docs/roadmap/CURRENT_PHASE`,
+`PHASE23_GOVERNANCE_OVERVIEW.md`,
+`PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`,
+`PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`,
+`PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`, and
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`. In case
+of conflict, those documents prevail unless this document is the narrower
+Phase-23 accepted-evidence set membership decision record for the exact
+governance-only bounded membership-decision boundary identified below.
+
+**Status:** PHASE-23 ACCEPTED-EVIDENCE SET MEMBERSHIP DECISION / LOCAL
+DRAFT / GOVERNANCE-ONLY ACCEPTED-EVIDENCE SET MEMBERSHIP DECISION ONLY /
+BOUNDED ACCEPTED-EVIDENCE SET MEMBERSHIP DECISION BOUNDARY ONLY / NO
+ACCEPTED-EVIDENCE SET MEMBERSHIP / NO ACCEPTED EVIDENCE / NO EVIDENCE
+ITEM ACCEPTANCE / NO VALIDATOR OUTPUT ACCEPTANCE / NO RECEIPT EVIDENCE
+ACCEPTANCE / NO RUNTIME IMPLEMENTATION PROCEDURE / NO SOURCE
+MODIFICATION / NO CODE IMPLEMENTATION / NO CODE EXECUTION / NO PROCESS
+START / NO RUNTIME STATE CREATION / NO PACKAGE INSTALLATION / NO PACKAGE
+LOADING / NO PACKAGE EXECUTION / NO DEPLOYMENT / NO CAPABILITY ISSUANCE /
+NO TRUST ASSIGNMENT / NO REGISTRY PUBLICATION / NO DISTRIBUTION
+AUTHORITY / NO SOURCE ACCEPTANCE / NO SOURCE MERGE AUTHORITY / NO KERNEL
+ABI EXPANSION / NO SYSCALL EXPANSION / NO WORKFLOW-THRESHOLD CHANGE / NO
+BASELINE CHANGE / NO DEPENDENCY CHANGE / NO RING0 AUTHORITY
+**Decision date:** 2026-07-08
+**Decision id:**
+`ayken.phase23.accepted_evidence_set_membership_decision.v1`
+**Decision drafting base main SHA:**
+`ac05e74885f85f2d0bed540d66b9c80059086c5d`
+**Decision publication subject:** pending separate reviewed publication
+**Reviewed Phase-23 accepted-evidence set membership decision candidate
+publication subject:** `ac05e74885f85f2d0bed540d66b9c80059086c5d`
+**Reviewed Phase-23 accepted-evidence set membership decision candidate
+PR:** PR #275
+**Reviewed Phase-23 accepted-evidence set membership decision candidate
+exact-main ci-freeze run:** `28965796705`
+**Reviewed Phase-23 accepted-evidence set membership decision candidate
+exact-main ci-freeze attempt:** attempt 1
+**Reviewed Phase-23 accepted-evidence set membership decision candidate
+exact-main ci-freeze job:** `freeze / 85948503930`
+**Reviewed Phase-23 accepted-evidence set membership decision candidate
+exact-main ci-freeze result:** PASS
+**Reviewed Phase-23 accepted-evidence set membership decision candidate
+exact-main Dev Loop Validation run:** `28965796716`
+**Reviewed Phase-23 accepted-evidence set membership decision candidate
+exact-main Dev Loop Validation attempt:** attempt 1
+**Reviewed Phase-23 accepted-evidence set membership decision candidate
+exact-main Dev Loop Validation job:** `devloop / 85948504542`
+**Reviewed Phase-23 accepted-evidence set membership decision candidate
+exact-main Dev Loop Validation result:** PASS
+**Reviewed Phase-23 accepted-evidence set membership decision candidate
+exact-main Dev Loop CI run:** `28965796726`
+**Reviewed Phase-23 accepted-evidence set membership decision candidate
+exact-main Dev Loop CI attempt:** attempt 1
+**Reviewed Phase-23 accepted-evidence set membership decision candidate
+exact-main Dev Loop CI result:** PASS
+**Reviewed Phase-23 accepted-evidence set membership decision candidate
+exact-main smoke job:** `smoke / 85948503898`
+**Reviewed Phase-23 accepted-evidence set membership decision candidate
+exact-main smoke result:** PASS
+**Reviewed Phase-23 accepted-evidence set membership decision candidate
+exact-main contract job:** `contract / 85948753035`
+**Reviewed Phase-23 accepted-evidence set membership decision candidate
+exact-main contract result:** PASS
+**Reviewed Phase-23 accepted-evidence set membership decision candidate
+exact-main full job:** `full / 85949162621`
+**Reviewed Phase-23 accepted-evidence set membership decision candidate
+exact-main full result:** PASS
+**Reviewed Phase-23 accepted-evidence set membership decision candidate
+exact-main isolation job:** `isolation / 85949730233`
+**Reviewed Phase-23 accepted-evidence set membership decision candidate
+exact-main isolation result:** PASS
+**Reviewed Phase-23 accepted-evidence set membership decision candidate
+exact-main performance job:** `performance / 85950201379`
+**Reviewed Phase-23 accepted-evidence set membership decision candidate
+exact-main performance result:** PASS
+**Phase-23 accepted-evidence set decision publication-status sync
+subject:** `1e6c2e1af515a57ef2be910dbf6aa61d5fc081ff`
+**Phase-23 accepted-evidence set decision publication subject:**
+`a39cec2fcdc03c43a6a97de27cad0e16085b17c8`
+**Phase-23 accepted-evidence set decision candidate publication subject:**
+`206d1a9aff8ba3dd2aaa4a0e258315d5c92379cd`
+**Phase-23 evidence acceptance decision publication subject:**
+`1fe089b141af09e9f98be2a153589e68ab015c18`
+**Phase-23 evidence acceptance decision candidate publication subject:**
+`7d90f2c195afecfb4875876f1ea832df3d9b6528`
+**Phase-23 accepted-evidence authority decision publication subject:**
+`d9ac910c24601002971e7d06cf94463d739b1358`
+**Phase-23 accepted-evidence authority decision candidate publication
+subject:** `72d5234654a5af4fa84b52f3ba3753b9104a4dce`
+**Phase-23 accepted-evidence decision publication subject:**
+`0f6da8e9abe8d354e98c5243b3300cf9a75f697a`
+**Phase-23 accepted-evidence decision candidate publication subject:**
+`a895f3ae5eeebe5848e52a1d75874b0b75518137`
+**Phase-23 validator-output boundary planning publication-status sync
+subject:** `d225b2b5ffcd83fe12c70bf0150b60f8f288f329`
+**Phase-23 validator-output boundary planning publication subject:**
+`08585f64b6088ed9f76a8027daecec6dc70da885`
+**Phase-23 receipt-evidence boundary planning publication-status sync
+subject:** `9153d858c8ca99b09beb2fa60c6c7bcc565445a9`
+**Phase-23 receipt-evidence boundary planning publication subject:**
+`e6d21b2bfabfd9658a748d69fddcede3d88af401`
+**Phase-23 accepted-evidence boundary planning publication-status sync
+subject:** `40aba477d35902193fca9c75e4042ea1cf8539e5`
+**Phase-23 accepted-evidence boundary planning publication subject:**
+`bc56d0baada3becdc3c820c4a5a167d7859abbbd`
+**Phase-23 exact-SHA evidence expectation boundary publication-status
+sync subject:** `1c6148a7dd1655d6281cdc20489026871c6e3975`
+**Phase-23 exact-SHA evidence expectation boundary publication subject:**
+`22f3f134eb9fd9a0da4d11f9b523ff6ea8c781a2`
+**Phase-23 initial governance boundary publication-status sync subject:**
+`97aab9383e76fcbdc1dfcf0c3520f7de9e0e7692`
+**Phase-23 initial governance boundary publication subject:**
+`3db9a2e740a414b040daa30ee70a54850fdbeb1f`
+**Phase-23 governance overview publication-status sync subject:**
+`1c34b754a07d4eed1493a4b5d456bf870681362f`
+**Phase-23 governance overview publication subject:**
+`bfd4b07d5332f16b5d0295f3170f795629ca7ca8`
+**Phase-23 current phase pointer update subject:**
+`9b70ee20707023709e906d0200a80a1ac69fa698`
+**Phase-23 pointer transition decision subject:**
+`16ac421a40ce93641ccccc28fb5ad869f2b8984e`
+**Phase-23 pointer transition candidate subject:**
+`77fd954607ad076cdea888047f19e4fed60bfb65`
+**Phase-22 closure publication-status sync subject:**
+`6c0a0c878d54ebc6a768e1c708a68d7eb5898b15`
+**Phase-22 closure decision publication subject:**
+`9b19c94a01170d105bd7a7e9fb198df05be17fdf`
+**Current phase pointer:** `CURRENT_PHASE=23`
+**Accepted Phase-23 accepted-evidence set membership decision boundary:**
+bounded accepted-evidence set membership decision boundary as a
+governance decision boundary only; accepted-evidence set membership,
+accepted evidence, evidence item acceptance, validator output acceptance,
+and receipt evidence acceptance remain pending separate reviewed decision
+paths if ever authorized
+**Authority boundary:** Accepted-evidence set membership decision record
+only; bounded accepted-evidence set membership decision boundary only;
+not accepted-evidence set membership, not accepted evidence, not
+evidence item acceptance, not validator output acceptance, not receipt
+evidence acceptance, not runtime implementation procedure, not source
+modification, not code implementation, not code execution, not process
+start, not runtime state creation, not general runtime authority, not
+unbounded execution authority, not package authority, not package
+installation, not package loading, not package execution, not source
+acceptance, not source merge authority, not source repository authority,
+not module loading, not workspace runtime, not plugin loading, not
+capability token minting, not capability issuance, not trust assignment,
+not trust issuer authority, not registry authority, not registry
+publication, not publication authority, not deployment authority, not
+distribution authority, not distribution execution, not Semantic CLI
+authority, not AI Runtime authority, not agent authority, not syscall
+expansion, not kernel ABI expansion, not workflow-threshold, baseline,
+dependency, or Ring0 authority.
+
+## Purpose
+
+This document records a Phase-23 governance-only accepted-evidence set
+membership decision after the clean-fixed Phase-23 Accepted-Evidence Set
+Membership Decision Candidate publication.
+
+It evaluates only:
+
+```text
+May a bounded accepted-evidence set membership decision boundary be
+defined during Phase-23 without assigning membership, accepting any
+evidence item, or creating accepted evidence?
+```
+
+It accepts only the bounded accepted-evidence set membership decision
+boundary as a governance decision boundary.
+
+This decision may define a bounded accepted-evidence set membership
+decision boundary, but it does not assign accepted-evidence set
+membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not convert CI PASS results, receipts, validator output, package
+review output, source review output, historical results, or clean-fixed
+claims into accepted evidence or accepted-evidence set membership.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, source acceptance, source merge, registry publication, trust
+assignment, capability issuance, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+It does not answer:
+
+```text
+Which evidence item is a member of an accepted-evidence set?
+Which evidence is accepted?
+How is accepted evidence created?
+How is accepted-evidence set membership assigned?
+How is evidence item acceptance performed?
+How is validator output accepted?
+How is receipt evidence accepted?
+How is runtime implementation procedure defined?
+How is source modified?
+How is code implemented or executed?
+How is a process started?
+How is runtime state created?
+How is a package installed, loaded, executed, deployed, or distributed?
+How is source accepted or merged?
+How is a capability issued?
+How is trust assigned?
+How is a registry entry published?
+How is kernel ABI or syscall surface expanded?
+How are workflow thresholds, baselines, or dependencies changed?
+```
+
+Those questions require later reviewed decision paths, if ever authorized.
+
+## Exact Subject
+
+This decision draft is based on exact main SHA:
+
+```text
+ac05e74885f85f2d0bed540d66b9c80059086c5d
+```
+
+That subject is the squash merge of PR #275:
+
+```text
+Phase-23 accepted-evidence set membership decision candidate
+```
+
+PR #275 changed only:
+
+```text
+PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md
+```
+
+PR #275 produced post-merge exact-main verification:
+
+| Evidence | Run / job | Result |
+|---|---|---|
+| `ci-freeze` | run `28965796705`, attempt 1, job `freeze / 85948503930` | PASS |
+| Dev Loop Validation | run `28965796716`, attempt 1, job `devloop / 85948504542` | PASS |
+| AykenOS Dev Loop CI | run `28965796726`, attempt 1 | PASS |
+| smoke | job `85948503898` | PASS |
+| contract | job `85948753035` | PASS |
+| full | job `85949162621` | PASS |
+| isolation | job `85949730233` | PASS |
+| performance | job `85950201379` | PASS |
+
+The Phase-23 Accepted-Evidence Set Membership Decision Candidate remains
+bound to:
+
+```text
+ac05e74885f85f2d0bed540d66b9c80059086c5d
+```
+
+That decision candidate recorded that it was not accepted-evidence set
+membership, not accepted evidence, not evidence item acceptance, not
+validator output acceptance, not receipt evidence acceptance, not a
+decision, and not an authority grant.
+
+This decision consumes that exact subject as governance input only. It
+does not replace, broaden, reinterpret, or supersede the
+accepted-evidence set membership decision candidate or any earlier
+Phase-23 governance boundary.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped subject readings fail closed.
+
+## Core Rule
+
+```text
+accepted-evidence set membership decision == bounded accepted-evidence set membership decision boundary only
+accepted-evidence set membership decision != accepted-evidence set
+accepted-evidence set membership decision != accepted-evidence set membership
+accepted-evidence set membership decision != accepted evidence
+accepted-evidence set membership decision != evidence item acceptance
+accepted-evidence set membership decision != validator output acceptance
+accepted-evidence set membership decision != receipt evidence acceptance
+accepted-evidence set membership decision != runtime implementation procedure
+accepted-evidence set membership decision != source modification
+accepted-evidence set membership decision != package loading
+accepted-evidence set membership decision != package execution
+accepted-evidence set membership decision != source acceptance
+accepted-evidence set membership decision != source merge
+bounded accepted-evidence set membership decision boundary != accepted-evidence set membership
+bounded accepted-evidence set membership decision boundary != accepted evidence
+bounded accepted-evidence set membership decision boundary != evidence item acceptance
+bounded accepted-evidence set membership decision boundary != validator output acceptance
+bounded accepted-evidence set membership decision boundary != receipt evidence acceptance
+accepted-evidence set membership decision candidate != accepted-evidence set membership decision until clean-fixed
+decision candidate != decision
+decision candidate != authority grant
+accepted-evidence set membership != accepted evidence unless separately reviewed
+accepted-evidence set membership != evidence item acceptance unless separately reviewed
+accepted-evidence set membership != validator output acceptance unless separately reviewed
+accepted-evidence set membership != receipt evidence acceptance unless separately reviewed
+accepted-evidence set decision != accepted-evidence set membership unless separately reviewed
+accepted-evidence set != accepted evidence unless separately reviewed
+accepted-evidence set != evidence item acceptance unless separately reviewed
+accepted-evidence set != validator output acceptance unless separately reviewed
+accepted-evidence set != receipt evidence acceptance unless separately reviewed
+evidence acceptance decision != accepted-evidence set membership
+evidence acceptance decision != accepted evidence
+bounded evidence acceptance decision boundary != accepted-evidence set membership
+bounded evidence acceptance decision boundary != accepted evidence
+bounded accepted evidence authority != accepted-evidence set membership
+bounded accepted evidence authority != accepted evidence
+bounded accepted evidence authority != validator output acceptance
+bounded accepted evidence authority != receipt evidence acceptance
+accepted evidence authority != accepted-evidence set membership
+accepted evidence authority != accepted evidence
+accepted evidence authority != validator output acceptance
+accepted evidence authority != receipt evidence acceptance
+accepted evidence != validator output unless separately reviewed
+accepted evidence != receipt evidence unless separately reviewed
+validator output != accepted evidence
+receipt evidence != accepted evidence
+receipt evidence != validator output
+CI PASS != accepted-evidence set membership
+CI PASS != accepted evidence
+CI PASS != evidence item acceptance
+ci-freeze PASS != accepted-evidence set membership
+ci-freeze PASS != accepted evidence
+ci-freeze PASS != evidence item acceptance
+Dev Loop PASS != accepted-evidence set membership
+Dev Loop PASS != accepted evidence
+Dev Loop PASS != evidence item acceptance
+AykenOS Dev Loop CI PASS != accepted-evidence set membership
+AykenOS Dev Loop CI PASS != accepted evidence
+AykenOS Dev Loop CI PASS != evidence item acceptance
+post-merge exact-main verification != accepted-evidence set membership
+post-merge exact-main verification != accepted evidence
+post-merge exact-main verification != evidence item acceptance
+clean-fixed != accepted-evidence set membership
+clean-fixed != accepted evidence
+clean-fixed != evidence item acceptance
+publication-status sync != accepted-evidence set membership
+publication-status sync != accepted evidence
+publication-status sync != evidence item acceptance
+CURRENT_PHASE=23 != accepted-evidence set membership
+CURRENT_PHASE=23 != accepted evidence
+CURRENT_PHASE=23 != evidence item acceptance
+CURRENT_PHASE=23 != validator output acceptance
+CURRENT_PHASE=23 != receipt evidence acceptance
+CURRENT_PHASE=23 != runtime implementation procedure
+CURRENT_PHASE=23 != source modification
+CURRENT_PHASE=23 != execution authority
+CURRENT_PHASE=23 != package loading
+CURRENT_PHASE=23 != source merge authority
+CURRENT_PHASE=23 != kernel ABI expansion
+CURRENT_PHASE=23 != syscall expansion
+historical PASS != inherited evidence
+previous PR evidence != later PR evidence
+```
+
+The safe default remains no accepted-evidence set membership, no accepted
+evidence, no evidence item acceptance, no validator output acceptance, no
+receipt evidence acceptance, no runtime behavior, no implementation
+procedure, no source modification, no code execution, no runtime state,
+and no package, capability, registry, trust, distribution, deployment,
+source acceptance, source merge, kernel ABI, syscall, workflow-threshold,
+baseline, dependency, or Ring0 authority unless a later reviewed Phase-23
+decision grants a specific bounded authority with its own exact-SHA
+evidence.
+
+Unknown authority readings fail closed.
+
+## Accepted-Evidence Set Membership Decision
+
+The Phase-23 accepted-evidence set membership decision is accepted only
+as:
+
+```text
+bounded accepted-evidence set membership decision boundary
+```
+
+This decision may define a bounded accepted-evidence set membership
+decision boundary, but it does not assign accepted-evidence set
+membership.
+
+This bounded decision boundary permits a later separate reviewed
+membership-assignment candidate, evidence item acceptance candidate, or
+accepted-evidence decision to be evaluated after this decision is
+published and clean-fixed, if ever proposed.
+
+This decision does not define an accepted-evidence set membership set.
+
+This decision does not identify any member of an accepted-evidence set.
+
+This decision does not create accepted evidence.
+
+This decision does not accept any specific evidence item.
+
+This decision does not accept validator output.
+
+This decision does not accept receipt evidence.
+
+This decision does not authorize package loading.
+
+This decision does not authorize source acceptance or source merge.
+
+This decision does not authorize runtime implementation procedure, code
+execution, process start, runtime state creation, capability issuance,
+registry publication, trust assignment, deployment, distribution, kernel
+ABI expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Any later accepted-evidence set membership, evidence item acceptance,
+accepted evidence, validator output acceptance, or receipt evidence
+acceptance requires a separate reviewed decision path with its own exact
+subject, changed-file scope, non-authorization boundary, and post-merge
+exact-main verification.
+
+## Decision Scope
+
+This decision scope is limited to:
+
+1. Accepting the Phase-23 accepted-evidence set membership boundary only
+   as a bounded governance decision boundary.
+2. Binding this decision to PR #275 as the clean-fixed
+   accepted-evidence set membership decision-candidate input.
+3. Preserving the distinction between an accepted-evidence set
+   membership decision boundary and accepted-evidence set membership.
+4. Preserving the distinction between accepted-evidence set membership
+   and accepted evidence.
+5. Preserving the distinction between accepted-evidence set membership
+   and evidence item acceptance.
+6. Preserving separation from validator output acceptance and receipt
+   evidence acceptance.
+7. Establishing post-merge exact-main verification expectations for this
+   accepted-evidence set membership decision record.
+
+Decision scope is governance text only.
+
+Decision scope is bounded accepted-evidence set membership decision
+boundary only.
+
+Decision scope is not accepted-evidence set membership.
+
+Decision scope is not accepted evidence.
+
+Decision scope is not evidence item acceptance.
+
+Decision scope is not validator output acceptance.
+
+Decision scope is not receipt evidence acceptance.
+
+Decision scope is not runtime implementation procedure.
+
+Decision scope is not package loading authority.
+
+Decision scope is not execution authority.
+
+Decision scope is not source merge authority.
+
+## Current Phase Pointer Boundary
+
+The current phase pointer remains:
+
+```text
+CURRENT_PHASE=23
+```
+
+This decision does not modify:
+
+```text
+docs/roadmap/CURRENT_PHASE
+```
+
+This decision does not change the active phase pointer.
+
+`CURRENT_PHASE=23` does not authorize accepted-evidence set membership,
+accepted evidence, evidence item acceptance, validator output acceptance,
+receipt evidence acceptance, runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package loading, package execution, capability
+issuance, registry publication, trust assignment, deployment,
+distribution, source acceptance, source merge, kernel ABI expansion,
+syscall expansion, workflow-threshold changes, baseline changes,
+dependency changes, or Ring0 authority.
+
+## Accepted-Evidence Set Membership Decision Candidate Input
+
+This decision consumes the clean-fixed Phase-23 Accepted-Evidence Set
+Membership Decision Candidate as its exact governance prerequisite.
+
+The accepted-evidence set membership decision candidate remains bound to:
+
+```text
+ac05e74885f85f2d0bed540d66b9c80059086c5d
+```
+
+The accepted-evidence set membership decision candidate recorded that it
+was not accepted-evidence set membership, not accepted evidence, not
+evidence item acceptance, not validator output acceptance, not receipt
+evidence acceptance, not a decision, and not an authority grant.
+
+This decision accepts only the later bounded accepted-evidence set
+membership decision boundary after that candidate publication is
+clean-fixed.
+
+This decision does not reinterpret the accepted-evidence set membership
+decision candidate as accepted-evidence set membership, accepted
+evidence, evidence item acceptance, validator output acceptance, receipt
+evidence acceptance, runtime implementation procedure, execution
+authority, package loading authority, source acceptance, source merge
+authority, capability issuance, registry publication, trust assignment,
+deployment, distribution, kernel ABI expansion, syscall expansion,
+workflow-threshold change, baseline change, dependency change, or Ring0
+authority.
+
+Any accepted-evidence set membership decision-candidate conflict fails
+closed.
+
+## Relationship To Set Membership And Accepted Evidence
+
+Accepted-evidence set membership remains separate from accepted evidence
+unless a separate reviewed decision explicitly grants that narrower
+status.
+
+Accepted-evidence set membership remains separate from evidence item
+acceptance unless a separate reviewed decision explicitly accepts an
+exact evidence item.
+
+This decision may define a bounded accepted-evidence set membership
+decision boundary, but it does not assign accepted-evidence set
+membership.
+
+This decision does not define an accepted-evidence set membership set.
+
+This decision does not identify any member of an accepted-evidence set.
+
+This decision does not create accepted evidence.
+
+This decision does not identify accepted evidence.
+
+This decision does not accept any specific evidence item.
+
+This decision does not make accepted evidence inevitable.
+
+This decision does not make accepted-evidence set membership inevitable.
+
+Any attempt to treat this decision as accepted evidence,
+accepted-evidence set membership, or evidence item acceptance fails
+closed.
+
+## Relationship To Validator Output And Receipt Evidence
+
+This decision consumes the clean-fixed Phase-23 Validator-Output Boundary
+Planning and Receipt-Evidence Boundary Planning records as exact
+governance prerequisites only.
+
+The Phase-23 Validator-Output Boundary Planning publication-status sync
+remains bound to:
+
+```text
+d225b2b5ffcd83fe12c70bf0150b60f8f288f329
+```
+
+The Phase-23 Receipt-Evidence Boundary Planning publication-status sync
+remains bound to:
+
+```text
+9153d858c8ca99b09beb2fa60c6c7bcc565445a9
+```
+
+This decision does not convert validator output into accepted evidence.
+
+This decision does not convert receipt evidence into accepted evidence.
+
+This decision does not accept validator output.
+
+This decision does not accept receipt evidence.
+
+This decision does not grant accepted-evidence set membership over
+validator output, receipt evidence, package review output, source review
+output, historical PASS results, or clean-fixed claims.
+
+Any validator-output or receipt-evidence boundary conflict fails closed.
+
+## Relationship To Phase-23 Accepted-Evidence Set Decision
+
+This decision consumes the clean-fixed Phase-23 Accepted-Evidence Set
+Decision and its publication-status sync as exact governance
+prerequisites.
+
+The Phase-23 Accepted-Evidence Set Decision publication-status sync
+remains bound to:
+
+```text
+1e6c2e1af515a57ef2be910dbf6aa61d5fc081ff
+```
+
+The underlying Phase-23 Accepted-Evidence Set Decision publication
+remains bound to:
+
+```text
+a39cec2fcdc03c43a6a97de27cad0e16085b17c8
+```
+
+The accepted-evidence set decision accepted only the bounded
+accepted-evidence set decision boundary.
+
+This accepted-evidence set membership decision does not convert that
+bounded decision boundary into accepted-evidence set membership.
+
+This accepted-evidence set membership decision does not convert that
+bounded decision boundary into accepted evidence.
+
+This accepted-evidence set membership decision does not accept any
+evidence item.
+
+This accepted-evidence set membership decision does not broaden the
+accepted-evidence set decision record or its publication-status sync.
+
+Any accepted-evidence set decision or publication-status sync conflict
+fails closed.
+
+## Relationship To Phase-23 Accepted-Evidence Authority Decision
+
+This decision consumes the clean-fixed Phase-23 Accepted-Evidence
+Authority Decision as an exact governance prerequisite.
+
+The Phase-23 Accepted-Evidence Authority Decision remains bound to:
+
+```text
+d9ac910c24601002971e7d06cf94463d739b1358
+```
+
+The accepted-evidence authority decision accepted only bounded accepted
+evidence authority as a governance authority class.
+
+This accepted-evidence set membership decision does not convert that
+bounded authority class into accepted evidence.
+
+This accepted-evidence set membership decision does not convert that
+bounded authority class into accepted-evidence set membership.
+
+This accepted-evidence set membership decision does not broaden the
+accepted-evidence authority decision record.
+
+Any accepted-evidence authority decision conflict fails closed.
+
+## Relationship To Phase-23 Accepted-Evidence Boundary Planning
+
+This decision consumes the clean-fixed Phase-23 Accepted-Evidence
+Boundary Planning record and its clean-fixed publication-status sync as
+exact governance prerequisites.
+
+The Phase-23 Accepted-Evidence Boundary Planning publication-status sync
+remains bound to:
+
+```text
+40aba477d35902193fca9c75e4042ea1cf8539e5
+```
+
+The Phase-23 Accepted-Evidence Boundary Planning publication remains
+bound to:
+
+```text
+bc56d0baada3becdc3c820c4a5a167d7859abbbd
+```
+
+This decision does not convert accepted-evidence boundary planning into
+accepted evidence.
+
+This decision does not convert accepted-evidence boundary planning into
+an accepted-evidence set.
+
+This decision does not define accepted-evidence set membership.
+
+This decision does not broaden the accepted-evidence boundary planning
+record.
+
+Any accepted-evidence boundary planning conflict fails closed.
+
+## Relationship To Phase-23 Exact-SHA Evidence Expectation Boundary
+
+This decision consumes the clean-fixed Phase-23 Exact-SHA Evidence
+Expectation Boundary and its clean-fixed publication-status sync as exact
+governance prerequisites.
+
+The Phase-23 Exact-SHA Evidence Expectation Boundary publication-status
+sync remains bound to:
+
+```text
+1c6148a7dd1655d6281cdc20489026871c6e3975
+```
+
+The Phase-23 Exact-SHA Evidence Expectation Boundary publication remains
+bound to:
+
+```text
+22f3f134eb9fd9a0da4d11f9b523ff6ea8c781a2
+```
+
+This decision uses those expectations only as prerequisites for the
+bounded accepted-evidence set membership decision boundary.
+
+This decision does not convert exact-SHA expectations into accepted
+evidence.
+
+This decision does not convert exact-SHA expectations into an
+accepted-evidence set.
+
+This decision does not define accepted-evidence set membership.
+
+Any exact-SHA evidence expectation boundary conflict fails closed.
+
+## Relationship To Phase-23 Governance Overview And Initial Boundary
+
+This decision consumes the clean-fixed Phase-23 Governance Overview,
+Phase-23 Initial Governance Boundary, and their publication-status syncs
+as exact governance prerequisites.
+
+The Phase-23 Governance Overview publication-status sync remains bound
+to:
+
+```text
+1c34b754a07d4eed1493a4b5d456bf870681362f
+```
+
+The Phase-23 Initial Governance Boundary publication-status sync remains
+bound to:
+
+```text
+97aab9383e76fcbdc1dfcf0c3520f7de9e0e7692
+```
+
+This decision does not broaden the Phase-23 governance overview.
+
+This decision does not broaden the Phase-23 initial governance boundary.
+
+Any overview or initial-boundary conflict fails closed.
+
+## Relationship To Phase-22 Closure
+
+This decision consumes the Phase-22 Closure Decision and the Phase-22
+closure publication-status sync as exact governance prerequisites.
+
+The Phase-22 Closure Decision remains bound to:
+
+```text
+9b19c94a01170d105bd7a7e9fb198df05be17fdf
+```
+
+The latest Phase-22 closure publication-status sync remains bound to:
+
+```text
+6c0a0c878d54ebc6a768e1c708a68d7eb5898b15
+```
+
+Phase-22 remains closed only as:
+
+```text
+actual skeleton reviewed;
+static package acceptance boundary defined and clean-recovered;
+Phase-21 First Bounded Implementation actual skeleton exact 12-file set
+accepted as a static package subject only.
+```
+
+This decision does not reopen Phase-22.
+
+This decision does not reinterpret Phase-22 closure as Phase-23 accepted
+evidence, an accepted-evidence set, accepted-evidence membership,
+validator output acceptance, receipt evidence acceptance, runtime
+implementation procedure, package loading, package execution, source
+acceptance, source merge authority, capability issuance, registry
+publication, trust assignment, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Any Phase-22 closure conflict fails closed.
+
+## Relationship To Phase-19 Runtime Authority
+
+This decision remains subordinate to Phase-19 runtime authority records.
+
+This decision must not broaden, replace, supersede, weaken, or
+reinterpret Phase-19 runtime authority records.
+
+This decision must not use accepted-evidence set membership decision
+authority to infer runtime authority.
+
+This decision must not use evidence acceptance decision records to infer
+runtime authority.
+
+This decision must not use accepted-evidence authority to infer runtime
+authority.
+
+This decision must not use accepted-evidence boundary planning to infer
+runtime authority.
+
+This decision must not use validator-output planning to infer runtime
+authority.
+
+This decision must not use receipt-evidence planning to infer runtime
+authority.
+
+This decision must not use exact-SHA evidence expectations to infer
+runtime authority.
+
+This decision must not use `CURRENT_PHASE=23` to infer runtime authority.
+
+Any Phase-23 accepted-evidence set membership decision reading that
+conflicts with Phase-19 runtime authority records fails closed.
+
+## Not Authorized By This Decision
+
+This decision does not authorize:
+
+1. Accepted-evidence set creation.
+2. Accepted-evidence set membership.
+3. Accepted evidence.
+4. Evidence item acceptance.
+5. Validator output acceptance.
+6. Receipt evidence acceptance.
+7. Runtime implementation procedure.
+8. Source modification.
+9. Source acceptance.
+10. Source merge.
+11. Code implementation.
+12. Code execution.
+13. Process start.
+14. Runtime state creation.
+15. Package installation.
+16. Package loading.
+17. Package execution.
+18. Module loading.
+19. Workspace runtime or real mounts.
+20. Plugin loading or plugin instantiation.
+21. Capability token minting.
+22. Capability issuance.
+23. Registry publication.
+24. Trust assignment.
+25. Distribution execution.
+26. Deployment.
+27. Semantic CLI authority.
+28. AI Runtime authority.
+29. Agent authority.
+30. Syscall expansion.
+31. Kernel ABI expansion.
+32. Ring0 policy movement.
+33. Workflow-threshold changes.
+34. Baseline changes.
+35. Dependency changes.
+36. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this decision is published, the publication may change only this file:
+
+```text
+PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md
+```
+
+The publication must not change:
+
+1. `docs/roadmap/CURRENT_PHASE`.
+2. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`.
+3. `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`.
+4. `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`.
+5. `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`.
+6. `PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`.
+7. `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`.
+8. `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`.
+9. `PHASE23_ACCEPTED_EVIDENCE_DECISION.md`.
+10. `PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`.
+11. `PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`.
+12. `PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`.
+13. `PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`.
+14. `PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`.
+15. `PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`.
+16. `PHASE23_GOVERNANCE_OVERVIEW.md`.
+17. CI workflows.
+18. Baselines.
+19. Dependencies.
+20. Runtime source or kernel source.
+21. Syscalls or kernel ABI.
+22. Package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution paths.
+23. `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md`.
+
+Any changed-file expansion beyond this decision record requires separate
+review and fails this decision scope.
+
+## Post-Merge Exact-Main Evidence Rule
+
+If this decision is later published, the decision publication subject must
+receive its own post-merge exact-main verification:
+
+1. `ci-freeze` PASS for the exact decision publication SHA.
+2. AykenOS Dev Loop CI PASS for the exact decision publication SHA.
+3. smoke PASS.
+4. contract PASS.
+5. full PASS.
+6. isolation PASS.
+7. performance PASS.
+8. Exact changed-file list confirmation.
+9. No `docs/roadmap/CURRENT_PHASE` change.
+10. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`
+    change.
+11. No `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md` change.
+12. No `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md` change.
+13. No `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md` change.
+14. No `PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md` change.
+15. No `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md` change.
+16. No `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`
+    change.
+17. No `PHASE23_ACCEPTED_EVIDENCE_DECISION.md` change.
+18. No `PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md` change.
+19. No `PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md` change.
+20. No `PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md` change.
+21. No `PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md` change.
+22. No `PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md` change.
+23. No `PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md` change.
+24. No `PHASE23_GOVERNANCE_OVERVIEW.md` change.
+25. No CI workflow change.
+26. No baseline change.
+27. No dependency change.
+28. No runtime source or kernel source change.
+29. No syscall or kernel ABI change.
+30. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution change.
+
+Until that exact-main post-merge verification exists, this decision must
+not be recorded as clean-fixed.
+
+Historical PASS results may be cited as context only.
+
+Failed attempts may be cited as transparent non-clean context only.
+
+They cannot be inherited as accepted-evidence set membership, accepted
+evidence, evidence item acceptance, validator output acceptance, receipt
+evidence acceptance, runtime authority, package loading authority,
+package execution authority, source merge authority, capability
+authority, registry authority, trust authority, kernel ABI authority,
+syscall authority, workflow-threshold authority, baseline authority,
+dependency authority, or Ring0 authority.
+
+## Later Membership Assignment Dependency
+
+This decision is a prerequisite input for a possible later bounded
+accepted-evidence set membership assignment candidate or membership
+assignment decision.
+
+A later membership assignment record, if ever proposed, must define:
+
+1. Exact membership assignment subject.
+2. Exact Phase-23 accepted-evidence set membership decision prerequisite.
+3. Exact changed-file boundary.
+4. Exact accepted-evidence set membership being assigned, if any.
+5. Exact evidence item acceptance denial or separate evidence item
+   acceptance scope.
+6. Exact accepted-evidence denial or separate accepted-evidence scope.
+7. Exact validator-output acceptance denial or separate validator-output
+   acceptance scope.
+8. Exact receipt-evidence acceptance denial or separate receipt-evidence
+   acceptance scope.
+9. Exact runtime implementation procedure denial.
+10. Exact package loading and package execution denials.
+11. Exact source acceptance and source merge denials.
+12. Exact capability, registry, trust, deployment, distribution, kernel
+    ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+    denials.
+13. Exact post-merge verification requirements.
+
+Until such a later reviewed membership assignment record is published, no
+accepted-evidence set membership exists from this decision.
+
+Until such a later reviewed accepted-evidence record is published, no
+accepted evidence exists from this decision.
+
+Until such a later reviewed evidence item acceptance record is published,
+no evidence item acceptance exists from this decision.
+
+Until such a later reviewed validator-output acceptance record is
+published, no validator output acceptance exists from this decision.
+
+Until such a later reviewed receipt-evidence acceptance record is
+published, no receipt evidence acceptance exists from this decision.
+
+## Excluded Local Draft
+
+This decision does not consume:
+
+```text
+PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md
+```
+
+If that file exists locally as an untracked file, it remains:
+
+```text
+untracked
+PR-disjoint
+not decision input
+not evidence input
+not accepted-evidence set
+not accepted-evidence set membership
+not accepted evidence
+not validator output
+not receipt evidence
+not source authority
+not package acceptance
+not runtime authority
+```
+
+It must not be staged, committed, or included in any Phase-23
+accepted-evidence set membership decision PR unless a separate reviewed
+scope explicitly authorizes that file.
+
+## Governance Boundary Invariants
+
+Every later RFC must preserve these Phase-23 accepted-evidence set
+membership decision invariants:
+
+1. This decision is bounded accepted-evidence set membership decision
+   boundary only.
+2. This decision is not accepted-evidence set membership.
+3. This decision is not accepted evidence.
+4. This decision is not evidence item acceptance.
+5. This decision is not validator output acceptance.
+6. This decision is not receipt evidence acceptance.
+7. Accepted-evidence set membership is not accepted evidence unless
+   separately reviewed.
+8. Accepted-evidence set membership is not evidence item acceptance
+   unless separately reviewed.
+9. Accepted-evidence set decision is not accepted-evidence set
+   membership unless separately reviewed.
+10. Evidence acceptance decision is not accepted-evidence set membership.
+11. Bounded accepted evidence authority is not accepted-evidence set
+    membership.
+12. This decision is not runtime implementation procedure.
+13. This decision is not source modification.
+14. This decision is not code implementation.
+15. This decision is not code execution.
+16. This decision is not process start.
+17. This decision is not runtime state creation.
+18. This decision is not package installation.
+19. This decision is not package loading.
+20. This decision is not package execution.
+21. This decision is not capability issuance.
+22. This decision is not registry publication.
+23. This decision is not trust assignment.
+24. This decision is not deployment.
+25. This decision is not distribution authority.
+26. This decision is not source acceptance.
+27. This decision is not source merge authority.
+28. This decision does not modify `docs/roadmap/CURRENT_PHASE`.
+29. This decision does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`.
+30. This decision does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`.
+31. This decision does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`.
+32. This decision does not modify `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`.
+33. This decision does not modify
+    `PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`.
+34. This decision does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`.
+35. This decision does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`.
+36. This decision does not modify `PHASE23_ACCEPTED_EVIDENCE_DECISION.md`.
+37. This decision does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`.
+38. This decision does not modify
+    `PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`.
+39. This decision does not modify
+    `PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`.
+40. This decision does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`.
+41. This decision does not modify
+    `PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`.
+42. This decision does not modify `PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`.
+43. This decision does not modify `PHASE23_GOVERNANCE_OVERVIEW.md`.
+44. `CURRENT_PHASE=23` is not accepted-evidence set membership.
+45. `CURRENT_PHASE=23` is not accepted evidence.
+46. `CURRENT_PHASE=23` is not evidence item acceptance.
+47. `CURRENT_PHASE=23` is not validator output acceptance.
+48. `CURRENT_PHASE=23` is not receipt evidence acceptance.
+49. `CURRENT_PHASE=23` is not runtime implementation procedure.
+50. `CURRENT_PHASE=23` is not source modification.
+51. `CURRENT_PHASE=23` is not execution authority.
+52. `CURRENT_PHASE=23` is not package loading.
+53. `CURRENT_PHASE=23` is not source merge authority.
+54. This decision does not broaden Phase-19 runtime authority.
+55. This decision does not reopen Phase-20.
+56. This decision does not reopen Phase-21.
+57. This decision does not reopen Phase-22.
+58. This decision does not expand kernel ABI or syscalls.
+59. This decision does not change workflow thresholds, baselines, or
+    dependencies.
+60. This decision is not an accepted-evidence set.
+61. `CURRENT_PHASE=23` is not an accepted-evidence set.
+62. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-23 accepted-evidence set membership decision
+**Architecture status:** Local draft accepted-evidence set membership
+decision / pending separate reviewed publication
+**Authority notice:** This signature identifies the architectural
+authorship of this decision. It grants only the bounded
+accepted-evidence set membership decision boundary defined in this
+record. It grants no accepted-evidence set authority, accepted-evidence
+set membership authority, accepted evidence status, evidence item
+acceptance authority, validator output acceptance authority, receipt
+evidence acceptance authority, runtime implementation procedure
+authority, source modification authority, code implementation authority,
+code execution authority, process start authority, general runtime
+authority, unbounded execution authority, runtime state authority,
+package installation authority, package loading authority, package
+execution authority, source merge authority, trust authority, registry
+authority, distribution authority, publication authority, capability
+issuance authority, deployment authority, module authority, plugin
+authority, Semantic CLI authority, AI Runtime authority, agent authority,
+kernel ABI authority, syscall authority, workflow-threshold authority,
+baseline authority, dependency authority, or Ring0 authority.
+
+## Conclusion
+
+This Phase-23 accepted-evidence set membership decision is based on the
+clean-fixed Phase-23 Accepted-Evidence Set Membership Decision Candidate
+publication subject:
+
+```text
+ac05e74885f85f2d0bed540d66b9c80059086c5d
+```
+
+It accepts only the bounded accepted-evidence set membership decision
+boundary.
+
+This decision may define a bounded accepted-evidence set membership
+decision boundary, but it does not assign accepted-evidence set
+membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize accepted-evidence set membership, accepted evidence,
+evidence item acceptance, validator output acceptance, receipt evidence
+acceptance, runtime implementation procedure, source modification, code
+implementation, code execution, process start, runtime state creation,
+package installation, package loading, package execution, capability
+issuance, registry publication, trust assignment, deployment,
+distribution, source acceptance, source merge, kernel ABI expansion,
+syscall expansion, workflow-threshold changes, baseline changes,
+dependency changes, or Ring0 authority.
+
+Any later Phase-23 accepted-evidence set membership assignment, evidence
+item acceptance, accepted-evidence, validator-output, receipt-evidence,
+package-review, source-review, runtime-implementation-procedure, or
+non-authorization boundary record requires its own exact-SHA evidence,
+changed-file scope, non-authorization boundary, and reviewed decision
+path.


### PR DESCRIPTION
This PR changes only PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md and accepts only a bounded accepted-evidence set membership decision boundary. It does not assign accepted-evidence set membership, create accepted evidence, accept any evidence item, accept validator output, accept receipt evidence, or authorize runtime/source/package/source-merge/capability/registry/trust/deployment/distribution/kernel ABI/syscall/workflow-threshold/baseline/dependency/Ring0 authority. Validation: git diff --cached --check passed before commit.