### PR TITLE
Phase-23 accepted-evidence set membership assignment record candidate

### DIFF
--- a/PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md
+++ b/PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md
@@ -1,0 +1,1378 @@
+# Phase-23 Accepted-Evidence Set Membership Assignment Record Candidate
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY_CLEAN_RECOVERY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_FIRST_BOUNDED_IMPLEMENTATION.md`,
+`PHASE22_CLOSURE_DECISION.md`,
+`PHASE23_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE23_POINTER_TRANSITION_DECISION.md`,
+`docs/roadmap/CURRENT_PHASE`,
+`PHASE23_GOVERNANCE_OVERVIEW.md`,
+`PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`,
+`PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`,
+`PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+and
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`. In
+case of conflict, those documents prevail unless this document is the
+narrower Phase-23 accepted-evidence set membership assignment record
+candidate for the exact governance-only bounded assignment-record
+candidate scope identified below.
+
+**Status:** PHASE-23 ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT RECORD
+CANDIDATE / LOCAL DRAFT / GOVERNANCE-ONLY ACCEPTED-EVIDENCE SET
+MEMBERSHIP ASSIGNMENT RECORD CANDIDATE ONLY / NO ACCEPTED-EVIDENCE SET
+MEMBERSHIP ASSIGNMENT RECORD / NO ACCEPTED-EVIDENCE SET MEMBERSHIP
+ASSIGNMENT / NO ACCEPTED-EVIDENCE SET MEMBERSHIP / NO ACCEPTED-EVIDENCE
+SET / NO ACCEPTED EVIDENCE / NO EVIDENCE ITEM ACCEPTANCE / NO VALIDATOR
+OUTPUT ACCEPTANCE / NO RECEIPT EVIDENCE ACCEPTANCE / NO RUNTIME
+IMPLEMENTATION PROCEDURE / NO SOURCE MODIFICATION / NO CODE
+IMPLEMENTATION / NO CODE EXECUTION / NO PROCESS START / NO RUNTIME STATE
+CREATION / NO PACKAGE INSTALLATION / NO PACKAGE LOADING / NO PACKAGE
+EXECUTION / NO DEPLOYMENT / NO CAPABILITY ISSUANCE / NO TRUST ASSIGNMENT
+/ NO REGISTRY PUBLICATION / NO DISTRIBUTION AUTHORITY / NO SOURCE
+ACCEPTANCE / NO SOURCE MERGE AUTHORITY / NO KERNEL ABI EXPANSION / NO
+SYSCALL EXPANSION / NO WORKFLOW-THRESHOLD CHANGE / NO BASELINE CHANGE /
+NO DEPENDENCY CHANGE / NO RING0 AUTHORITY
+**Candidate date:** 2026-07-09
+**Candidate id:**
+`ayken.phase23.accepted_evidence_set_membership_assignment_record_candidate.v1`
+**Candidate drafting base main SHA:**
+`f60e093a53865fb2e03ce3ded375ed7bace763e5`
+**Candidate publication subject:** pending separate reviewed publication
+**Reviewed Phase-23 accepted-evidence set membership assignment decision
+publication subject:** `f60e093a53865fb2e03ce3ded375ed7bace763e5`
+**Reviewed Phase-23 accepted-evidence set membership assignment decision
+PR:** PR #278
+**Reviewed Phase-23 accepted-evidence set membership assignment decision
+exact-main ci-freeze run:** `29031867556`
+**Reviewed Phase-23 accepted-evidence set membership assignment decision
+exact-main ci-freeze attempt:** attempt 1
+**Reviewed Phase-23 accepted-evidence set membership assignment decision
+exact-main ci-freeze job:** `freeze / 86166477199`
+**Reviewed Phase-23 accepted-evidence set membership assignment decision
+exact-main ci-freeze result:** PASS
+**Reviewed Phase-23 accepted-evidence set membership assignment decision
+exact-main Dev Loop Validation run:** `29031867620`
+**Reviewed Phase-23 accepted-evidence set membership assignment decision
+exact-main Dev Loop Validation attempt:** attempt 1
+**Reviewed Phase-23 accepted-evidence set membership assignment decision
+exact-main Dev Loop Validation job:** `devloop / 86166477981`
+**Reviewed Phase-23 accepted-evidence set membership assignment decision
+exact-main Dev Loop Validation result:** PASS
+**Reviewed Phase-23 accepted-evidence set membership assignment decision
+exact-main Dev Loop CI run:** `29031867573`
+**Reviewed Phase-23 accepted-evidence set membership assignment decision
+exact-main Dev Loop CI attempt:** attempt 1
+**Reviewed Phase-23 accepted-evidence set membership assignment decision
+exact-main Dev Loop CI result:** PASS
+**Reviewed Phase-23 accepted-evidence set membership assignment decision
+exact-main smoke job:** `smoke / 86166477188`
+**Reviewed Phase-23 accepted-evidence set membership assignment decision
+exact-main smoke result:** PASS
+**Reviewed Phase-23 accepted-evidence set membership assignment decision
+exact-main contract job:** `contract / 86166811288`
+**Reviewed Phase-23 accepted-evidence set membership assignment decision
+exact-main contract result:** PASS
+**Reviewed Phase-23 accepted-evidence set membership assignment decision
+exact-main full job:** `full / 86167457349`
+**Reviewed Phase-23 accepted-evidence set membership assignment decision
+exact-main full result:** PASS
+**Reviewed Phase-23 accepted-evidence set membership assignment decision
+exact-main isolation job:** `isolation / 86168039104`
+**Reviewed Phase-23 accepted-evidence set membership assignment decision
+exact-main isolation result:** PASS
+**Reviewed Phase-23 accepted-evidence set membership assignment decision
+exact-main performance job:** `performance / 86168562634`
+**Reviewed Phase-23 accepted-evidence set membership assignment decision
+exact-main performance result:** PASS
+**Phase-23 accepted-evidence set membership assignment decision candidate
+publication subject:** `3c8cdfa992ae1c94098b75b7b6064bf8bd40c184`
+**Phase-23 accepted-evidence set membership decision publication
+subject:** `6f8326a895ebdd3e07b4dc73d8be849bfe0df7fc`
+**Phase-23 accepted-evidence set membership decision candidate publication
+subject:** `ac05e74885f85f2d0bed540d66b9c80059086c5d`
+**Phase-23 accepted-evidence set decision publication-status sync
+subject:** `1e6c2e1af515a57ef2be910dbf6aa61d5fc081ff`
+**Phase-23 accepted-evidence set decision publication subject:**
+`a39cec2fcdc03c43a6a97de27cad0e16085b17c8`
+**Phase-23 accepted-evidence set decision candidate publication subject:**
+`206d1a9aff8ba3dd2aaa4a0e258315d5c92379cd`
+**Phase-23 evidence acceptance decision publication subject:**
+`1fe089b141af09e9f98be2a153589e68ab015c18`
+**Phase-23 evidence acceptance decision candidate publication subject:**
+`7d90f2c195afecfb4875876f1ea832df3d9b6528`
+**Phase-23 accepted-evidence authority decision publication subject:**
+`d9ac910c24601002971e7d06cf94463d739b1358`
+**Phase-23 accepted-evidence authority decision candidate publication
+subject:** `72d5234654a5af4fa84b52f3ba3753b9104a4dce`
+**Phase-23 accepted-evidence decision publication subject:**
+`0f6da8e9abe8d354e98c5243b3300cf9a75f697a`
+**Phase-23 accepted-evidence decision candidate publication subject:**
+`a895f3ae5eeebe5848e52a1d75874b0b75518137`
+**Phase-23 validator-output boundary planning publication-status sync
+subject:** `d225b2b5ffcd83fe12c70bf0150b60f8f288f329`
+**Phase-23 validator-output boundary planning publication subject:**
+`08585f64b6088ed9f76a8027daecec6dc70da885`
+**Phase-23 receipt-evidence boundary planning publication-status sync
+subject:** `9153d858c8ca99b09beb2fa60c6c7bcc565445a9`
+**Phase-23 receipt-evidence boundary planning publication subject:**
+`e6d21b2bfabfd9658a748d69fddcede3d88af401`
+**Phase-23 accepted-evidence boundary planning publication-status sync
+subject:** `40aba477d35902193fca9c75e4042ea1cf8539e5`
+**Phase-23 accepted-evidence boundary planning publication subject:**
+`bc56d0baada3becdc3c820c4a5a167d7859abbbd`
+**Phase-23 exact-SHA evidence expectation boundary publication-status
+sync subject:** `1c6148a7dd1655d6281cdc20489026871c6e3975`
+**Phase-23 exact-SHA evidence expectation boundary publication subject:**
+`22f3f134eb9fd9a0da4d11f9b523ff6ea8c781a2`
+**Phase-23 initial governance boundary publication-status sync subject:**
+`97aab9383e76fcbdc1dfcf0c3520f7de9e0e7692`
+**Phase-23 initial governance boundary publication subject:**
+`3db9a2e740a414b040daa30ee70a54850fdbeb1f`
+**Phase-23 governance overview publication-status sync subject:**
+`1c34b754a07d4eed1493a4b5d456bf870681362f`
+**Phase-23 governance overview publication subject:**
+`bfd4b07d5332f16b5d0295f3170f795629ca7ca8`
+**Phase-23 current phase pointer update subject:**
+`9b70ee20707023709e906d0200a80a1ac69fa698`
+**Phase-23 pointer transition decision subject:**
+`16ac421a40ce93641ccccc28fb5ad869f2b8984e`
+**Phase-23 pointer transition candidate subject:**
+`77fd954607ad076cdea888047f19e4fed60bfb65`
+**Phase-22 closure publication-status sync subject:**
+`6c0a0c878d54ebc6a768e1c708a68d7eb5898b15`
+**Phase-22 closure decision publication subject:**
+`9b19c94a01170d105bd7a7e9fb198df05be17fdf`
+**Current phase pointer:** `CURRENT_PHASE=23`
+**Candidate theme:** Governance-only decision-candidate boundary for
+whether a later accepted-evidence set membership assignment record path
+may be evaluated after a bounded membership assignment decision boundary
+exists
+**Authority boundary:** Accepted-evidence set membership assignment
+record candidate only; not an accepted-evidence set membership assignment
+record, not accepted-evidence set membership assignment, not
+accepted-evidence set membership, not an accepted-evidence set, not
+accepted evidence, not evidence item acceptance, not validator output
+acceptance, not receipt evidence acceptance, not runtime implementation
+procedure, not source modification, not code implementation, not code
+execution, not process start, not runtime state creation, not general
+runtime authority, not unbounded execution authority, not package
+authority, not package installation, not package loading, not package
+execution, not source acceptance, not source merge authority, not source
+repository authority, not module loading, not workspace runtime, not
+plugin loading, not capability token minting, not capability issuance,
+not trust assignment, not trust issuer authority, not registry authority,
+not registry publication, not publication authority, not deployment
+authority, not distribution authority, not distribution execution, not
+Semantic CLI authority, not AI Runtime authority, not agent authority, not
+syscall expansion, not kernel ABI expansion, not workflow-threshold,
+baseline, dependency, or Ring0 authority.
+
+## Purpose
+
+This document records a Phase-23 governance-only accepted-evidence set
+membership assignment record candidate after the clean-fixed Phase-23
+Accepted-Evidence Set Membership Assignment Decision publication.
+
+It answers one question:
+
+```text
+May a bounded accepted-evidence set membership assignment record decision
+path be evaluated during Phase-23 without publishing an assignment
+record, assigning membership, accepting any evidence item, or creating
+accepted evidence?
+```
+
+It maps only the fail-closed decision-candidate prerequisites for that
+future accepted-evidence set membership assignment record path.
+
+It does not publish an accepted-evidence set membership assignment
+record.
+
+It does not assign accepted-evidence set membership.
+
+It does not define accepted-evidence set membership.
+
+It does not create an accepted-evidence set.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not convert CI PASS results, receipts, validator output, package
+review output, source review output, historical results, or clean-fixed
+claims into accepted evidence.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, source acceptance, source merge, registry publication, trust
+assignment, capability issuance, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+It does not answer:
+
+```text
+Which assignment record is published?
+Which membership assignment is made?
+Which evidence item is assigned to accepted-evidence set membership?
+Which evidence is accepted?
+Which evidence belongs to an accepted-evidence set?
+How is accepted evidence created?
+How is validator output accepted?
+How is receipt evidence accepted?
+How is runtime implementation procedure defined?
+How is source modified?
+How is code implemented or executed?
+How is a process started?
+How is runtime state created?
+How is a package installed, loaded, executed, deployed, or distributed?
+How is source accepted or merged?
+How is a capability issued?
+How is trust assigned?
+How is a registry entry published?
+How is kernel ABI or syscall surface expanded?
+How are workflow thresholds, baselines, or dependencies changed?
+```
+
+Those questions require later reviewed decision paths, if ever
+authorized.
+
+## Exact Subject
+
+This decision candidate is based on exact main SHA:
+
+```text
+f60e093a53865fb2e03ce3ded375ed7bace763e5
+```
+
+That subject is the squash merge of PR #278:
+
+```text
+Phase-23 accepted-evidence set membership assignment decision
+```
+
+PR #278 changed only:
+
+```text
+PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md
+```
+
+PR #278 produced post-merge exact-main verification:
+
+| Evidence | Run / job | Result |
+|---|---|---|
+| `ci-freeze` | run `29031867556`, attempt 1, job `freeze / 86166477199` | PASS |
+| Dev Loop Validation | run `29031867620`, attempt 1, job `devloop / 86166477981` | PASS |
+| AykenOS Dev Loop CI | run `29031867573`, attempt 1 | PASS |
+| smoke | job `86166477188` | PASS |
+| contract | job `86166811288` | PASS |
+| full | job `86167457349` | PASS |
+| isolation | job `86168039104` | PASS |
+| performance | job `86168562634` | PASS |
+
+The Phase-23 Accepted-Evidence Set Membership Assignment Decision remains
+bound to:
+
+```text
+f60e093a53865fb2e03ce3ded375ed7bace763e5
+```
+
+That decision accepted only a bounded accepted-evidence set membership
+assignment decision boundary.
+
+That decision did not publish an accepted-evidence set membership
+assignment record.
+
+That decision did not assign accepted-evidence set membership.
+
+That decision did not create accepted evidence.
+
+That decision did not accept any evidence item.
+
+That decision did not accept validator output.
+
+That decision did not accept receipt evidence.
+
+This decision candidate consumes that exact subject as governance input
+only. It does not replace, broaden, reinterpret, or supersede the
+accepted-evidence set membership assignment decision or any earlier
+Phase-23 governance boundary.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped subject readings fail closed.
+
+## Core Rule
+
+```text
+accepted-evidence set membership assignment record candidate != accepted-evidence set membership assignment record
+accepted-evidence set membership assignment record candidate != accepted-evidence set membership assignment
+accepted-evidence set membership assignment record candidate != accepted-evidence set membership
+accepted-evidence set membership assignment record candidate != accepted-evidence set
+accepted-evidence set membership assignment record candidate != accepted evidence
+accepted-evidence set membership assignment record candidate != evidence item acceptance
+accepted-evidence set membership assignment record candidate != validator output acceptance
+accepted-evidence set membership assignment record candidate != receipt evidence acceptance
+accepted-evidence set membership assignment record candidate != runtime implementation procedure
+accepted-evidence set membership assignment record candidate != source modification
+accepted-evidence set membership assignment record candidate != package loading
+accepted-evidence set membership assignment record candidate != package execution
+accepted-evidence set membership assignment record candidate != source acceptance
+accepted-evidence set membership assignment record candidate != source merge
+assignment record candidate != assignment record
+assignment record candidate != decision
+assignment record candidate != authority grant
+decision candidate != decision
+decision candidate != authority grant
+accepted-evidence set membership assignment decision != accepted-evidence set membership assignment record
+accepted-evidence set membership assignment decision != accepted-evidence set membership assignment
+accepted-evidence set membership assignment decision != accepted-evidence set membership
+accepted-evidence set membership assignment decision != accepted-evidence set
+accepted-evidence set membership assignment decision != accepted evidence
+accepted-evidence set membership assignment decision != evidence item acceptance
+accepted-evidence set membership assignment record != accepted-evidence set membership assignment unless separately reviewed
+accepted-evidence set membership assignment != accepted-evidence set membership unless separately reviewed
+accepted-evidence set membership assignment != accepted evidence unless separately reviewed
+accepted-evidence set membership assignment != evidence item acceptance unless separately reviewed
+accepted-evidence set membership != accepted evidence unless separately reviewed
+accepted-evidence set membership != evidence item acceptance unless separately reviewed
+accepted-evidence set != accepted evidence unless separately reviewed
+accepted evidence != validator output unless separately reviewed
+accepted evidence != receipt evidence unless separately reviewed
+validator output != accepted evidence
+receipt evidence != accepted evidence
+receipt evidence != validator output
+CI PASS != accepted-evidence set membership assignment record
+CI PASS != accepted-evidence set membership assignment
+CI PASS != accepted-evidence set membership
+CI PASS != accepted evidence
+ci-freeze PASS != accepted-evidence set membership assignment record
+ci-freeze PASS != accepted-evidence set membership assignment
+ci-freeze PASS != accepted-evidence set membership
+ci-freeze PASS != accepted evidence
+Dev Loop PASS != accepted-evidence set membership assignment record
+Dev Loop PASS != accepted-evidence set membership assignment
+Dev Loop PASS != accepted-evidence set membership
+Dev Loop PASS != accepted evidence
+AykenOS Dev Loop CI PASS != accepted-evidence set membership assignment record
+AykenOS Dev Loop CI PASS != accepted-evidence set membership assignment
+AykenOS Dev Loop CI PASS != accepted-evidence set membership
+AykenOS Dev Loop CI PASS != accepted evidence
+post-merge exact-main verification != accepted-evidence set membership assignment record
+post-merge exact-main verification != accepted-evidence set membership assignment
+post-merge exact-main verification != accepted-evidence set membership
+post-merge exact-main verification != accepted evidence
+clean-fixed != accepted-evidence set membership assignment record
+clean-fixed != accepted-evidence set membership assignment
+clean-fixed != accepted-evidence set membership
+clean-fixed != accepted evidence
+publication-status sync != accepted-evidence set membership assignment record
+publication-status sync != accepted-evidence set membership assignment
+publication-status sync != accepted-evidence set membership
+publication-status sync != accepted evidence
+CURRENT_PHASE=23 != accepted-evidence set membership assignment record
+CURRENT_PHASE=23 != accepted-evidence set membership assignment
+CURRENT_PHASE=23 != accepted-evidence set membership
+CURRENT_PHASE=23 != accepted-evidence set
+CURRENT_PHASE=23 != accepted evidence
+CURRENT_PHASE=23 != evidence item acceptance
+CURRENT_PHASE=23 != validator output acceptance
+CURRENT_PHASE=23 != receipt evidence acceptance
+CURRENT_PHASE=23 != runtime implementation procedure
+CURRENT_PHASE=23 != source modification
+CURRENT_PHASE=23 != execution authority
+CURRENT_PHASE=23 != package loading
+CURRENT_PHASE=23 != source merge authority
+CURRENT_PHASE=23 != kernel ABI expansion
+CURRENT_PHASE=23 != syscall expansion
+historical PASS != inherited evidence
+previous PR evidence != later PR evidence
+```
+
+The safe default remains no accepted-evidence set membership assignment
+record, no accepted-evidence set membership assignment, no
+accepted-evidence set membership, no accepted-evidence set, no accepted
+evidence, no evidence item acceptance, no validator output acceptance,
+no receipt evidence acceptance, no runtime behavior, no implementation
+procedure, no source modification, no code execution, no runtime state,
+and no package, capability, registry, trust, distribution, deployment,
+source acceptance, source merge, kernel ABI, syscall,
+workflow-threshold, baseline, dependency, or Ring0 authority unless a
+later reviewed Phase-23 decision grants a specific bounded authority with
+its own exact-SHA evidence.
+
+Unknown authority readings fail closed.
+
+## Accepted-Evidence Set Membership Assignment Record-Candidate Boundary
+
+This decision candidate may be used only to evaluate whether a later
+accepted-evidence set membership assignment record path can be reviewed.
+
+The only later-evaluable boundary is:
+
+```text
+bounded accepted-evidence set membership assignment record path as a
+future reviewed record
+```
+
+This candidate does not publish an accepted-evidence set membership
+assignment record.
+
+This candidate does not assign accepted-evidence set membership.
+
+This candidate does not define accepted-evidence set membership.
+
+This candidate does not create an accepted-evidence set.
+
+This candidate does not create accepted evidence.
+
+This candidate does not accept any evidence item.
+
+This candidate does not accept validator output.
+
+This candidate does not accept receipt evidence.
+
+This candidate does not make a later membership assignment record
+inevitable.
+
+Any later membership assignment record requires a separate reviewed
+decision path with its own exact subject, changed-file scope,
+non-authorization boundary, and post-merge exact-main verification.
+
+## Candidate Scope
+
+This candidate scope is limited to:
+
+1. Mapping accepted-evidence set membership assignment record as a later
+   decision-candidate topic.
+2. Binding this candidate to PR #278 as the clean-fixed accepted-evidence
+   set membership assignment decision input.
+3. Preserving the distinction between an assignment-record candidate and
+   an assignment record.
+4. Preserving the distinction between assignment record and membership
+   assignment.
+5. Preserving the distinction between membership assignment and accepted
+   evidence.
+6. Preserving separation from evidence item acceptance, validator output
+   acceptance, and receipt evidence acceptance.
+7. Establishing post-merge exact-main verification expectations for this
+   decision-candidate record.
+
+Candidate scope is governance text only.
+
+Candidate scope is accepted-evidence set membership assignment record
+candidate only.
+
+Candidate scope is not an accepted-evidence set membership assignment
+record.
+
+Candidate scope is not accepted-evidence set membership assignment.
+
+Candidate scope is not accepted-evidence set membership.
+
+Candidate scope is not accepted evidence.
+
+Candidate scope is not evidence item acceptance.
+
+Candidate scope is not validator output acceptance.
+
+Candidate scope is not receipt evidence acceptance.
+
+Candidate scope is not runtime implementation procedure.
+
+Candidate scope is not package loading authority.
+
+Candidate scope is not execution authority.
+
+Candidate scope is not source merge authority.
+
+## Current Phase Pointer Boundary
+
+The current phase pointer remains:
+
+```text
+CURRENT_PHASE=23
+```
+
+This decision candidate does not modify:
+
+```text
+docs/roadmap/CURRENT_PHASE
+```
+
+This decision candidate does not change the active phase pointer.
+
+`CURRENT_PHASE=23` does not authorize an accepted-evidence set
+membership assignment record, accepted-evidence set membership
+assignment, accepted-evidence set membership, accepted evidence,
+evidence item acceptance, validator output acceptance, receipt evidence
+acceptance, runtime implementation procedure, source modification, code
+implementation, code execution, process start, runtime state creation,
+package loading, package execution, capability issuance, registry
+publication, trust assignment, deployment, distribution, source
+acceptance, source merge, kernel ABI expansion, syscall expansion,
+workflow-threshold changes, baseline changes, dependency changes, or
+Ring0 authority.
+
+## Accepted-Evidence Set Membership Assignment Decision Input
+
+This decision candidate consumes the clean-fixed Phase-23
+Accepted-Evidence Set Membership Assignment Decision as its exact
+governance prerequisite.
+
+The accepted-evidence set membership assignment decision remains bound
+to:
+
+```text
+f60e093a53865fb2e03ce3ded375ed7bace763e5
+```
+
+The accepted-evidence set membership assignment decision accepted only a
+bounded accepted-evidence set membership assignment decision boundary.
+
+This decision candidate does not reinterpret that bounded decision
+boundary as an accepted-evidence set membership assignment record,
+accepted-evidence set membership assignment, accepted-evidence set
+membership, accepted evidence, evidence item acceptance, validator output
+acceptance, receipt evidence acceptance, runtime implementation
+procedure, execution authority, package loading authority, source
+acceptance, source merge authority, capability issuance, registry
+publication, trust assignment, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold change, baseline change,
+dependency change, or Ring0 authority.
+
+Any accepted-evidence set membership assignment decision conflict fails
+closed.
+
+## Relationship To Assignment Record And Membership Assignment
+
+An accepted-evidence set membership assignment record remains separate
+from accepted-evidence set membership assignment unless a separate
+reviewed decision explicitly grants that narrower authority.
+
+Accepted-evidence set membership assignment remains separate from
+accepted-evidence set membership unless a separate reviewed decision
+explicitly grants that narrower authority.
+
+Accepted-evidence set membership remains separate from accepted evidence
+unless a separate reviewed decision explicitly grants that narrower
+authority.
+
+This decision candidate does not publish an accepted-evidence set
+membership assignment record.
+
+This decision candidate does not assign accepted-evidence set membership.
+
+This decision candidate does not define accepted-evidence set membership.
+
+This decision candidate does not identify accepted evidence.
+
+This decision candidate does not define an accepted-evidence set.
+
+This decision candidate does not define accepted-evidence set membership
+contents.
+
+This decision candidate does not accept any evidence item.
+
+This decision candidate does not make an assignment record inevitable.
+
+This decision candidate does not make membership assignment inevitable.
+
+This decision candidate does not make accepted evidence inevitable.
+
+Any attempt to treat this candidate as an assignment record, membership
+assignment, accepted-evidence set membership, accepted evidence, or
+evidence item acceptance fails closed.
+
+## Relationship To Validator Output And Receipt Evidence
+
+This decision candidate consumes the clean-fixed Phase-23
+Validator-Output Boundary Planning and Receipt-Evidence Boundary Planning
+records as exact governance prerequisites only.
+
+The Phase-23 Validator-Output Boundary Planning publication-status sync
+remains bound to:
+
+```text
+d225b2b5ffcd83fe12c70bf0150b60f8f288f329
+```
+
+The Phase-23 Receipt-Evidence Boundary Planning publication-status sync
+remains bound to:
+
+```text
+9153d858c8ca99b09beb2fa60c6c7bcc565445a9
+```
+
+This decision candidate does not convert validator output into accepted
+evidence.
+
+This decision candidate does not convert receipt evidence into accepted
+evidence.
+
+This decision candidate does not accept validator output.
+
+This decision candidate does not accept receipt evidence.
+
+This decision candidate does not grant membership assignment over
+validator output, receipt evidence, package review output, source review
+output, historical PASS results, or clean-fixed claims.
+
+Any validator-output or receipt-evidence boundary conflict fails closed.
+
+## Relationship To Phase-23 Accepted-Evidence Set Membership Assignment Decision
+
+This decision candidate consumes the clean-fixed Phase-23
+Accepted-Evidence Set Membership Assignment Decision as an exact
+governance prerequisite.
+
+The Phase-23 Accepted-Evidence Set Membership Assignment Decision remains
+bound to:
+
+```text
+f60e093a53865fb2e03ce3ded375ed7bace763e5
+```
+
+The accepted-evidence set membership assignment decision accepted only a
+bounded accepted-evidence set membership assignment decision boundary.
+
+This assignment-record candidate does not convert that decision boundary
+into an accepted-evidence set membership assignment record.
+
+This assignment-record candidate does not convert that decision boundary
+into accepted-evidence set membership assignment.
+
+This assignment-record candidate does not convert that decision boundary
+into accepted evidence.
+
+This assignment-record candidate does not broaden the accepted-evidence
+set membership assignment decision record.
+
+Any accepted-evidence set membership assignment decision conflict fails
+closed.
+
+## Relationship To Phase-23 Accepted-Evidence Set Membership Decision
+
+This decision candidate consumes the clean-fixed Phase-23
+Accepted-Evidence Set Membership Decision as an exact governance
+prerequisite.
+
+The Phase-23 Accepted-Evidence Set Membership Decision remains bound to:
+
+```text
+6f8326a895ebdd3e07b4dc73d8be849bfe0df7fc
+```
+
+The accepted-evidence set membership decision accepted only a bounded
+accepted-evidence set membership decision boundary.
+
+This assignment-record candidate does not convert that decision boundary
+into accepted-evidence set membership assignment.
+
+This assignment-record candidate does not convert that decision boundary
+into accepted-evidence set membership.
+
+This assignment-record candidate does not convert that decision boundary
+into accepted evidence.
+
+This assignment-record candidate does not broaden the accepted-evidence
+set membership decision record.
+
+Any accepted-evidence set membership decision conflict fails closed.
+
+## Relationship To Phase-23 Accepted-Evidence Set Decision
+
+This decision candidate consumes the clean-fixed and publication-status
+synced Phase-23 Accepted-Evidence Set Decision as an exact governance
+prerequisite.
+
+The Phase-23 Accepted-Evidence Set Decision publication-status sync
+remains bound to:
+
+```text
+1e6c2e1af515a57ef2be910dbf6aa61d5fc081ff
+```
+
+The Phase-23 Accepted-Evidence Set Decision publication remains bound to:
+
+```text
+a39cec2fcdc03c43a6a97de27cad0e16085b17c8
+```
+
+The accepted-evidence set decision accepted only a bounded
+accepted-evidence set decision boundary.
+
+This assignment-record candidate does not convert that decision boundary
+into an accepted-evidence set membership assignment record.
+
+This assignment-record candidate does not convert that decision boundary
+into accepted-evidence set membership assignment.
+
+This assignment-record candidate does not convert that decision boundary
+into accepted-evidence set membership.
+
+This assignment-record candidate does not convert that decision boundary
+into accepted evidence.
+
+This assignment-record candidate does not broaden the accepted-evidence
+set decision record.
+
+Any accepted-evidence set decision conflict fails closed.
+
+## Relationship To Phase-23 Accepted-Evidence Authority Decision
+
+This decision candidate consumes the clean-fixed Phase-23
+Accepted-Evidence Authority Decision as an exact governance prerequisite.
+
+The Phase-23 Accepted-Evidence Authority Decision remains bound to:
+
+```text
+d9ac910c24601002971e7d06cf94463d739b1358
+```
+
+The accepted-evidence authority decision accepted only bounded accepted
+evidence authority as a governance authority class.
+
+This assignment-record candidate does not convert that bounded authority
+class into an accepted-evidence set membership assignment record.
+
+This assignment-record candidate does not convert that bounded authority
+class into accepted-evidence set membership assignment.
+
+This assignment-record candidate does not convert that bounded authority
+class into accepted evidence.
+
+This assignment-record candidate does not broaden the accepted-evidence
+authority decision record.
+
+Any accepted-evidence authority decision conflict fails closed.
+
+## Relationship To Phase-23 Accepted-Evidence Boundary Planning
+
+This decision candidate consumes the clean-fixed Phase-23
+Accepted-Evidence Boundary Planning record and its clean-fixed
+publication-status sync as exact governance prerequisites.
+
+The Phase-23 Accepted-Evidence Boundary Planning publication-status sync
+remains bound to:
+
+```text
+40aba477d35902193fca9c75e4042ea1cf8539e5
+```
+
+The Phase-23 Accepted-Evidence Boundary Planning publication remains
+bound to:
+
+```text
+bc56d0baada3becdc3c820c4a5a167d7859abbbd
+```
+
+This decision candidate does not convert accepted-evidence boundary
+planning into accepted-evidence set membership assignment.
+
+This decision candidate does not convert accepted-evidence boundary
+planning into accepted-evidence set membership.
+
+This decision candidate does not convert accepted-evidence boundary
+planning into accepted evidence.
+
+This decision candidate does not broaden the accepted-evidence boundary
+planning record.
+
+Any accepted-evidence boundary planning conflict fails closed.
+
+## Relationship To Phase-23 Exact-SHA Evidence Expectation Boundary
+
+This decision candidate consumes the clean-fixed Phase-23 Exact-SHA
+Evidence Expectation Boundary and its clean-fixed publication-status sync
+as exact governance prerequisites.
+
+The Phase-23 Exact-SHA Evidence Expectation Boundary publication-status
+sync remains bound to:
+
+```text
+1c6148a7dd1655d6281cdc20489026871c6e3975
+```
+
+The Phase-23 Exact-SHA Evidence Expectation Boundary publication remains
+bound to:
+
+```text
+22f3f134eb9fd9a0da4d11f9b523ff6ea8c781a2
+```
+
+This decision candidate uses those expectations only as prerequisites for
+a later accepted-evidence set membership assignment record-candidate
+boundary.
+
+This decision candidate does not convert exact-SHA expectations into
+accepted-evidence set membership assignment.
+
+This decision candidate does not convert exact-SHA expectations into
+accepted evidence.
+
+Any exact-SHA evidence expectation boundary conflict fails closed.
+
+## Relationship To Phase-23 Governance Overview And Initial Boundary
+
+This decision candidate consumes the clean-fixed Phase-23 Governance
+Overview, Phase-23 Initial Governance Boundary, and their
+publication-status syncs as exact governance prerequisites.
+
+The Phase-23 Governance Overview publication-status sync remains bound
+to:
+
+```text
+1c34b754a07d4eed1493a4b5d456bf870681362f
+```
+
+The Phase-23 Initial Governance Boundary publication-status sync remains
+bound to:
+
+```text
+97aab9383e76fcbdc1dfcf0c3520f7de9e0e7692
+```
+
+This decision candidate does not broaden the Phase-23 governance
+overview.
+
+This decision candidate does not broaden the Phase-23 initial governance
+boundary.
+
+Any overview or initial-boundary conflict fails closed.
+
+## Relationship To Phase-22 Closure
+
+This decision candidate consumes the Phase-22 Closure Decision and the
+Phase-22 closure publication-status sync as exact governance
+prerequisites.
+
+The Phase-22 Closure Decision remains bound to:
+
+```text
+9b19c94a01170d105bd7a7e9fb198df05be17fdf
+```
+
+The latest Phase-22 closure publication-status sync remains bound to:
+
+```text
+6c0a0c878d54ebc6a768e1c708a68d7eb5898b15
+```
+
+Phase-22 remains closed only as:
+
+```text
+actual skeleton reviewed;
+static package acceptance boundary defined and clean-recovered;
+Phase-21 First Bounded Implementation actual skeleton exact 12-file set
+accepted as a static package subject only.
+```
+
+This decision candidate does not reopen Phase-22.
+
+This decision candidate does not reinterpret Phase-22 closure as Phase-23
+accepted evidence, an accepted-evidence set, accepted-evidence set
+membership, accepted-evidence set membership assignment, an assignment
+record, evidence item acceptance, validator output acceptance, receipt
+evidence acceptance, runtime implementation procedure, package loading,
+package execution, source acceptance, source merge authority, capability
+issuance, registry publication, trust assignment, deployment,
+distribution, kernel ABI expansion, syscall expansion,
+workflow-threshold changes, baseline changes, dependency changes, or
+Ring0 authority.
+
+Any Phase-22 closure conflict fails closed.
+
+## Relationship To Phase-19 Runtime Authority
+
+This decision candidate remains subordinate to Phase-19 runtime authority
+records.
+
+This decision candidate must not broaden, replace, supersede, weaken, or
+reinterpret Phase-19 runtime authority records.
+
+This decision candidate must not use assignment-record candidate planning
+to infer runtime authority.
+
+This decision candidate must not use membership assignment decision
+authority to infer runtime authority.
+
+This decision candidate must not use accepted-evidence set membership
+decision records to infer runtime authority.
+
+This decision candidate must not use accepted-evidence set decision
+records to infer runtime authority.
+
+This decision candidate must not use accepted-evidence authority to infer
+runtime authority.
+
+This decision candidate must not use validator-output planning to infer
+runtime authority.
+
+This decision candidate must not use receipt-evidence planning to infer
+runtime authority.
+
+This decision candidate must not use exact-SHA evidence expectations to
+infer runtime authority.
+
+This decision candidate must not use `CURRENT_PHASE=23` to infer runtime
+authority.
+
+Any Phase-23 accepted-evidence set membership assignment record-candidate
+reading that conflicts with Phase-19 runtime authority records fails
+closed.
+
+## Not Authorized By This Decision Candidate
+
+This decision candidate does not authorize:
+
+1. Accepted-evidence set membership assignment record publication.
+2. Accepted-evidence set membership assignment.
+3. Accepted-evidence set membership.
+4. Accepted-evidence set creation.
+5. Accepted evidence.
+6. Evidence item acceptance.
+7. Validator output acceptance.
+8. Receipt evidence acceptance.
+9. Runtime implementation procedure.
+10. Source modification.
+11. Source acceptance.
+12. Source merge.
+13. Code implementation.
+14. Code execution.
+15. Process start.
+16. Runtime state creation.
+17. Package installation.
+18. Package loading.
+19. Package execution.
+20. Module loading.
+21. Workspace runtime or real mounts.
+22. Plugin loading or plugin instantiation.
+23. Capability token minting.
+24. Capability issuance.
+25. Registry publication.
+26. Trust assignment.
+27. Distribution execution.
+28. Deployment.
+29. Semantic CLI authority.
+30. AI Runtime authority.
+31. Agent authority.
+32. Syscall expansion.
+33. Kernel ABI expansion.
+34. Ring0 policy movement.
+35. Workflow-threshold changes.
+36. Baseline changes.
+37. Dependency changes.
+38. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this decision candidate is published, the publication may change only
+this file:
+
+```text
+PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md
+```
+
+The publication must not change:
+
+1. `docs/roadmap/CURRENT_PHASE`.
+2. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+3. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`.
+4. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`.
+5. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`.
+6. `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`.
+7. `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`.
+8. `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`.
+9. `PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`.
+10. `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`.
+11. `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`.
+12. `PHASE23_ACCEPTED_EVIDENCE_DECISION.md`.
+13. `PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`.
+14. `PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`.
+15. `PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`.
+16. `PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`.
+17. `PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`.
+18. `PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`.
+19. `PHASE23_GOVERNANCE_OVERVIEW.md`.
+20. CI workflows.
+21. Baselines.
+22. Dependencies.
+23. Runtime source or kernel source.
+24. Syscalls or kernel ABI.
+25. Package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution paths.
+26. `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md`.
+
+Any changed-file expansion beyond this decision-candidate record
+requires separate review and fails this candidate scope.
+
+## Post-Merge Exact-Main Evidence Rule
+
+If this decision candidate is later published, the candidate publication
+subject must receive its own post-merge exact-main verification:
+
+1. `ci-freeze` PASS for the exact candidate publication SHA.
+2. Dev Loop Validation PASS for the exact candidate publication SHA.
+3. AykenOS Dev Loop CI PASS for the exact candidate publication SHA.
+4. smoke PASS.
+5. contract PASS.
+6. full PASS.
+7. isolation PASS.
+8. performance PASS.
+9. Exact changed-file list confirmation.
+10. No `docs/roadmap/CURRENT_PHASE` change.
+11. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`
+    change.
+12. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`
+    change.
+13. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md` change.
+14. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`
+    change.
+15. No `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md` change.
+16. No `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md` change.
+17. No `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md` change.
+18. No `PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md` change.
+19. No `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md` change.
+20. No `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`
+    change.
+21. No `PHASE23_ACCEPTED_EVIDENCE_DECISION.md` change.
+22. No `PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md` change.
+23. No `PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md` change.
+24. No `PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md` change.
+25. No `PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md` change.
+26. No `PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md` change.
+27. No `PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md` change.
+28. No `PHASE23_GOVERNANCE_OVERVIEW.md` change.
+29. No CI workflow change.
+30. No baseline change.
+31. No dependency change.
+32. No runtime source or kernel source change.
+33. No syscall or kernel ABI change.
+34. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution change.
+
+Until that exact-main post-merge verification exists, this decision
+candidate must not be recorded as clean-fixed.
+
+Historical PASS results may be cited as context only.
+
+Failed attempts may be cited as transparent non-clean context only.
+
+They cannot be inherited as an accepted-evidence set membership
+assignment record, accepted-evidence set membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime authority, package loading authority, package execution
+authority, source merge authority, capability authority, registry
+authority, trust authority, kernel ABI authority, syscall authority,
+workflow-threshold authority, baseline authority, dependency authority,
+or Ring0 authority.
+
+## Later Membership Assignment Record Dependency
+
+This decision candidate is a prerequisite input for a possible later
+bounded accepted-evidence set membership assignment record.
+
+A later accepted-evidence set membership assignment record, if ever
+proposed, must define:
+
+1. Exact accepted-evidence set membership assignment record subject.
+2. Exact Phase-23 accepted-evidence set membership assignment record
+   candidate prerequisite.
+3. Exact changed-file boundary.
+4. Exact accepted-evidence set membership assignment record scope, if
+   any.
+5. Exact accepted-evidence set membership assignment scope, if any.
+6. Exact accepted-evidence set membership being assigned, if any.
+7. Exact evidence item reference proposed for membership assignment, if
+   any, without evidence item acceptance unless separately reviewed.
+8. Exact evidence item acceptance denial or separate evidence item
+   acceptance scope.
+9. Exact accepted-evidence creation denial or separate accepted-evidence
+   scope.
+10. Exact validator-output acceptance denial or separate validator-output
+    acceptance scope.
+11. Exact receipt-evidence acceptance denial or separate receipt-evidence
+    acceptance scope.
+12. Exact runtime implementation procedure denial.
+13. Exact package loading and package execution denials.
+14. Exact source acceptance and source merge denials.
+15. Exact capability, registry, trust, deployment, distribution, kernel
+    ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+    denials.
+16. Exact post-merge verification requirements.
+
+Until such a later reviewed membership-assignment record is published,
+no accepted-evidence set membership assignment record exists from this
+decision candidate.
+
+Until such a later reviewed membership-assignment record is published,
+no accepted-evidence set membership assignment exists from this decision
+candidate.
+
+Until such a later reviewed membership record is published, no
+accepted-evidence set membership exists from this decision candidate.
+
+Until such a later reviewed evidence-item acceptance record is published,
+no evidence item acceptance exists from this decision candidate.
+
+Until such a later reviewed accepted-evidence record is published, no
+accepted evidence exists from this decision candidate.
+
+Until such a later reviewed validator-output acceptance record is
+published, no validator output acceptance exists from this decision
+candidate.
+
+Until such a later reviewed receipt-evidence acceptance record is
+published, no receipt evidence acceptance exists from this decision
+candidate.
+
+## Excluded Local Draft
+
+This decision candidate does not consume:
+
+```text
+PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md
+```
+
+If that file exists locally as an untracked file, it remains:
+
+```text
+untracked
+PR-disjoint
+not decision input
+not evidence input
+not assignment record input
+not membership assignment
+not accepted-evidence set membership
+not accepted evidence
+not evidence item acceptance
+not validator output
+not receipt evidence
+not source authority
+not package acceptance
+not runtime authority
+```
+
+It must not be staged, committed, or included in any Phase-23
+accepted-evidence set membership assignment record-candidate PR unless a
+separate reviewed scope explicitly authorizes that file.
+
+## Governance Boundary Invariants
+
+Every later RFC must preserve these Phase-23 accepted-evidence set
+membership assignment record candidate invariants:
+
+1. This decision candidate is not an accepted-evidence set membership
+   assignment record.
+2. This decision candidate is not accepted-evidence set membership
+   assignment.
+3. This decision candidate is not accepted-evidence set membership.
+4. This decision candidate is not an accepted-evidence set.
+5. This decision candidate is not accepted evidence.
+6. This decision candidate is not evidence item acceptance.
+7. This decision candidate is not validator output acceptance.
+8. This decision candidate is not receipt evidence acceptance.
+9. This decision candidate is not a decision.
+10. This decision candidate is not an authority grant.
+11. Assignment record candidate is not assignment record.
+12. Accepted-evidence set membership assignment is not
+    accepted-evidence set membership unless separately reviewed.
+13. Accepted-evidence set membership assignment is not accepted evidence
+    unless separately reviewed.
+14. Accepted-evidence set membership assignment is not evidence item
+    acceptance unless separately reviewed.
+15. Accepted-evidence set membership is not accepted evidence unless
+    separately reviewed.
+16. This decision candidate is not runtime implementation procedure.
+17. This decision candidate is not source modification.
+18. This decision candidate is not code implementation.
+19. This decision candidate is not code execution.
+20. This decision candidate is not process start.
+21. This decision candidate is not runtime state creation.
+22. This decision candidate is not package installation.
+23. This decision candidate is not package loading.
+24. This decision candidate is not package execution.
+25. This decision candidate is not capability issuance.
+26. This decision candidate is not registry publication.
+27. This decision candidate is not trust assignment.
+28. This decision candidate is not deployment.
+29. This decision candidate is not distribution authority.
+30. This decision candidate is not source acceptance.
+31. This decision candidate is not source merge authority.
+32. This decision candidate does not modify `docs/roadmap/CURRENT_PHASE`.
+33. This decision candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+34. This decision candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`.
+35. This decision candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`.
+36. This decision candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`.
+37. This decision candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`.
+38. This decision candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`.
+39. This decision candidate does not modify
+    `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`.
+40. This decision candidate does not modify
+    `PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`.
+41. This decision candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`.
+42. This decision candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`.
+43. This decision candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_DECISION.md`.
+44. This decision candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`.
+45. This decision candidate does not modify
+    `PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`.
+46. This decision candidate does not modify
+    `PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`.
+47. This decision candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`.
+48. This decision candidate does not modify
+    `PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`.
+49. This decision candidate does not modify
+    `PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`.
+50. This decision candidate does not modify `PHASE23_GOVERNANCE_OVERVIEW.md`.
+51. `CURRENT_PHASE=23` is not an accepted-evidence set membership
+    assignment record.
+52. `CURRENT_PHASE=23` is not accepted-evidence set membership
+    assignment.
+53. `CURRENT_PHASE=23` is not accepted-evidence set membership.
+54. `CURRENT_PHASE=23` is not an accepted-evidence set.
+55. `CURRENT_PHASE=23` is not accepted evidence.
+56. `CURRENT_PHASE=23` is not evidence item acceptance.
+57. `CURRENT_PHASE=23` is not validator output acceptance.
+58. `CURRENT_PHASE=23` is not receipt evidence acceptance.
+59. `CURRENT_PHASE=23` is not runtime implementation procedure.
+60. `CURRENT_PHASE=23` is not source modification.
+61. `CURRENT_PHASE=23` is not execution authority.
+62. `CURRENT_PHASE=23` is not package loading.
+63. `CURRENT_PHASE=23` is not source merge authority.
+64. This decision candidate does not broaden Phase-19 runtime authority.
+65. This decision candidate does not reopen Phase-20.
+66. This decision candidate does not reopen Phase-21.
+67. This decision candidate does not reopen Phase-22.
+68. This decision candidate does not expand kernel ABI or syscalls.
+69. This decision candidate does not change workflow thresholds,
+    baselines, or dependencies.
+70. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-23 accepted-evidence set membership assignment
+record candidate
+**Architecture status:** Local draft accepted-evidence set membership
+assignment record candidate / pending separate reviewed publication
+**Authority notice:** This signature identifies the architectural
+authorship of this decision candidate. It grants no accepted-evidence set
+membership assignment record authority, accepted-evidence set membership
+assignment authority, accepted-evidence set membership authority,
+accepted evidence status, evidence item acceptance authority, validator
+output acceptance authority, receipt evidence acceptance authority,
+runtime implementation procedure authority, source modification
+authority, code implementation authority, code execution authority,
+process start authority, general runtime authority, unbounded execution
+authority, runtime state authority, package installation authority,
+package loading authority, package execution authority, source merge
+authority, trust authority, registry authority, distribution authority,
+publication authority, capability issuance authority, deployment
+authority, module authority, plugin authority, Semantic CLI authority, AI
+Runtime authority, agent authority, kernel ABI authority, syscall
+authority, workflow-threshold authority, baseline authority, dependency
+authority, or Ring0 authority.
+
+## Conclusion
+
+This Phase-23 accepted-evidence set membership assignment record
+candidate is based on the clean-fixed Phase-23 Accepted-Evidence Set
+Membership Assignment Decision publication subject:
+
+```text
+f60e093a53865fb2e03ce3ded375ed7bace763e5
+```
+
+It defines only the governance-only candidate boundary for whether a
+later accepted-evidence set membership assignment record path may be
+evaluated after a bounded accepted-evidence set membership assignment
+decision boundary exists.
+
+It does not publish an accepted-evidence set membership assignment
+record.
+
+It does not assign accepted-evidence set membership.
+
+It does not define accepted-evidence set membership.
+
+It does not create an accepted-evidence set.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize accepted-evidence set membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime implementation procedure, source modification, code
+implementation, code execution, process start, runtime state creation,
+package installation, package loading, package execution, capability
+issuance, registry publication, trust assignment, deployment,
+distribution, source acceptance, source merge, kernel ABI expansion,
+syscall expansion, workflow-threshold changes, baseline changes,
+dependency changes, or Ring0 authority.
+
+Any later Phase-23 accepted-evidence set membership assignment record,
+accepted-evidence set membership assignment, accepted-evidence set
+membership, accepted-evidence, evidence-item acceptance,
+validator-output, receipt-evidence, package-review, source-review,
+runtime-implementation-procedure, or non-authorization boundary record
+requires its own exact-SHA evidence, changed-file scope,
+non-authorization boundary, and reviewed decision path.


### PR DESCRIPTION
This PR changes only `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md` and defines only a governance-only candidate boundary for whether a later accepted-evidence set membership assignment record path may be evaluated.

It does not publish an assignment record, assign membership, create accepted evidence, accept any evidence item, accept validator output, accept receipt evidence, or authorize runtime/source/package/source-merge/capability/registry/trust/deployment/distribution/kernel ABI/syscall/workflow-threshold/baseline/dependency/Ring0 authority.

Base subject: `f60e093a53865fb2e03ce3ded375ed7bace763e5`
Input: PR #278 clean-fixed accepted-evidence set membership assignment decision
Scope: `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md` only

Validation before PR creation:
- `git diff --cached --check` passed before commit
- staged scope was `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md` only
- `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md` remained untracked / PR-disjoint