### PR TITLE
Phase-23 concrete accepted-evidence set membership assignment record

### DIFF
--- a/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md
+++ b/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md
@@ -1,0 +1,1257 @@
+# Phase-23 Concrete Accepted-Evidence Set Membership Assignment Record
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY_CLEAN_RECOVERY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_FIRST_BOUNDED_IMPLEMENTATION.md`,
+`PHASE22_CLOSURE_DECISION.md`,
+`PHASE23_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE23_POINTER_TRANSITION_DECISION.md`,
+`docs/roadmap/CURRENT_PHASE`,
+`PHASE23_GOVERNANCE_OVERVIEW.md`,
+`PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`,
+`PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`,
+`PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`, and
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+In case of conflict, those documents prevail unless this document is the
+narrower Phase-23 concrete accepted-evidence set membership assignment
+record for the exact governance-only bounded concrete-record boundary
+identified below.
+
+**Status:** PHASE-23 CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT
+RECORD / LOCAL DRAFT / GOVERNANCE-ONLY CONCRETE ACCEPTED-EVIDENCE SET
+MEMBERSHIP ASSIGNMENT RECORD ONLY / BOUNDED CONCRETE ACCEPTED-EVIDENCE
+SET MEMBERSHIP ASSIGNMENT RECORD BOUNDARY ONLY / NO ACCEPTED-EVIDENCE SET
+MEMBERSHIP ASSIGNMENT / NO ACCEPTED-EVIDENCE SET MEMBERSHIP / NO
+ACCEPTED-EVIDENCE SET / NO ACCEPTED EVIDENCE / NO EVIDENCE ITEM
+ACCEPTANCE / NO VALIDATOR OUTPUT ACCEPTANCE / NO RECEIPT EVIDENCE
+ACCEPTANCE / NO RUNTIME IMPLEMENTATION PROCEDURE / NO SOURCE
+MODIFICATION / NO CODE IMPLEMENTATION / NO CODE EXECUTION / NO PROCESS
+START / NO RUNTIME STATE CREATION / NO PACKAGE INSTALLATION / NO PACKAGE
+LOADING / NO PACKAGE EXECUTION / NO DEPLOYMENT / NO CAPABILITY ISSUANCE /
+NO TRUST ASSIGNMENT / NO REGISTRY PUBLICATION / NO DISTRIBUTION
+AUTHORITY / NO SOURCE ACCEPTANCE / NO SOURCE MERGE AUTHORITY / NO KERNEL
+ABI EXPANSION / NO SYSCALL EXPANSION / NO WORKFLOW-THRESHOLD CHANGE / NO
+BASELINE CHANGE / NO DEPENDENCY CHANGE / NO RING0 AUTHORITY
+**Record date:** 2026-07-10
+**Record id:**
+`ayken.phase23.concrete_accepted_evidence_set_membership_assignment_record.v1`
+**Record drafting base main SHA:**
+`c20309a39c91d08dab1df3163a204ab80bc767a5`
+**Record publication subject:** pending separate reviewed publication
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record candidate publication subject:**
+`c20309a39c91d08dab1df3163a204ab80bc767a5`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record candidate PR:** PR #281
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record candidate exact-main ci-freeze run:** `29057618188`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record candidate exact-main ci-freeze attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record candidate exact-main ci-freeze job:** `freeze / 86252380246`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record candidate exact-main ci-freeze result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record candidate exact-main Dev Loop Validation run:** `29057618200`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record candidate exact-main Dev Loop Validation attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record candidate exact-main Dev Loop Validation job:** `devloop / 86252380252`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record candidate exact-main Dev Loop Validation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record candidate exact-main Dev Loop CI run:** `29057618253`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record candidate exact-main Dev Loop CI attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record candidate exact-main Dev Loop CI result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record candidate exact-main smoke job:** `smoke / 86252380512`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record candidate exact-main smoke result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record candidate exact-main contract job:** `contract / 86252514911`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record candidate exact-main contract result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record candidate exact-main full job:** `full / 86252839926`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record candidate exact-main full result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record candidate exact-main isolation job:** `isolation / 86253196972`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record candidate exact-main isolation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record candidate exact-main performance job:** `performance / 86253525684`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record candidate exact-main performance result:** PASS
+**Phase-23 accepted-evidence set membership assignment record publication
+subject:** `91a24c007276f1ff8804f6b92bda052f4c16bb2c`
+**Phase-23 accepted-evidence set membership assignment record candidate
+publication subject:** `5805d1187a7b29aec28097d0383f2166c7e508dd`
+**Phase-23 accepted-evidence set membership assignment decision
+publication subject:** `f60e093a53865fb2e03ce3ded375ed7bace763e5`
+**Phase-23 accepted-evidence set membership assignment decision candidate
+publication subject:** `3c8cdfa992ae1c94098b75b7b6064bf8bd40c184`
+**Phase-23 accepted-evidence set membership decision publication
+subject:** `6f8326a895ebdd3e07b4dc73d8be849bfe0df7fc`
+**Phase-23 accepted-evidence set membership decision candidate publication
+subject:** `ac05e74885f85f2d0bed540d66b9c80059086c5d`
+**Phase-23 accepted-evidence set decision publication-status sync
+subject:** `1e6c2e1af515a57ef2be910dbf6aa61d5fc081ff`
+**Phase-23 accepted-evidence set decision publication subject:**
+`a39cec2fcdc03c43a6a97de27cad0e16085b17c8`
+**Phase-23 accepted-evidence set decision candidate publication subject:**
+`206d1a9aff8ba3dd2aaa4a0e258315d5c92379cd`
+**Phase-23 evidence acceptance decision publication subject:**
+`1fe089b141af09e9f98be2a153589e68ab015c18`
+**Phase-23 evidence acceptance decision candidate publication subject:**
+`7d90f2c195afecfb4875876f1ea832df3d9b6528`
+**Phase-23 accepted-evidence authority decision publication subject:**
+`d9ac910c24601002971e7d06cf94463d739b1358`
+**Phase-23 accepted-evidence authority decision candidate publication
+subject:** `72d5234654a5af4fa84b52f3ba3753b9104a4dce`
+**Phase-23 accepted-evidence decision publication subject:**
+`0f6da8e9abe8d354e98c5243b3300cf9a75f697a`
+**Phase-23 accepted-evidence decision candidate publication subject:**
+`a895f3ae5eeebe5848e52a1d75874b0b75518137`
+**Phase-23 validator-output boundary planning publication-status sync
+subject:** `d225b2b5ffcd83fe12c70bf0150b60f8f288f329`
+**Phase-23 validator-output boundary planning publication subject:**
+`08585f64b6088ed9f76a8027daecec6dc70da885`
+**Phase-23 receipt-evidence boundary planning publication-status sync
+subject:** `9153d858c8ca99b09beb2fa60c6c7bcc565445a9`
+**Phase-23 receipt-evidence boundary planning publication subject:**
+`e6d21b2bfabfd9658a748d69fddcede3d88af401`
+**Phase-23 accepted-evidence boundary planning publication-status sync
+subject:** `40aba477d35902193fca9c75e4042ea1cf8539e5`
+**Phase-23 accepted-evidence boundary planning publication subject:**
+`bc56d0baada3becdc3c820c4a5a167d7859abbbd`
+**Phase-23 exact-SHA evidence expectation boundary publication-status
+sync subject:** `1c6148a7dd1655d6281cdc20489026871c6e3975`
+**Phase-23 exact-SHA evidence expectation boundary publication subject:**
+`22f3f134eb9fd9a0da4d11f9b523ff6ea8c781a2`
+**Phase-23 initial governance boundary publication-status sync subject:**
+`97aab9383e76fcbdc1dfcf0c3520f7de9e0e7692`
+**Phase-23 initial governance boundary publication subject:**
+`3db9a2e740a414b040daa30ee70a54850fdbeb1f`
+**Phase-23 governance overview publication-status sync subject:**
+`1c34b754a07d4eed1493a4b5d456bf870681362f`
+**Phase-23 governance overview publication subject:**
+`bfd4b07d5332f16b5d0295f3170f795629ca7ca8`
+**Phase-23 current phase pointer update subject:**
+`9b70ee20707023709e906d0200a80a1ac69fa698`
+**Phase-23 pointer transition decision subject:**
+`16ac421a40ce93641ccccc28fb5ad869f2b8984e`
+**Phase-23 pointer transition candidate subject:**
+`77fd954607ad076cdea888047f19e4fed60bfb65`
+**Phase-22 closure publication-status sync subject:**
+`6c0a0c878d54ebc6a768e1c708a68d7eb5898b15`
+**Phase-22 closure decision publication subject:**
+`9b19c94a01170d105bd7a7e9fb198df05be17fdf`
+**Current phase pointer:** `CURRENT_PHASE=23`
+**Accepted Phase-23 concrete accepted-evidence set membership assignment
+record boundary:** bounded concrete accepted-evidence set membership
+assignment record boundary as a governance record boundary only;
+accepted-evidence set membership assignment, accepted-evidence set
+membership, accepted evidence, evidence item acceptance, validator output
+acceptance, and receipt evidence acceptance remain pending separate
+reviewed decision or record paths if ever authorized
+**Authority boundary:** Concrete accepted-evidence set membership
+assignment record only; bounded concrete accepted-evidence set membership
+assignment record boundary only; not accepted-evidence set membership
+assignment unless separately reviewed, not accepted-evidence set
+membership, not an accepted-evidence set, not accepted evidence, not
+evidence item acceptance, not validator output acceptance, not receipt
+evidence acceptance, not runtime implementation procedure, not source
+modification, not code implementation, not code execution, not process
+start, not runtime state creation, not general runtime authority, not
+unbounded execution authority, not package authority, not package
+installation, not package loading, not package execution, not source
+acceptance, not source merge authority, not source repository authority,
+not module loading, not workspace runtime, not plugin loading, not
+capability token minting, not capability issuance, not trust assignment,
+not trust issuer authority, not registry authority, not registry
+publication, not publication authority, not deployment authority, not
+distribution authority, not distribution execution, not Semantic CLI
+authority, not AI Runtime authority, not agent authority, not syscall
+expansion, not kernel ABI expansion, not workflow-threshold, baseline,
+dependency, or Ring0 authority.
+
+## Purpose
+
+This document records a Phase-23 governance-only concrete
+accepted-evidence set membership assignment record after the clean-fixed
+Phase-23 Concrete Accepted-Evidence Set Membership Assignment Record
+Candidate publication.
+
+It evaluates only:
+
+```text
+May a bounded concrete accepted-evidence set membership assignment record
+boundary be defined during Phase-23 without assigning membership,
+accepting any evidence item, or creating accepted evidence?
+```
+
+It accepts only the bounded concrete accepted-evidence set membership
+assignment record boundary as a governance record boundary.
+
+This record may define a bounded concrete accepted-evidence set
+membership assignment record boundary, but it does not assign
+accepted-evidence set membership.
+
+It does not define accepted-evidence set membership.
+
+It does not create an accepted-evidence set.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not convert CI PASS results, receipts, validator output, package
+review output, source review output, historical results, clean-fixed
+claims, concrete-record claims, or record-boundary claims into accepted
+evidence, membership assignment, accepted-evidence set membership,
+evidence item acceptance, validator output acceptance, or receipt
+evidence acceptance.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start, runtime
+state creation, package installation, package loading, package execution,
+source acceptance, source merge, registry publication, trust assignment,
+capability issuance, deployment, distribution, kernel ABI expansion,
+syscall expansion, workflow-threshold changes, baseline changes,
+dependency changes, or Ring0 authority.
+
+It does not answer:
+
+```text
+Which accepted-evidence set membership is assigned?
+Which evidence item is accepted?
+Which evidence item becomes accepted evidence?
+How is accepted-evidence set membership assigned?
+How is accepted evidence created?
+How is validator output accepted?
+How is receipt evidence accepted?
+How is runtime implementation procedure defined?
+How is source modified?
+How is code implemented or executed?
+How is a process started?
+How is runtime state created?
+How is a package installed, loaded, executed, deployed, or distributed?
+How is source accepted or merged?
+How is a capability issued?
+How is trust assigned?
+How is a registry entry published?
+How is kernel ABI or syscall surface expanded?
+How are workflow thresholds, baselines, or dependencies changed?
+```
+
+Those questions require later reviewed decision or record paths, if ever
+authorized.
+
+## Exact Subject
+
+This record draft is based on exact main SHA:
+
+```text
+c20309a39c91d08dab1df3163a204ab80bc767a5
+```
+
+That subject is the squash merge of PR #281:
+
+```text
+Phase-23 concrete accepted-evidence set membership assignment record candidate
+```
+
+PR #281 changed only:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md
+```
+
+PR #281 produced post-merge exact-main verification:
+
+| Evidence | Run / job | Result |
+|---|---|---|
+| `ci-freeze` | run `29057618188`, attempt 1, job `freeze / 86252380246` | PASS |
+| Dev Loop Validation | run `29057618200`, attempt 1, job `devloop / 86252380252` | PASS |
+| AykenOS Dev Loop CI | run `29057618253`, attempt 1 | PASS |
+| smoke | job `86252380512` | PASS |
+| contract | job `86252514911` | PASS |
+| full | job `86252839926` | PASS |
+| isolation | job `86253196972` | PASS |
+| performance | job `86253525684` | PASS |
+
+The Phase-23 Concrete Accepted-Evidence Set Membership Assignment Record
+Candidate remains bound to:
+
+```text
+c20309a39c91d08dab1df3163a204ab80bc767a5
+```
+
+That candidate recorded that it was not a concrete accepted-evidence set
+membership assignment record, not accepted-evidence set membership
+assignment, not accepted-evidence set membership, not accepted evidence,
+not evidence item acceptance, not validator output acceptance, not
+receipt evidence acceptance, not a decision, and not an authority grant.
+
+This record consumes that exact subject as governance input only. It does
+not replace, broaden, reinterpret, or supersede the concrete record
+candidate or any earlier Phase-23 governance boundary.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped subject readings fail closed.
+
+## Core Rule
+
+```text
+concrete accepted-evidence set membership assignment record == bounded concrete accepted-evidence set membership assignment record boundary only
+concrete accepted-evidence set membership assignment record != accepted-evidence set membership assignment unless separately reviewed
+concrete accepted-evidence set membership assignment record != accepted-evidence set membership
+concrete accepted-evidence set membership assignment record != accepted-evidence set
+concrete accepted-evidence set membership assignment record != accepted evidence
+concrete accepted-evidence set membership assignment record != evidence item acceptance
+concrete accepted-evidence set membership assignment record != validator output acceptance
+concrete accepted-evidence set membership assignment record != receipt evidence acceptance
+concrete accepted-evidence set membership assignment record != runtime implementation procedure
+concrete accepted-evidence set membership assignment record != source modification
+concrete accepted-evidence set membership assignment record != package loading
+concrete accepted-evidence set membership assignment record != package execution
+concrete accepted-evidence set membership assignment record != source acceptance
+concrete accepted-evidence set membership assignment record != source merge
+bounded concrete accepted-evidence set membership assignment record boundary != accepted-evidence set membership assignment unless separately reviewed
+bounded concrete accepted-evidence set membership assignment record boundary != accepted-evidence set membership
+bounded concrete accepted-evidence set membership assignment record boundary != accepted evidence
+bounded concrete accepted-evidence set membership assignment record boundary != evidence item acceptance
+concrete accepted-evidence set membership assignment record candidate != concrete accepted-evidence set membership assignment record
+concrete record publication != membership assignment
+concrete record boundary != accepted-evidence set membership assignment unless separately reviewed
+concrete assignment record != accepted-evidence set membership assignment unless separately reviewed
+accepted-evidence set membership assignment != accepted-evidence set membership unless separately reviewed
+accepted-evidence set membership assignment != accepted evidence unless separately reviewed
+accepted-evidence set membership assignment != evidence item acceptance unless separately reviewed
+accepted-evidence set membership != accepted evidence unless separately reviewed
+accepted-evidence set membership != evidence item acceptance unless separately reviewed
+accepted-evidence set != accepted evidence unless separately reviewed
+accepted evidence != validator output unless separately reviewed
+accepted evidence != receipt evidence unless separately reviewed
+validator output != accepted evidence
+receipt evidence != accepted evidence
+receipt evidence != validator output
+CI PASS != concrete accepted-evidence set membership assignment record
+CI PASS != accepted-evidence set membership assignment
+CI PASS != accepted-evidence set membership
+CI PASS != accepted evidence
+ci-freeze PASS != concrete accepted-evidence set membership assignment record
+ci-freeze PASS != accepted-evidence set membership assignment
+ci-freeze PASS != accepted-evidence set membership
+ci-freeze PASS != accepted evidence
+Dev Loop PASS != concrete accepted-evidence set membership assignment record
+Dev Loop PASS != accepted-evidence set membership assignment
+Dev Loop PASS != accepted-evidence set membership
+Dev Loop PASS != accepted evidence
+AykenOS Dev Loop CI PASS != concrete accepted-evidence set membership assignment record
+AykenOS Dev Loop CI PASS != accepted-evidence set membership assignment
+AykenOS Dev Loop CI PASS != accepted-evidence set membership
+AykenOS Dev Loop CI PASS != accepted evidence
+post-merge exact-main verification != concrete accepted-evidence set membership assignment record
+post-merge exact-main verification != accepted-evidence set membership assignment
+post-merge exact-main verification != accepted-evidence set membership
+post-merge exact-main verification != accepted evidence
+clean-fixed != concrete accepted-evidence set membership assignment record
+clean-fixed != accepted-evidence set membership assignment
+clean-fixed != accepted-evidence set membership
+clean-fixed != accepted evidence
+publication-status sync != concrete accepted-evidence set membership assignment record
+publication-status sync != accepted-evidence set membership assignment
+publication-status sync != accepted-evidence set membership
+publication-status sync != accepted evidence
+CURRENT_PHASE=23 != concrete accepted-evidence set membership assignment record
+CURRENT_PHASE=23 != accepted-evidence set membership assignment
+CURRENT_PHASE=23 != accepted-evidence set membership
+CURRENT_PHASE=23 != accepted-evidence set
+CURRENT_PHASE=23 != accepted evidence
+CURRENT_PHASE=23 != evidence item acceptance
+CURRENT_PHASE=23 != validator output acceptance
+CURRENT_PHASE=23 != receipt evidence acceptance
+CURRENT_PHASE=23 != runtime implementation procedure
+CURRENT_PHASE=23 != source modification
+CURRENT_PHASE=23 != execution authority
+CURRENT_PHASE=23 != package loading
+CURRENT_PHASE=23 != source merge authority
+CURRENT_PHASE=23 != kernel ABI expansion
+CURRENT_PHASE=23 != syscall expansion
+historical PASS != inherited evidence
+previous PR evidence != later PR evidence
+```
+
+The safe default remains no accepted-evidence set membership assignment,
+no accepted-evidence set membership, no accepted-evidence set, no
+accepted evidence, no evidence item acceptance, no validator output
+acceptance, no receipt evidence acceptance, no runtime behavior, no
+implementation procedure, no source modification, no code execution, no
+runtime state, and no package, capability, registry, trust, distribution,
+deployment, source acceptance, source merge, kernel ABI, syscall,
+workflow-threshold, baseline, dependency, or Ring0 authority unless a
+later reviewed Phase-23 decision or record grants a specific bounded
+authority with its own exact-SHA evidence.
+
+Unknown authority readings fail closed.
+
+## Concrete Assignment Record Boundary
+
+The Phase-23 concrete accepted-evidence set membership assignment record
+is accepted only as:
+
+```text
+bounded concrete accepted-evidence set membership assignment record boundary
+```
+
+This record may define a bounded concrete accepted-evidence set
+membership assignment record boundary, but it does not assign
+accepted-evidence set membership.
+
+This bounded record boundary permits a later separate reviewed membership
+assignment record, accepted-evidence set membership record, evidence item
+acceptance candidate, accepted-evidence candidate, validator-output
+acceptance candidate, or receipt-evidence acceptance candidate to be
+evaluated after this record is published and clean-fixed, if ever
+proposed.
+
+This record does not assign accepted-evidence set membership.
+
+This record does not define accepted-evidence set membership.
+
+This record does not create an accepted-evidence set.
+
+This record does not create accepted evidence.
+
+This record does not accept any evidence item.
+
+This record does not accept validator output.
+
+This record does not accept receipt evidence.
+
+This record does not authorize package loading.
+
+This record does not authorize source acceptance or source merge.
+
+This record does not authorize runtime implementation procedure, code
+execution, process start, runtime state creation, capability issuance,
+registry publication, trust assignment, deployment, distribution, kernel
+ABI expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Any later accepted-evidence set membership assignment,
+accepted-evidence set membership, evidence item acceptance, accepted
+evidence, validator output acceptance, or receipt evidence acceptance
+requires a separate reviewed decision or record path with its own exact
+subject, changed-file scope, non-authorization boundary, and post-merge
+exact-main verification.
+
+## Record Scope
+
+This record scope is limited to:
+
+1. Accepting the Phase-23 concrete accepted-evidence set membership
+   assignment record boundary only as a bounded governance record
+   boundary.
+2. Binding this record to PR #281 as the clean-fixed concrete
+   assignment-record-candidate input.
+3. Preserving the distinction between concrete assignment record boundary
+   and accepted-evidence set membership assignment.
+4. Preserving the distinction between membership assignment and
+   accepted-evidence set membership.
+5. Preserving the distinction between accepted-evidence set membership,
+   accepted evidence, and evidence item acceptance.
+6. Preserving separation from validator output acceptance and receipt
+   evidence acceptance.
+7. Establishing post-merge exact-main verification expectations for this
+   concrete assignment record.
+
+Record scope is governance text only.
+
+Record scope is bounded concrete accepted-evidence set membership
+assignment record boundary only.
+
+Record scope is not accepted-evidence set membership assignment.
+
+Record scope is not accepted-evidence set membership.
+
+Record scope is not an accepted-evidence set.
+
+Record scope is not accepted evidence.
+
+Record scope is not evidence item acceptance.
+
+Record scope is not validator output acceptance.
+
+Record scope is not receipt evidence acceptance.
+
+Record scope is not runtime implementation procedure.
+
+Record scope is not package loading authority.
+
+Record scope is not execution authority.
+
+Record scope is not source merge authority.
+
+## Current Phase Pointer Boundary
+
+The current phase pointer remains:
+
+```text
+CURRENT_PHASE=23
+```
+
+This record does not modify:
+
+```text
+docs/roadmap/CURRENT_PHASE
+```
+
+This record does not change the active phase pointer.
+
+`CURRENT_PHASE=23` does not authorize concrete accepted-evidence set
+membership assignment record status beyond this bounded record boundary,
+accepted-evidence set membership assignment, accepted-evidence set
+membership, accepted evidence, evidence item acceptance, validator output
+acceptance, receipt evidence acceptance, runtime implementation
+procedure, source modification, code implementation, code execution,
+process start, runtime state creation, package loading, package
+execution, capability issuance, registry publication, trust assignment,
+deployment, distribution, source acceptance, source merge, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+## Concrete Assignment Record Candidate Input
+
+This record consumes the clean-fixed Phase-23 Concrete Accepted-Evidence
+Set Membership Assignment Record Candidate as its exact governance
+prerequisite.
+
+The concrete accepted-evidence set membership assignment record candidate
+remains bound to:
+
+```text
+c20309a39c91d08dab1df3163a204ab80bc767a5
+```
+
+The concrete accepted-evidence set membership assignment record candidate
+recorded that it was not a concrete accepted-evidence set membership
+assignment record, not accepted-evidence set membership assignment, not
+accepted-evidence set membership, not accepted evidence, not evidence
+item acceptance, not validator output acceptance, not receipt evidence
+acceptance, not a decision, and not an authority grant.
+
+This record accepts only the later bounded concrete accepted-evidence set
+membership assignment record boundary after that candidate publication is
+clean-fixed.
+
+This record does not reinterpret the concrete record candidate as
+membership assignment, accepted-evidence set membership, accepted
+evidence, evidence item acceptance, validator output acceptance, receipt
+evidence acceptance, runtime implementation procedure, execution
+authority, package loading authority, source acceptance, source merge
+authority, capability issuance, registry publication, trust assignment,
+deployment, distribution, kernel ABI expansion, syscall expansion,
+workflow-threshold change, baseline change, dependency change, or Ring0
+authority.
+
+Any concrete accepted-evidence set membership assignment record-candidate
+conflict fails closed.
+
+## Relationship To Membership Assignment
+
+This record is not accepted-evidence set membership assignment unless a
+separate reviewed record explicitly grants that narrower authority.
+
+This record does not assign accepted-evidence set membership.
+
+This record does not define accepted-evidence set membership.
+
+This record does not make membership assignment inevitable.
+
+This record does not make accepted-evidence set membership inevitable.
+
+Any attempt to treat this record as accepted-evidence set membership
+assignment fails closed.
+
+## Relationship To Accepted Evidence And Evidence Item Acceptance
+
+Accepted-evidence set membership assignment remains separate from
+accepted evidence unless a separate reviewed decision explicitly grants
+that narrower authority.
+
+Accepted-evidence set membership remains separate from accepted evidence
+unless a separate reviewed decision explicitly grants that narrower
+authority.
+
+Evidence item acceptance remains separate from accepted evidence unless a
+separate reviewed decision explicitly grants that narrower authority.
+
+This record does not create accepted evidence.
+
+This record does not identify accepted evidence.
+
+This record does not accept any evidence item.
+
+This record does not define accepted-evidence membership.
+
+This record does not make accepted evidence inevitable.
+
+This record does not make evidence item acceptance inevitable.
+
+Any attempt to treat this record as accepted evidence or evidence item
+acceptance fails closed.
+
+## Relationship To Validator Output And Receipt Evidence
+
+This record consumes the clean-fixed Phase-23 Validator-Output Boundary
+Planning and Receipt-Evidence Boundary Planning records as exact
+governance prerequisites only.
+
+The Phase-23 Validator-Output Boundary Planning publication-status sync
+remains bound to:
+
+```text
+d225b2b5ffcd83fe12c70bf0150b60f8f288f329
+```
+
+The Phase-23 Receipt-Evidence Boundary Planning publication-status sync
+remains bound to:
+
+```text
+9153d858c8ca99b09beb2fa60c6c7bcc565445a9
+```
+
+This record does not convert validator output into accepted evidence.
+
+This record does not convert receipt evidence into accepted evidence.
+
+This record does not accept validator output.
+
+This record does not accept receipt evidence.
+
+This record does not grant membership assignment, accepted-evidence
+membership, or accepted-evidence status over validator output, receipt
+evidence, package review output, source review output, historical PASS
+results, or clean-fixed claims.
+
+Any validator-output or receipt-evidence boundary conflict fails closed.
+
+## Relationship To Phase-23 Accepted-Evidence Boundary Planning
+
+This record consumes the clean-fixed Phase-23 Accepted-Evidence Boundary
+Planning record and its clean-fixed publication-status sync as exact
+governance prerequisites.
+
+The Phase-23 Accepted-Evidence Boundary Planning publication-status sync
+remains bound to:
+
+```text
+40aba477d35902193fca9c75e4042ea1cf8539e5
+```
+
+The Phase-23 Accepted-Evidence Boundary Planning publication remains
+bound to:
+
+```text
+bc56d0baada3becdc3c820c4a5a167d7859abbbd
+```
+
+This record does not convert accepted-evidence boundary planning into
+membership assignment.
+
+This record does not convert accepted-evidence boundary planning into
+accepted-evidence set membership.
+
+This record does not convert accepted-evidence boundary planning into
+accepted evidence.
+
+This record does not broaden the accepted-evidence boundary planning
+record.
+
+Any accepted-evidence boundary planning conflict fails closed.
+
+## Relationship To Phase-23 Exact-SHA Evidence Expectation Boundary
+
+This record consumes the clean-fixed Phase-23 Exact-SHA Evidence
+Expectation Boundary and its clean-fixed publication-status sync as exact
+governance prerequisites.
+
+The Phase-23 Exact-SHA Evidence Expectation Boundary publication-status
+sync remains bound to:
+
+```text
+1c6148a7dd1655d6281cdc20489026871c6e3975
+```
+
+The Phase-23 Exact-SHA Evidence Expectation Boundary publication remains
+bound to:
+
+```text
+22f3f134eb9fd9a0da4d11f9b523ff6ea8c781a2
+```
+
+This record uses those expectations only as prerequisites for the bounded
+concrete accepted-evidence set membership assignment record boundary.
+
+This record does not convert exact-SHA expectations into membership
+assignment.
+
+This record does not convert exact-SHA expectations into accepted
+evidence.
+
+Any exact-SHA evidence expectation boundary conflict fails closed.
+
+## Relationship To Phase-23 Governance Overview And Initial Boundary
+
+This record consumes the clean-fixed Phase-23 Governance Overview,
+Phase-23 Initial Governance Boundary, and their publication-status syncs
+as exact governance prerequisites.
+
+The Phase-23 Governance Overview publication-status sync remains bound
+to:
+
+```text
+1c34b754a07d4eed1493a4b5d456bf870681362f
+```
+
+The Phase-23 Initial Governance Boundary publication-status sync remains
+bound to:
+
+```text
+97aab9383e76fcbdc1dfcf0c3520f7de9e0e7692
+```
+
+This record does not broaden the Phase-23 governance overview.
+
+This record does not broaden the Phase-23 initial governance boundary.
+
+Any overview or initial-boundary conflict fails closed.
+
+## Relationship To Phase-22 Closure
+
+This record consumes the Phase-22 Closure Decision and the Phase-22
+closure publication-status sync as exact governance prerequisites.
+
+The Phase-22 Closure Decision remains bound to:
+
+```text
+9b19c94a01170d105bd7a7e9fb198df05be17fdf
+```
+
+The latest Phase-22 closure publication-status sync remains bound to:
+
+```text
+6c0a0c878d54ebc6a768e1c708a68d7eb5898b15
+```
+
+Phase-22 remains closed only as:
+
+```text
+actual skeleton reviewed;
+static package acceptance boundary defined and clean-recovered;
+Phase-21 First Bounded Implementation actual skeleton exact 12-file set
+accepted as a static package subject only.
+```
+
+This record does not reopen Phase-22.
+
+This record does not reinterpret Phase-22 closure as a Phase-23
+membership assignment, accepted-evidence set membership, accepted
+evidence, evidence item acceptance, validator output acceptance, receipt
+evidence acceptance, runtime implementation procedure, package loading,
+package execution, source acceptance, source merge authority, capability
+issuance, registry publication, trust assignment, deployment,
+distribution, kernel ABI expansion, syscall expansion,
+workflow-threshold changes, baseline changes, dependency changes, or
+Ring0 authority.
+
+Any Phase-22 closure conflict fails closed.
+
+## Relationship To Phase-19 Runtime Authority
+
+This record remains subordinate to Phase-19 runtime authority records.
+
+This record must not broaden, replace, supersede, weaken, or reinterpret
+Phase-19 runtime authority records.
+
+This record must not use concrete assignment record boundary planning to
+infer runtime authority.
+
+This record must not use membership assignment planning to infer runtime
+authority.
+
+This record must not use accepted-evidence decision records to infer
+runtime authority.
+
+This record must not use validator-output planning to infer runtime
+authority.
+
+This record must not use receipt-evidence planning to infer runtime
+authority.
+
+This record must not use exact-SHA evidence expectations to infer runtime
+authority.
+
+This record must not use `CURRENT_PHASE=23` to infer runtime authority.
+
+Any Phase-23 concrete accepted-evidence set membership assignment record
+reading that conflicts with Phase-19 runtime authority records fails
+closed.
+
+## Not Authorized By This Record
+
+This record does not authorize:
+
+1. Accepted-evidence set membership assignment.
+2. Accepted-evidence set membership.
+3. Accepted-evidence set creation.
+4. Accepted evidence.
+5. Evidence item acceptance.
+6. Validator output acceptance.
+7. Receipt evidence acceptance.
+8. Runtime implementation procedure.
+9. Source modification.
+10. Source acceptance.
+11. Source merge.
+12. Code implementation.
+13. Code execution.
+14. Process start.
+15. Runtime state creation.
+16. Package installation.
+17. Package loading.
+18. Package execution.
+19. Module loading.
+20. Workspace runtime or real mounts.
+21. Plugin loading or plugin instantiation.
+22. Capability token minting.
+23. Capability issuance.
+24. Registry publication.
+25. Trust assignment.
+26. Distribution execution.
+27. Deployment.
+28. Semantic CLI authority.
+29. AI Runtime authority.
+30. Agent authority.
+31. Syscall expansion.
+32. Kernel ABI expansion.
+33. Ring0 policy movement.
+34. Workflow-threshold changes.
+35. Baseline changes.
+36. Dependency changes.
+37. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this record is published, the publication may change only this file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md
+```
+
+The publication must not change:
+
+1. `docs/roadmap/CURRENT_PHASE`.
+2. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+3. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+4. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+5. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+6. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`.
+7. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`.
+8. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`.
+9. `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`.
+10. `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`.
+11. `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`.
+12. `PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`.
+13. `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`.
+14. `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`.
+15. `PHASE23_ACCEPTED_EVIDENCE_DECISION.md`.
+16. `PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`.
+17. `PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`.
+18. `PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`.
+19. `PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`.
+20. `PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`.
+21. `PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`.
+22. `PHASE23_GOVERNANCE_OVERVIEW.md`.
+23. CI workflows.
+24. Baselines.
+25. Dependencies.
+26. Runtime source or kernel source.
+27. Syscalls or kernel ABI.
+28. Package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution paths.
+29. `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md`.
+
+Any changed-file expansion beyond this concrete record requires separate
+review and fails this record scope.
+
+## Post-Merge Exact-Main Evidence Rule
+
+If this record is later published, the record publication subject must
+receive its own post-merge exact-main verification:
+
+1. `ci-freeze` PASS for the exact record publication SHA.
+2. Dev Loop Validation PASS for the exact record publication SHA.
+3. AykenOS Dev Loop CI PASS for the exact record publication SHA.
+4. smoke PASS.
+5. contract PASS.
+6. full PASS.
+7. isolation PASS.
+8. performance PASS.
+9. Exact changed-file list confirmation.
+10. No `docs/roadmap/CURRENT_PHASE` change.
+11. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`
+    change.
+12. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`
+    change.
+13. No
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`
+    change.
+14. No
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`
+    change.
+15. No
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`
+    change.
+16. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md` change.
+17. No
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`
+    change.
+18. No `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md` change.
+19. No `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md` change.
+20. No `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md` change.
+21. No `PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md` change.
+22. No `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md` change.
+23. No `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`
+    change.
+24. No `PHASE23_ACCEPTED_EVIDENCE_DECISION.md` change.
+25. No `PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md` change.
+26. No `PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md` change.
+27. No `PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md` change.
+28. No `PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md` change.
+29. No `PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md` change.
+30. No `PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md` change.
+31. No `PHASE23_GOVERNANCE_OVERVIEW.md` change.
+32. No CI workflow change.
+33. No baseline change.
+34. No dependency change.
+35. No runtime source or kernel source change.
+36. No syscall or kernel ABI change.
+37. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution change.
+
+Until that exact-main post-merge verification exists, this record must
+not be recorded as clean-fixed.
+
+Historical PASS results may be cited as context only.
+
+Failed attempts may be cited as transparent non-clean context only.
+
+They cannot be inherited as accepted-evidence set membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime authority, package loading authority, package execution
+authority, source merge authority, capability authority, registry
+authority, trust authority, kernel ABI authority, syscall authority,
+workflow-threshold authority, baseline authority, dependency authority,
+or Ring0 authority.
+
+## Later Membership Assignment Dependency
+
+This record is a prerequisite input for a possible later bounded
+accepted-evidence set membership assignment record or membership
+assignment decision.
+
+A later accepted-evidence set membership assignment record, if ever
+proposed, must define:
+
+1. Exact accepted-evidence set membership assignment record subject.
+2. Exact Phase-23 concrete accepted-evidence set membership assignment
+   record prerequisite.
+3. Exact changed-file boundary.
+4. Exact accepted-evidence set membership assignment scope, if any.
+5. Exact accepted-evidence set membership being assigned, if any.
+6. Exact evidence item reference proposed for membership assignment, if
+   any, without evidence item acceptance unless separately reviewed.
+7. Exact evidence item acceptance denial or separate evidence item
+   acceptance scope.
+8. Exact accepted-evidence creation denial or separate accepted-evidence
+   scope.
+9. Exact validator-output acceptance denial or separate validator-output
+   acceptance scope.
+10. Exact receipt-evidence acceptance denial or separate receipt-evidence
+    acceptance scope.
+11. Exact runtime implementation procedure denial.
+12. Exact package loading and package execution denials.
+13. Exact source acceptance and source merge denials.
+14. Exact capability, registry, trust, deployment, distribution, kernel
+    ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+    denials.
+15. Exact post-merge verification requirements.
+
+Until such a later reviewed membership-assignment record is published, no
+accepted-evidence set membership assignment exists from this record.
+
+Until such a later reviewed accepted-evidence set membership record is
+published, no accepted-evidence set membership exists from this record.
+
+Until such a later reviewed evidence-item acceptance record is published,
+no evidence item acceptance exists from this record.
+
+Until such a later reviewed accepted-evidence record is published, no
+accepted evidence exists from this record.
+
+Until such a later reviewed validator-output acceptance record is
+published, no validator output acceptance exists from this record.
+
+Until such a later reviewed receipt-evidence acceptance record is
+published, no receipt evidence acceptance exists from this record.
+
+## Excluded Local Draft
+
+This record does not consume:
+
+```text
+PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md
+```
+
+If that file exists locally as an untracked file, it remains:
+
+```text
+untracked
+PR-disjoint
+not decision input
+not record input
+not concrete assignment record input
+not membership assignment input
+not accepted-evidence set membership
+not accepted evidence
+not evidence item acceptance
+not validator output
+not receipt evidence
+not source authority
+not package acceptance
+not runtime authority
+```
+
+It must not be staged, committed, or included in any Phase-23 concrete
+accepted-evidence set membership assignment record PR unless a separate
+reviewed scope explicitly authorizes that file.
+
+## Governance Boundary Invariants
+
+Every later RFC must preserve these Phase-23 concrete accepted-evidence
+set membership assignment record invariants:
+
+1. This record is bounded concrete accepted-evidence set membership
+   assignment record boundary only.
+2. This record is not accepted-evidence set membership assignment unless
+   separately reviewed.
+3. This record is not accepted-evidence set membership.
+4. This record is not an accepted-evidence set.
+5. This record is not accepted evidence.
+6. This record is not evidence item acceptance.
+7. This record is not validator output acceptance.
+8. This record is not receipt evidence acceptance.
+9. Concrete record publication is not membership assignment.
+10. Concrete assignment record is not accepted-evidence set membership
+    assignment unless separately reviewed.
+11. Membership assignment is not accepted-evidence set membership unless
+    separately reviewed.
+12. Membership assignment is not accepted evidence unless separately
+    reviewed.
+13. Membership assignment is not evidence item acceptance unless
+    separately reviewed.
+14. This record is not runtime implementation procedure.
+15. This record is not source modification.
+16. This record is not code implementation.
+17. This record is not code execution.
+18. This record is not process start.
+19. This record is not runtime state creation.
+20. This record is not package installation.
+21. This record is not package loading.
+22. This record is not package execution.
+23. This record is not capability issuance.
+24. This record is not registry publication.
+25. This record is not trust assignment.
+26. This record is not deployment.
+27. This record is not distribution authority.
+28. This record is not source acceptance.
+29. This record is not source merge authority.
+30. This record does not modify `docs/roadmap/CURRENT_PHASE`.
+31. This record does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+32. This record does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+33. This record does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+34. This record does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+35. This record does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`.
+36. This record does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`.
+37. This record does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`.
+38. This record does not modify `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`.
+39. This record does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`.
+40. This record does not modify `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`.
+41. This record does not modify
+    `PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`.
+42. This record does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`.
+43. This record does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`.
+44. This record does not modify `PHASE23_ACCEPTED_EVIDENCE_DECISION.md`.
+45. This record does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`.
+46. This record does not modify
+    `PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`.
+47. This record does not modify
+    `PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`.
+48. This record does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`.
+49. This record does not modify
+    `PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`.
+50. This record does not modify `PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`.
+51. This record does not modify `PHASE23_GOVERNANCE_OVERVIEW.md`.
+52. `CURRENT_PHASE=23` is not a concrete accepted-evidence set membership
+    assignment record beyond this bounded record boundary.
+53. `CURRENT_PHASE=23` is not accepted-evidence set membership
+    assignment.
+54. `CURRENT_PHASE=23` is not accepted-evidence set membership.
+55. `CURRENT_PHASE=23` is not an accepted-evidence set.
+56. `CURRENT_PHASE=23` is not accepted evidence.
+57. `CURRENT_PHASE=23` is not evidence item acceptance.
+58. `CURRENT_PHASE=23` is not validator output acceptance.
+59. `CURRENT_PHASE=23` is not receipt evidence acceptance.
+60. `CURRENT_PHASE=23` is not runtime implementation procedure.
+61. `CURRENT_PHASE=23` is not source modification.
+62. `CURRENT_PHASE=23` is not execution authority.
+63. `CURRENT_PHASE=23` is not package loading.
+64. `CURRENT_PHASE=23` is not source merge authority.
+65. This record does not broaden Phase-19 runtime authority.
+66. This record does not reopen Phase-20.
+67. This record does not reopen Phase-21.
+68. This record does not reopen Phase-22.
+69. This record does not expand kernel ABI or syscalls.
+70. This record does not change workflow thresholds, baselines, or
+    dependencies.
+71. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-23 concrete accepted-evidence set membership
+assignment record
+**Architecture status:** Local draft concrete accepted-evidence set
+membership assignment record / pending separate reviewed publication
+**Authority notice:** This signature identifies the architectural
+authorship of this record. It grants only the bounded concrete
+accepted-evidence set membership assignment record boundary defined in
+this record. It grants no accepted-evidence set membership assignment
+authority, accepted-evidence set membership status, accepted evidence
+status, evidence item acceptance authority, validator output acceptance
+authority, receipt evidence acceptance authority, runtime implementation
+procedure authority, source modification authority, code implementation
+authority, code execution authority, process start authority, general
+runtime authority, unbounded execution authority, runtime state
+authority, package installation authority, package loading authority,
+package execution authority, source merge authority, trust authority,
+registry authority, distribution authority, publication authority,
+capability issuance authority, deployment authority, module authority,
+plugin authority, Semantic CLI authority, AI Runtime authority, agent
+authority, kernel ABI authority, syscall authority, workflow-threshold
+authority, baseline authority, dependency authority, or Ring0 authority.
+
+## Conclusion
+
+This Phase-23 concrete accepted-evidence set membership assignment record
+is based on the clean-fixed Phase-23 Concrete Accepted-Evidence Set
+Membership Assignment Record Candidate publication subject:
+
+```text
+c20309a39c91d08dab1df3163a204ab80bc767a5
+```
+
+It accepts only the bounded concrete accepted-evidence set membership
+assignment record boundary.
+
+It does not assign accepted-evidence set membership.
+
+It does not define accepted-evidence set membership.
+
+It does not create an accepted-evidence set.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize accepted-evidence set membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime implementation procedure, source modification, code
+implementation, code execution, process start, runtime state creation,
+package installation, package loading, package execution, capability
+issuance, registry publication, trust assignment, deployment,
+distribution, source acceptance, source merge, kernel ABI expansion,
+syscall expansion, workflow-threshold changes, baseline changes,
+dependency changes, or Ring0 authority.
+
+Any later Phase-23 membership-assignment, membership, evidence-item,
+accepted-evidence, validator-output, receipt-evidence, package-review,
+source-review, runtime-implementation-procedure, or non-authorization
+boundary record requires its own exact-SHA evidence, changed-file scope,
+non-authorization boundary, and reviewed decision or record path.


### PR DESCRIPTION
This PR changes only PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md and accepts only a bounded concrete accepted-evidence set membership assignment record boundary.

It does not assign accepted-evidence set membership, create accepted evidence, accept any evidence item, accept validator output, accept receipt evidence, or authorize runtime/source/package/source-merge/capability/registry/trust/deployment/distribution/kernel ABI/syscall/workflow-threshold/baseline/dependency/Ring0 authority.

Validation:
- git diff --check
- git diff --cached --check before commit

Scope exclusions:
- docs/roadmap/CURRENT_PHASE unchanged
- PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md remains PR-disjoint