### PR TITLE
Phase-23 concrete accepted-evidence set membership assignment candidate

### DIFF
--- a/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md
+++ b/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md
@@ -1,0 +1,1006 @@
+# Phase-23 Concrete Accepted-Evidence Set Membership Assignment Candidate
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY_CLEAN_RECOVERY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_FIRST_BOUNDED_IMPLEMENTATION.md`,
+`PHASE22_CLOSURE_DECISION.md`,
+`PHASE23_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE23_POINTER_TRANSITION_DECISION.md`,
+`docs/roadmap/CURRENT_PHASE`,
+`PHASE23_GOVERNANCE_OVERVIEW.md`,
+`PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`,
+`PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`,
+`PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+and
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+In case of conflict, those documents prevail unless this document is the
+narrower Phase-23 concrete accepted-evidence set membership assignment
+candidate for the exact governance-only assignment-candidate scope
+identified below.
+
+**Status:** PHASE-23 CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT
+CANDIDATE / LOCAL DRAFT / GOVERNANCE-ONLY CONCRETE ACCEPTED-EVIDENCE SET
+MEMBERSHIP ASSIGNMENT CANDIDATE ONLY / NO CONCRETE ACCEPTED-EVIDENCE SET
+MEMBERSHIP ASSIGNMENT / NO ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT /
+NO ACCEPTED-EVIDENCE SET MEMBERSHIP / NO ACCEPTED-EVIDENCE SET / NO
+ACCEPTED EVIDENCE / NO EVIDENCE ITEM ACCEPTANCE / NO VALIDATOR OUTPUT
+ACCEPTANCE / NO RECEIPT EVIDENCE ACCEPTANCE / NO RUNTIME IMPLEMENTATION
+PROCEDURE / NO SOURCE MODIFICATION / NO CODE IMPLEMENTATION / NO CODE
+EXECUTION / NO PROCESS START / NO RUNTIME STATE CREATION / NO PACKAGE
+INSTALLATION / NO PACKAGE LOADING / NO PACKAGE EXECUTION / NO DEPLOYMENT /
+NO CAPABILITY ISSUANCE / NO TRUST ASSIGNMENT / NO REGISTRY PUBLICATION /
+NO DISTRIBUTION AUTHORITY / NO SOURCE ACCEPTANCE / NO SOURCE MERGE
+AUTHORITY / NO KERNEL ABI EXPANSION / NO SYSCALL EXPANSION / NO
+WORKFLOW-THRESHOLD CHANGE / NO BASELINE CHANGE / NO DEPENDENCY CHANGE /
+NO RING0 AUTHORITY
+**Candidate date:** 2026-07-17
+**Candidate id:**
+`ayken.phase23.concrete_accepted_evidence_set_membership_assignment_candidate.v1`
+**Candidate drafting base main SHA:**
+`1d2ec43580e3c919b995365bdb058b852f6b3450`
+**Candidate publication subject:** pending separate reviewed publication
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record publication subject:** `1d2ec43580e3c919b995365bdb058b852f6b3450`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record PR:** PR #282
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record exact-main ci-freeze run:** `29599197808`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record exact-main ci-freeze attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record exact-main ci-freeze job:** `freeze / 87946940337`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record exact-main ci-freeze result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record exact-main Dev Loop Validation run:** `29599197789`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record exact-main Dev Loop Validation attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record exact-main Dev Loop Validation job:** `devloop / 87946940024`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record exact-main Dev Loop Validation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record exact-main Dev Loop CI run:** `29599197962`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record exact-main Dev Loop CI attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record exact-main Dev Loop CI result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record exact-main smoke job:** `smoke / 87946940722`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record exact-main smoke result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record exact-main contract job:** `contract / 87947238876`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record exact-main contract result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record exact-main full job:** `full / 87947719679`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record exact-main full result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record exact-main isolation job:** `isolation / 87948236576`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record exact-main isolation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record exact-main performance job:** `performance / 87948698184`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+record exact-main performance result:** PASS
+**Phase-23 concrete accepted-evidence set membership assignment record
+publication subject:** `1d2ec43580e3c919b995365bdb058b852f6b3450`
+**Phase-23 concrete accepted-evidence set membership assignment record
+candidate publication subject:** `c20309a39c91d08dab1df3163a204ab80bc767a5`
+**Phase-23 accepted-evidence set membership assignment record publication
+subject:** `91a24c007276f1ff8804f6b92bda052f4c16bb2c`
+**Phase-23 accepted-evidence set membership assignment record candidate
+publication subject:** `5805d1187a7b29aec28097d0383f2166c7e508dd`
+**Phase-23 accepted-evidence set membership assignment decision
+publication subject:** `f60e093a53865fb2e03ce3ded375ed7bace763e5`
+**Phase-23 accepted-evidence set membership assignment decision candidate
+publication subject:** `3c8cdfa992ae1c94098b75b7b6064bf8bd40c184`
+**Phase-23 accepted-evidence set membership decision publication
+subject:** `6f8326a895ebdd3e07b4dc73d8be849bfe0df7fc`
+**Phase-23 accepted-evidence set membership decision candidate publication
+subject:** `ac05e74885f85f2d0bed540d66b9c80059086c5d`
+**Phase-23 accepted-evidence set decision publication-status sync
+subject:** `1e6c2e1af515a57ef2be910dbf6aa61d5fc081ff`
+**Phase-23 accepted-evidence set decision publication subject:**
+`a39cec2fcdc03c43a6a97de27cad0e16085b17c8`
+**Phase-23 accepted-evidence set decision candidate publication subject:**
+`206d1a9aff8ba3dd2aaa4a0e258315d5c92379cd`
+**Phase-23 evidence acceptance decision publication subject:**
+`1fe089b141af09e9f98be2a153589e68ab015c18`
+**Phase-23 evidence acceptance decision candidate publication subject:**
+`7d90f2c195afecfb4875876f1ea832df3d9b6528`
+**Phase-23 accepted-evidence authority decision publication subject:**
+`d9ac910c24601002971e7d06cf94463d739b1358`
+**Phase-23 accepted-evidence authority decision candidate publication
+subject:** `72d5234654a5af4fa84b52f3ba3753b9104a4dce`
+**Phase-23 accepted-evidence decision publication subject:**
+`0f6da8e9abe8d354e98c5243b3300cf9a75f697a`
+**Phase-23 accepted-evidence decision candidate publication subject:**
+`a895f3ae5eeebe5848e52a1d75874b0b75518137`
+**Phase-23 validator-output boundary planning publication-status sync
+subject:** `d225b2b5ffcd83fe12c70bf0150b60f8f288f329`
+**Phase-23 validator-output boundary planning publication subject:**
+`08585f64b6088ed9f76a8027daecec6dc70da885`
+**Phase-23 receipt-evidence boundary planning publication-status sync
+subject:** `9153d858c8ca99b09beb2fa60c6c7bcc565445a9`
+**Phase-23 receipt-evidence boundary planning publication subject:**
+`e6d21b2bfabfd9658a748d69fddcede3d88af401`
+**Phase-23 accepted-evidence boundary planning publication-status sync
+subject:** `40aba477d35902193fca9c75e4042ea1cf8539e5`
+**Phase-23 accepted-evidence boundary planning publication subject:**
+`bc56d0baada3becdc3c820c4a5a167d7859abbbd`
+**Phase-23 exact-SHA evidence expectation boundary publication-status
+sync subject:** `1c6148a7dd1655d6281cdc20489026871c6e3975`
+**Phase-23 exact-SHA evidence expectation boundary publication subject:**
+`22f3f134eb9fd9a0da4d11f9b523ff6ea8c781a2`
+**Phase-23 initial governance boundary publication-status sync subject:**
+`97aab9383e76fcbdc1dfcf0c3520f7de9e0e7692`
+**Phase-23 initial governance boundary publication subject:**
+`3db9a2e740a414b040daa30ee70a54850fdbeb1f`
+**Phase-23 governance overview publication-status sync subject:**
+`1c34b754a07d4eed1493a4b5d456bf870681362f`
+**Phase-23 governance overview publication subject:**
+`bfd4b07d5332f16b5d0295f3170f795629ca7ca8`
+**Phase-23 current phase pointer update subject:**
+`9b70ee20707023709e906d0200a80a1ac69fa698`
+**Phase-23 pointer transition decision subject:**
+`16ac421a40ce93641ccccc28fb5ad869f2b8984e`
+**Phase-23 pointer transition candidate subject:**
+`77fd954607ad076cdea888047f19e4fed60bfb65`
+**Phase-22 closure publication-status sync subject:**
+`6c0a0c878d54ebc6a768e1c708a68d7eb5898b15`
+**Phase-22 closure decision publication subject:**
+`9b19c94a01170d105bd7a7e9fb198df05be17fdf`
+**Current phase pointer:** `CURRENT_PHASE=23`
+**Candidate theme:** Governance-only candidate boundary for whether a
+later concrete accepted-evidence set membership assignment path may be
+evaluated after the bounded concrete assignment record boundary exists.
+**Authority boundary:** Concrete accepted-evidence set membership
+assignment candidate only; not concrete accepted-evidence set membership
+assignment, not accepted-evidence set membership assignment, not
+accepted-evidence set membership, not an accepted-evidence set, not
+accepted evidence, not evidence item acceptance, not validator output
+acceptance, not receipt evidence acceptance, not runtime implementation
+procedure, not source modification, not code implementation, not code
+execution, not process start, not runtime state creation, not general
+runtime authority, not unbounded execution authority, not package
+authority, not package installation, not package loading, not package
+execution, not source acceptance, not source merge authority, not source
+repository authority, not module loading, not workspace runtime, not
+plugin loading, not capability token minting, not capability issuance,
+not trust assignment, not trust issuer authority, not registry
+authority, not registry publication, not publication authority, not
+deployment authority, not distribution authority, not distribution
+execution, not Semantic CLI authority, not AI Runtime authority, not
+agent authority, not syscall expansion, not kernel ABI expansion, not
+workflow-threshold, baseline, dependency, or Ring0 authority.
+
+## Purpose
+
+This document records a Phase-23 governance-only concrete
+accepted-evidence set membership assignment candidate after the
+clean-fixed Phase-23 Concrete Accepted-Evidence Set Membership Assignment
+Record publication.
+
+It answers only:
+
+```text
+May a concrete accepted-evidence set membership assignment path be
+evaluated during Phase-23 without assigning membership, accepting any
+evidence item, or creating accepted evidence?
+```
+
+It maps only the fail-closed candidate prerequisites for that future
+concrete membership-assignment path.
+
+It does not assign accepted-evidence set membership.
+
+It does not create accepted-evidence set membership.
+
+It does not create an accepted-evidence set.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not convert CI PASS results, receipts, validator output, package
+review output, source review output, historical results, concrete record
+boundaries, or clean-fixed claims into membership assignment, accepted
+evidence, or evidence item acceptance.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, source acceptance, source merge, registry publication, trust
+assignment, capability issuance, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Those questions require later reviewed decision or record paths, if ever
+authorized.
+
+## Exact Subject
+
+This assignment candidate is based on exact main SHA:
+
+```text
+1d2ec43580e3c919b995365bdb058b852f6b3450
+```
+
+That subject is the squash merge of PR #282:
+
+```text
+Phase-23 concrete accepted-evidence set membership assignment record
+```
+
+PR #282 changed only:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md
+```
+
+PR #282 produced post-merge exact-main verification:
+
+| Evidence | Run / job | Result |
+|---|---|---|
+| `ci-freeze` | run `29599197808`, attempt 1, job `freeze / 87946940337` | PASS |
+| Dev Loop Validation | run `29599197789`, attempt 1, job `devloop / 87946940024` | PASS |
+| AykenOS Dev Loop CI | run `29599197962`, attempt 1 | PASS |
+| smoke | job `87946940722` | PASS |
+| contract | job `87947238876` | PASS |
+| full | job `87947719679` | PASS |
+| isolation | job `87948236576` | PASS |
+| performance | job `87948698184` | PASS |
+
+The Phase-23 Concrete Accepted-Evidence Set Membership Assignment Record
+remains bound to:
+
+```text
+1d2ec43580e3c919b995365bdb058b852f6b3450
+```
+
+That record accepted only a bounded concrete accepted-evidence set
+membership assignment record boundary.
+
+That record did not assign accepted-evidence set membership.
+
+That record did not create accepted-evidence set membership.
+
+That record did not create accepted evidence.
+
+That record did not accept any evidence item.
+
+That record did not accept validator output.
+
+That record did not accept receipt evidence.
+
+This candidate consumes that exact subject as governance input only. It
+does not replace, broaden, reinterpret, or supersede the concrete
+assignment record or any earlier Phase-23 governance boundary.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped subject readings fail closed.
+
+## Core Rule
+
+```text
+concrete accepted-evidence set membership assignment candidate != concrete accepted-evidence set membership assignment
+concrete accepted-evidence set membership assignment candidate != accepted-evidence set membership assignment
+concrete accepted-evidence set membership assignment candidate != accepted-evidence set membership
+concrete accepted-evidence set membership assignment candidate != accepted-evidence set
+concrete accepted-evidence set membership assignment candidate != accepted evidence
+concrete accepted-evidence set membership assignment candidate != evidence item acceptance
+concrete accepted-evidence set membership assignment candidate != validator output acceptance
+concrete accepted-evidence set membership assignment candidate != receipt evidence acceptance
+concrete accepted-evidence set membership assignment candidate != runtime implementation procedure
+concrete accepted-evidence set membership assignment candidate != source modification
+concrete accepted-evidence set membership assignment candidate != package loading
+concrete accepted-evidence set membership assignment candidate != package execution
+concrete accepted-evidence set membership assignment candidate != source acceptance
+concrete accepted-evidence set membership assignment candidate != source merge
+concrete accepted-evidence set membership assignment candidate != decision
+concrete accepted-evidence set membership assignment candidate != authority grant
+assignment candidate != assignment
+assignment candidate != membership assignment
+assignment candidate != accepted-evidence set membership
+assignment candidate != accepted evidence
+assignment candidate != evidence item acceptance
+assignment candidate != validator output acceptance
+assignment candidate != receipt evidence acceptance
+concrete assignment record boundary != concrete assignment
+concrete assignment record boundary != membership assignment
+concrete record publication != membership assignment
+concrete assignment candidate publication != concrete assignment
+accepted-evidence set membership assignment != accepted-evidence set membership unless separately reviewed
+accepted-evidence set membership assignment != accepted evidence unless separately reviewed
+accepted-evidence set membership assignment != evidence item acceptance unless separately reviewed
+accepted-evidence set membership != accepted evidence unless separately reviewed
+accepted-evidence set membership != evidence item acceptance unless separately reviewed
+accepted-evidence set != accepted evidence unless separately reviewed
+accepted evidence != validator output unless separately reviewed
+accepted evidence != receipt evidence unless separately reviewed
+validator output != accepted evidence
+receipt evidence != accepted evidence
+receipt evidence != validator output
+CI PASS != concrete accepted-evidence set membership assignment
+CI PASS != accepted-evidence set membership assignment
+CI PASS != accepted-evidence set membership
+CI PASS != accepted evidence
+ci-freeze PASS != concrete accepted-evidence set membership assignment
+ci-freeze PASS != accepted-evidence set membership assignment
+ci-freeze PASS != accepted-evidence set membership
+ci-freeze PASS != accepted evidence
+Dev Loop PASS != concrete accepted-evidence set membership assignment
+Dev Loop PASS != accepted-evidence set membership assignment
+Dev Loop PASS != accepted-evidence set membership
+Dev Loop PASS != accepted evidence
+AykenOS Dev Loop CI PASS != concrete accepted-evidence set membership assignment
+AykenOS Dev Loop CI PASS != accepted-evidence set membership assignment
+AykenOS Dev Loop CI PASS != accepted-evidence set membership
+AykenOS Dev Loop CI PASS != accepted evidence
+post-merge exact-main verification != concrete accepted-evidence set membership assignment
+post-merge exact-main verification != accepted-evidence set membership assignment
+post-merge exact-main verification != accepted-evidence set membership
+post-merge exact-main verification != accepted evidence
+clean-fixed != concrete accepted-evidence set membership assignment
+clean-fixed != accepted-evidence set membership assignment
+clean-fixed != accepted-evidence set membership
+clean-fixed != accepted evidence
+CURRENT_PHASE=23 != concrete accepted-evidence set membership assignment
+CURRENT_PHASE=23 != accepted-evidence set membership assignment
+CURRENT_PHASE=23 != accepted-evidence set membership
+CURRENT_PHASE=23 != accepted evidence
+CURRENT_PHASE=23 != evidence item acceptance
+CURRENT_PHASE=23 != validator output acceptance
+CURRENT_PHASE=23 != receipt evidence acceptance
+CURRENT_PHASE=23 != runtime implementation procedure
+CURRENT_PHASE=23 != source modification
+CURRENT_PHASE=23 != execution authority
+CURRENT_PHASE=23 != package loading
+CURRENT_PHASE=23 != source merge authority
+historical PASS != inherited evidence
+previous PR evidence != later PR evidence
+```
+
+The safe default remains no concrete accepted-evidence set membership
+assignment, no accepted-evidence set membership assignment, no
+accepted-evidence set membership, no accepted evidence, no evidence item
+acceptance, no validator output acceptance, no receipt evidence
+acceptance, no runtime behavior, no implementation procedure, no source
+modification, no code execution, no runtime state, and no package,
+capability, registry, trust, distribution, deployment, source
+acceptance, source merge, kernel ABI, syscall, workflow-threshold,
+baseline, dependency, or Ring0 authority unless a later reviewed Phase-23
+decision or record grants a specific bounded authority with its own
+exact-SHA evidence.
+
+Unknown authority readings fail closed.
+
+## Assignment Candidate Boundary
+
+This candidate may be used only to evaluate whether a later concrete
+accepted-evidence set membership assignment path can be reviewed.
+
+The only later-evaluable boundary is:
+
+```text
+bounded concrete accepted-evidence set membership assignment path as a
+future reviewed decision or record
+```
+
+This candidate does not assign membership.
+
+This candidate does not create accepted-evidence set membership.
+
+This candidate does not identify any evidence item as accepted evidence.
+
+This candidate does not accept any evidence item.
+
+This candidate does not accept validator output.
+
+This candidate does not accept receipt evidence.
+
+This candidate does not make a later membership assignment inevitable.
+
+Any later concrete assignment decision or record requires a separate
+reviewed decision path with its own exact subject, changed-file scope,
+non-authorization boundary, and post-merge exact-main verification.
+
+## Candidate Scope
+
+This candidate scope is limited to:
+
+1. Mapping concrete accepted-evidence set membership assignment as a
+   later candidate topic.
+2. Binding this candidate to PR #282 as the clean-fixed concrete
+   assignment record-boundary input.
+3. Preserving the distinction between assignment candidate and assignment.
+4. Preserving the distinction between assignment and accepted-evidence
+   set membership.
+5. Preserving the distinction between membership assignment, accepted
+   evidence, and evidence item acceptance.
+6. Preserving separation from validator output acceptance and receipt
+   evidence acceptance.
+7. Establishing post-merge exact-main verification expectations for this
+   assignment-candidate record.
+
+Candidate scope is governance text only.
+
+Candidate scope is candidate-only.
+
+Candidate scope is not concrete accepted-evidence set membership
+assignment.
+
+Candidate scope is not accepted-evidence set membership assignment.
+
+Candidate scope is not accepted-evidence set membership.
+
+Candidate scope is not accepted evidence.
+
+Candidate scope is not evidence item acceptance.
+
+Candidate scope is not validator output acceptance.
+
+Candidate scope is not receipt evidence acceptance.
+
+Candidate scope is not runtime implementation procedure.
+
+Candidate scope is not package loading authority.
+
+Candidate scope is not execution authority.
+
+Candidate scope is not source merge authority.
+
+## Current Phase Pointer Boundary
+
+The current phase pointer remains:
+
+```text
+CURRENT_PHASE=23
+```
+
+This candidate does not modify:
+
+```text
+docs/roadmap/CURRENT_PHASE
+```
+
+This candidate does not change the active phase pointer.
+
+`CURRENT_PHASE=23` does not authorize concrete accepted-evidence set
+membership assignment, accepted-evidence set membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime implementation procedure, source modification, code
+implementation, code execution, process start, runtime state creation,
+package loading, package execution, capability issuance, registry
+publication, trust assignment, deployment, distribution, source
+acceptance, source merge, kernel ABI expansion, syscall expansion,
+workflow-threshold changes, baseline changes, dependency changes, or
+Ring0 authority.
+
+## Concrete Assignment Record Input
+
+This candidate consumes the clean-fixed Phase-23 Concrete
+Accepted-Evidence Set Membership Assignment Record as its exact
+governance prerequisite.
+
+The concrete assignment record remains bound to:
+
+```text
+1d2ec43580e3c919b995365bdb058b852f6b3450
+```
+
+The concrete assignment record accepted only a bounded concrete
+accepted-evidence set membership assignment record boundary.
+
+This candidate does not reinterpret that record boundary as concrete
+accepted-evidence set membership assignment, accepted-evidence set
+membership assignment, accepted-evidence set membership, accepted
+evidence, evidence item acceptance, validator output acceptance, receipt
+evidence acceptance, runtime implementation procedure, execution
+authority, package loading authority, source acceptance, source merge
+authority, capability issuance, registry publication, trust assignment,
+deployment, distribution, kernel ABI expansion, syscall expansion,
+workflow-threshold change, baseline change, dependency change, or Ring0
+authority.
+
+Any concrete assignment record conflict fails closed.
+
+## Relationship To Accepted Evidence And Evidence Item Acceptance
+
+Concrete accepted-evidence set membership assignment remains separate
+from accepted evidence unless a separate reviewed decision explicitly
+grants that narrower authority.
+
+Concrete accepted-evidence set membership assignment remains separate
+from evidence item acceptance unless a separate reviewed decision
+explicitly grants that narrower authority.
+
+This candidate does not create accepted evidence.
+
+This candidate does not identify accepted evidence.
+
+This candidate does not accept any evidence item.
+
+This candidate does not define accepted-evidence membership.
+
+This candidate does not make accepted evidence inevitable.
+
+This candidate does not make evidence item acceptance inevitable.
+
+Any attempt to treat this candidate as accepted evidence or evidence item
+acceptance fails closed.
+
+## Relationship To Validator Output And Receipt Evidence
+
+This candidate consumes the clean-fixed Phase-23 Validator-Output
+Boundary Planning and Receipt-Evidence Boundary Planning records as exact
+governance prerequisites only.
+
+The Phase-23 Validator-Output Boundary Planning publication-status sync
+remains bound to:
+
+```text
+d225b2b5ffcd83fe12c70bf0150b60f8f288f329
+```
+
+The Phase-23 Receipt-Evidence Boundary Planning publication-status sync
+remains bound to:
+
+```text
+9153d858c8ca99b09beb2fa60c6c7bcc565445a9
+```
+
+This candidate does not convert validator output into accepted evidence.
+
+This candidate does not convert receipt evidence into accepted evidence.
+
+This candidate does not accept validator output.
+
+This candidate does not accept receipt evidence.
+
+This candidate does not grant membership assignment over validator
+output, receipt evidence, package review output, source review output,
+historical PASS results, or clean-fixed claims.
+
+Any validator-output or receipt-evidence boundary conflict fails closed.
+
+## Relationship To Phase-19 Runtime Authority
+
+This candidate remains subordinate to Phase-19 runtime authority records.
+
+This candidate must not broaden, replace, supersede, weaken, or
+reinterpret Phase-19 runtime authority records.
+
+This candidate must not use concrete membership-assignment candidate
+planning to infer runtime authority.
+
+This candidate must not use accepted-evidence set membership assignment
+records to infer runtime authority.
+
+This candidate must not use accepted-evidence authority to infer runtime
+authority.
+
+This candidate must not use validator-output planning to infer runtime
+authority.
+
+This candidate must not use receipt-evidence planning to infer runtime
+authority.
+
+This candidate must not use exact-SHA evidence expectations to infer
+runtime authority.
+
+This candidate must not use `CURRENT_PHASE=23` to infer runtime
+authority.
+
+Any Phase-23 concrete assignment candidate reading that conflicts with
+Phase-19 runtime authority records fails closed.
+
+## Not Authorized By This Candidate
+
+This candidate does not authorize:
+
+1. Concrete accepted-evidence set membership assignment.
+2. Accepted-evidence set membership assignment.
+3. Accepted-evidence set membership.
+4. Accepted-evidence set creation.
+5. Accepted evidence.
+6. Evidence item acceptance.
+7. Validator output acceptance.
+8. Receipt evidence acceptance.
+9. Runtime implementation procedure.
+10. Source modification.
+11. Source acceptance.
+12. Source merge.
+13. Code implementation.
+14. Code execution.
+15. Process start.
+16. Runtime state creation.
+17. Package installation.
+18. Package loading.
+19. Package execution.
+20. Module loading.
+21. Workspace runtime or real mounts.
+22. Plugin loading or plugin instantiation.
+23. Capability token minting.
+24. Capability issuance.
+25. Registry publication.
+26. Trust assignment.
+27. Distribution execution.
+28. Deployment.
+29. Semantic CLI authority.
+30. AI Runtime authority.
+31. Agent authority.
+32. Syscall expansion.
+33. Kernel ABI expansion.
+34. Ring0 policy movement.
+35. Workflow-threshold changes.
+36. Baseline changes.
+37. Dependency changes.
+38. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this candidate is published, the publication may change only this
+file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md
+```
+
+The publication must not change:
+
+1. `docs/roadmap/CURRENT_PHASE`.
+2. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+3. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+4. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+5. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+6. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+7. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`.
+8. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`.
+9. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`.
+10. `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`.
+11. `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`.
+12. `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`.
+13. `PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`.
+14. `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`.
+15. `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`.
+16. `PHASE23_ACCEPTED_EVIDENCE_DECISION.md`.
+17. `PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`.
+18. `PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`.
+19. `PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`.
+20. `PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`.
+21. `PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`.
+22. `PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`.
+23. `PHASE23_GOVERNANCE_OVERVIEW.md`.
+24. CI workflows.
+25. Baselines.
+26. Dependencies.
+27. Runtime source or kernel source.
+28. Syscalls or kernel ABI.
+29. Package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment,
+    or distribution execution paths.
+30. `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md`.
+
+Any changed-file expansion beyond this candidate requires separate
+review and fails this candidate scope.
+
+## Post-Merge Exact-Main Evidence Rule
+
+If this candidate is later published, the candidate publication subject
+must receive its own post-merge exact-main verification:
+
+1. `ci-freeze` PASS for the exact candidate publication SHA.
+2. Dev Loop Validation PASS for the exact candidate publication SHA.
+3. AykenOS Dev Loop CI PASS for the exact candidate publication SHA.
+4. smoke PASS.
+5. contract PASS.
+6. full PASS.
+7. isolation PASS.
+8. performance PASS.
+9. Exact changed-file list confirmation.
+10. No `docs/roadmap/CURRENT_PHASE` change.
+11. No `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`
+    change.
+12. No `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`
+    change.
+13. No prior Phase-23 accepted-evidence, membership, assignment,
+    validator-output, or receipt-evidence record change.
+14. No CI workflow change.
+15. No baseline change.
+16. No dependency change.
+17. No runtime source or kernel source change.
+18. No syscall or kernel ABI change.
+19. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution change.
+
+Until that exact-main post-merge verification exists, this candidate
+must not be recorded as clean-fixed.
+
+Historical PASS results may be cited as context only.
+
+Failed attempts may be cited as transparent non-clean context only.
+
+They cannot be inherited as concrete accepted-evidence set membership
+assignment, accepted-evidence set membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime authority, package loading authority, package execution
+authority, source merge authority, capability authority, registry
+authority, trust authority, kernel ABI authority, syscall authority,
+workflow-threshold authority, baseline authority, dependency authority,
+or Ring0 authority.
+
+## Later Concrete Assignment Dependency
+
+This candidate is a prerequisite input for a possible later bounded
+concrete accepted-evidence set membership assignment decision or record.
+
+A later concrete accepted-evidence set membership assignment record, if
+ever proposed, must define:
+
+1. Exact concrete accepted-evidence set membership assignment decision or
+   record subject, if any.
+2. Exact Phase-23 concrete assignment candidate prerequisite.
+3. Exact changed-file boundary.
+4. Exact accepted-evidence set membership assignment scope, if any.
+5. Exact accepted-evidence set membership being assigned, if any.
+6. Exact evidence item reference proposed for membership assignment, if
+   any, without evidence item acceptance unless separately reviewed.
+7. Exact evidence item acceptance denial or separate evidence item
+   acceptance scope.
+8. Exact accepted-evidence creation denial or separate accepted-evidence
+   scope.
+9. Exact validator-output acceptance denial or separate validator-output
+   acceptance scope.
+10. Exact receipt-evidence acceptance denial or separate receipt-evidence
+    acceptance scope.
+11. Exact runtime implementation procedure denial.
+12. Exact package loading and package execution denials.
+13. Exact source acceptance and source merge denials.
+14. Exact capability, registry, trust, deployment, distribution, kernel
+    ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+    denials.
+15. Exact post-merge verification requirements.
+
+Until such a later reviewed membership-assignment record is published, no
+concrete accepted-evidence set membership assignment exists from this
+candidate.
+
+Until such a later reviewed accepted-evidence set membership record is
+published, no accepted-evidence set membership exists from this
+candidate.
+
+Until such a later reviewed evidence-item acceptance record is published,
+no evidence item acceptance exists from this candidate.
+
+Until such a later reviewed accepted-evidence record is published, no
+accepted evidence exists from this candidate.
+
+Until such a later reviewed validator-output acceptance record is
+published, no validator output acceptance exists from this candidate.
+
+Until such a later reviewed receipt-evidence acceptance record is
+published, no receipt evidence acceptance exists from this candidate.
+
+## Excluded Local Draft
+
+This candidate does not consume:
+
+```text
+PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md
+```
+
+If that file exists locally as an untracked file, it remains:
+
+```text
+untracked
+PR-disjoint
+not candidate input
+not decision input
+not record input
+not assignment input
+not evidence input
+not accepted-evidence set membership assignment
+not accepted-evidence set membership
+not accepted evidence
+not evidence item acceptance
+not validator output
+not receipt evidence
+not source authority
+not package acceptance
+not runtime authority
+```
+
+It must not be staged, committed, or included in any Phase-23 concrete
+accepted-evidence set membership assignment candidate PR unless a
+separate reviewed scope explicitly authorizes that file.
+
+## Governance Boundary Invariants
+
+Every later RFC must preserve these Phase-23 concrete assignment
+candidate invariants:
+
+1. This candidate is candidate-only.
+2. This candidate is not a decision.
+3. This candidate is not an authority grant.
+4. This candidate is not concrete accepted-evidence set membership
+   assignment.
+5. This candidate is not accepted-evidence set membership assignment.
+6. This candidate is not accepted-evidence set membership.
+7. This candidate is not an accepted-evidence set.
+8. This candidate is not accepted evidence.
+9. This candidate is not evidence item acceptance.
+10. This candidate is not validator output acceptance.
+11. This candidate is not receipt evidence acceptance.
+12. Concrete assignment record boundary is not membership assignment.
+13. Membership assignment is not accepted-evidence set membership unless
+    separately reviewed.
+14. Membership assignment is not accepted evidence unless separately
+    reviewed.
+15. Membership assignment is not evidence item acceptance unless
+    separately reviewed.
+16. This candidate is not runtime implementation procedure.
+17. This candidate is not source modification.
+18. This candidate is not code implementation.
+19. This candidate is not code execution.
+20. This candidate is not process start.
+21. This candidate is not runtime state creation.
+22. This candidate is not package installation.
+23. This candidate is not package loading.
+24. This candidate is not package execution.
+25. This candidate is not capability issuance.
+26. This candidate is not registry publication.
+27. This candidate is not trust assignment.
+28. This candidate is not deployment.
+29. This candidate is not distribution authority.
+30. This candidate is not source acceptance.
+31. This candidate is not source merge authority.
+32. This candidate does not modify `docs/roadmap/CURRENT_PHASE`.
+33. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+34. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+35. This candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+36. This candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+37. This candidate does not modify prior Phase-23 accepted-evidence,
+    membership, assignment, validator-output, or receipt-evidence
+    records.
+38. `CURRENT_PHASE=23` is not concrete accepted-evidence set membership
+    assignment.
+39. `CURRENT_PHASE=23` is not accepted-evidence set membership
+    assignment.
+40. `CURRENT_PHASE=23` is not accepted-evidence set membership.
+41. `CURRENT_PHASE=23` is not accepted evidence.
+42. `CURRENT_PHASE=23` is not evidence item acceptance.
+43. `CURRENT_PHASE=23` is not validator output acceptance.
+44. `CURRENT_PHASE=23` is not receipt evidence acceptance.
+45. `CURRENT_PHASE=23` is not runtime implementation procedure.
+46. `CURRENT_PHASE=23` is not source modification.
+47. `CURRENT_PHASE=23` is not execution authority.
+48. `CURRENT_PHASE=23` is not package loading.
+49. `CURRENT_PHASE=23` is not source merge authority.
+50. This candidate does not broaden Phase-19 runtime authority.
+51. This candidate does not reopen Phase-20.
+52. This candidate does not reopen Phase-21.
+53. This candidate does not reopen Phase-22.
+54. This candidate does not expand kernel ABI or syscalls.
+55. This candidate does not change workflow thresholds, baselines, or
+    dependencies.
+56. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-23 concrete accepted-evidence set membership
+assignment candidate
+**Architecture status:** Local draft concrete accepted-evidence set
+membership assignment candidate / pending separate reviewed publication
+**Authority notice:** This signature identifies the architectural
+authorship of this candidate. It grants no concrete accepted-evidence set
+membership assignment authority, accepted-evidence set membership
+assignment authority, accepted-evidence set membership status, accepted
+evidence status, evidence item acceptance authority, validator output
+acceptance authority, receipt evidence acceptance authority, runtime
+implementation procedure authority, source modification authority, code
+implementation authority, code execution authority, process start
+authority, general runtime authority, unbounded execution authority,
+runtime state authority, package installation authority, package loading
+authority, package execution authority, source merge authority, trust
+authority, registry authority, distribution authority, publication
+authority, capability issuance authority, deployment authority, module
+authority, plugin authority, Semantic CLI authority, AI Runtime
+authority, agent authority, kernel ABI authority, syscall authority,
+workflow-threshold authority, baseline authority, dependency authority,
+or Ring0 authority.
+
+## Conclusion
+
+This Phase-23 concrete accepted-evidence set membership assignment
+candidate is based on the clean-fixed Phase-23 Concrete
+Accepted-Evidence Set Membership Assignment Record publication subject:
+
+```text
+1d2ec43580e3c919b995365bdb058b852f6b3450
+```
+
+It defines only the governance-only candidate boundary for whether a
+later concrete accepted-evidence set membership assignment path may be
+evaluated after the bounded concrete assignment record boundary exists.
+
+It does not assign accepted-evidence set membership.
+
+It does not create accepted-evidence set membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize accepted-evidence set membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime implementation procedure, source modification, code
+implementation, code execution, process start, runtime state creation,
+package installation, package loading, package execution, capability
+issuance, registry publication, trust assignment, deployment,
+distribution, source acceptance, source merge, kernel ABI expansion,
+syscall expansion, workflow-threshold changes, baseline changes,
+dependency changes, or Ring0 authority.
+
+Any later Phase-23 concrete assignment, membership, accepted-evidence,
+evidence-item, validator-output, receipt-evidence, package-review,
+source-review, runtime-implementation-procedure, or non-authorization
+boundary record requires its own exact-SHA evidence, changed-file scope,
+non-authorization boundary, and reviewed decision path.


### PR DESCRIPTION
This PR changes only PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md and defines only a governance-only candidate boundary for whether a later concrete accepted-evidence set membership assignment path may be evaluated.

It does not assign accepted-evidence set membership, create accepted evidence, accept any evidence item, accept validator output, accept receipt evidence, or authorize runtime/source/package/source-merge/capability/registry/trust/deployment/distribution/kernel ABI/syscall/workflow-threshold/baseline/dependency/Ring0 authority.

Validation:
- git diff --check
- git diff --cached --check before commit

Scope exclusions:
- docs/roadmap/CURRENT_PHASE unchanged
- PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md remains PR-disjoint