### PR TITLE
Phase-23 concrete accepted-evidence set membership assignment decision candidate

### DIFF
--- a/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md
+++ b/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md
@@ -1,0 +1,1008 @@
+# Phase-23 Concrete Accepted-Evidence Set Membership Assignment Decision Candidate
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY_CLEAN_RECOVERY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_FIRST_BOUNDED_IMPLEMENTATION.md`,
+`PHASE22_CLOSURE_DECISION.md`,
+`PHASE23_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE23_POINTER_TRANSITION_DECISION.md`,
+`docs/roadmap/CURRENT_PHASE`,
+`PHASE23_GOVERNANCE_OVERVIEW.md`,
+`PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`,
+`PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`,
+`PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`, and
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+In case of conflict, those documents prevail unless this document is the
+narrower Phase-23 concrete accepted-evidence set membership assignment
+decision candidate for the exact governance-only decision-candidate scope
+identified below.
+
+**Status:** PHASE-23 CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT
+DECISION CANDIDATE / LOCAL DRAFT / GOVERNANCE-ONLY CONCRETE
+ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT DECISION CANDIDATE ONLY / NO
+CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT DECISION / NO
+CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT / NO
+ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT / NO ACCEPTED-EVIDENCE SET
+MEMBERSHIP / NO ACCEPTED-EVIDENCE SET / NO ACCEPTED EVIDENCE / NO
+EVIDENCE ITEM ACCEPTANCE / NO VALIDATOR OUTPUT ACCEPTANCE / NO RECEIPT
+EVIDENCE ACCEPTANCE / NO RUNTIME IMPLEMENTATION PROCEDURE / NO SOURCE
+MODIFICATION / NO CODE IMPLEMENTATION / NO CODE EXECUTION / NO PROCESS
+START / NO RUNTIME STATE CREATION / NO PACKAGE INSTALLATION / NO PACKAGE
+LOADING / NO PACKAGE EXECUTION / NO DEPLOYMENT / NO CAPABILITY ISSUANCE /
+NO TRUST ASSIGNMENT / NO REGISTRY PUBLICATION / NO DISTRIBUTION
+AUTHORITY / NO SOURCE ACCEPTANCE / NO SOURCE MERGE AUTHORITY / NO KERNEL
+ABI EXPANSION / NO SYSCALL EXPANSION / NO WORKFLOW-THRESHOLD CHANGE / NO
+BASELINE CHANGE / NO DEPENDENCY CHANGE / NO RING0 AUTHORITY
+**Candidate date:** 2026-07-17
+**Candidate id:**
+`ayken.phase23.concrete_accepted_evidence_set_membership_assignment_decision_candidate.v1`
+**Candidate drafting base main SHA:**
+`e9cb4866ce57240de34ef669b6822097473f9830`
+**Candidate publication subject:** pending separate reviewed publication
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+candidate publication subject:** `e9cb4866ce57240de34ef669b6822097473f9830`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+candidate PR:** PR #283
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+candidate exact-main ci-freeze run:** `29603370881`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+candidate exact-main ci-freeze attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+candidate exact-main ci-freeze job:** `freeze / 87960571830`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+candidate exact-main ci-freeze result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+candidate exact-main Dev Loop Validation run:** `29603370765`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+candidate exact-main Dev Loop Validation attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+candidate exact-main Dev Loop Validation job:** `devloop / 87960571279`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+candidate exact-main Dev Loop Validation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+candidate exact-main Dev Loop CI run:** `29603370769`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+candidate exact-main Dev Loop CI attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+candidate exact-main Dev Loop CI result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+candidate exact-main smoke job:** `smoke / 87960571344`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+candidate exact-main smoke result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+candidate exact-main contract job:** `contract / 87960802257`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+candidate exact-main contract result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+candidate exact-main full job:** `full / 87961208974`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+candidate exact-main full result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+candidate exact-main isolation job:** `isolation / 87961712078`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+candidate exact-main isolation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+candidate exact-main performance job:** `performance / 87962174595`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+candidate exact-main performance result:** PASS
+**Phase-23 concrete accepted-evidence set membership assignment candidate
+publication subject:** `e9cb4866ce57240de34ef669b6822097473f9830`
+**Phase-23 concrete accepted-evidence set membership assignment record
+publication subject:** `1d2ec43580e3c919b995365bdb058b852f6b3450`
+**Phase-23 concrete accepted-evidence set membership assignment record
+candidate publication subject:** `c20309a39c91d08dab1df3163a204ab80bc767a5`
+**Phase-23 accepted-evidence set membership assignment record publication
+subject:** `91a24c007276f1ff8804f6b92bda052f4c16bb2c`
+**Phase-23 accepted-evidence set membership assignment decision
+publication subject:** `f60e093a53865fb2e03ce3ded375ed7bace763e5`
+**Phase-23 accepted-evidence set membership decision publication
+subject:** `6f8326a895ebdd3e07b4dc73d8be849bfe0df7fc`
+**Phase-23 accepted-evidence set decision publication-status sync
+subject:** `1e6c2e1af515a57ef2be910dbf6aa61d5fc081ff`
+**Phase-23 evidence acceptance decision publication subject:**
+`1fe089b141af09e9f98be2a153589e68ab015c18`
+**Phase-23 accepted-evidence authority decision publication subject:**
+`d9ac910c24601002971e7d06cf94463d739b1358`
+**Current phase pointer:** `CURRENT_PHASE=23`
+**Candidate theme:** Governance-only decision-candidate boundary for
+whether a later concrete accepted-evidence set membership assignment
+decision path may be evaluated after the concrete assignment candidate
+publication is clean-fixed.
+**Authority boundary:** Concrete accepted-evidence set membership
+assignment decision candidate only; not concrete accepted-evidence set
+membership assignment decision, not concrete accepted-evidence set
+membership assignment, not accepted-evidence set membership assignment,
+not accepted-evidence set membership, not an accepted-evidence set, not
+accepted evidence, not evidence item acceptance, not validator output
+acceptance, not receipt evidence acceptance, not runtime implementation
+procedure, not source modification, not code implementation, not code
+execution, not process start, not runtime state creation, not general
+runtime authority, not unbounded execution authority, not package
+authority, not package installation, not package loading, not package
+execution, not source acceptance, not source merge authority, not source
+repository authority, not module loading, not workspace runtime, not
+plugin loading, not capability token minting, not capability issuance,
+not trust assignment, not trust issuer authority, not registry
+authority, not registry publication, not publication authority, not
+deployment authority, not distribution authority, not distribution
+execution, not Semantic CLI authority, not AI Runtime authority, not
+agent authority, not syscall expansion, not kernel ABI expansion, not
+workflow-threshold, baseline, dependency, or Ring0 authority.
+
+## Purpose
+
+This document records a Phase-23 governance-only concrete
+accepted-evidence set membership assignment decision candidate after the
+clean-fixed Phase-23 Concrete Accepted-Evidence Set Membership Assignment
+Candidate publication.
+
+It answers only:
+
+```text
+May a bounded concrete accepted-evidence set membership assignment
+decision path be evaluated during Phase-23 without assigning membership,
+accepting any evidence item, or creating accepted evidence?
+```
+
+It maps only the fail-closed decision-candidate prerequisites for that
+future concrete membership-assignment decision path.
+
+It does not create a concrete accepted-evidence set membership assignment
+decision.
+
+It does not assign accepted-evidence set membership.
+
+It does not create accepted-evidence set membership.
+
+It does not create an accepted-evidence set.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not convert CI PASS results, receipts, validator output, package
+review output, source review output, historical results, concrete record
+boundaries, assignment candidates, or clean-fixed claims into a concrete
+assignment decision, membership assignment, accepted evidence, or evidence
+item acceptance.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, source acceptance, source merge, registry publication, trust
+assignment, capability issuance, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Those questions require later reviewed decision or record paths, if ever
+authorized.
+
+## Exact Subject
+
+This decision candidate is based on exact main SHA:
+
+```text
+e9cb4866ce57240de34ef669b6822097473f9830
+```
+
+That subject is the squash merge of PR #283:
+
+```text
+Phase-23 concrete accepted-evidence set membership assignment candidate
+```
+
+PR #283 changed only:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md
+```
+
+PR #283 produced post-merge exact-main verification:
+
+| Evidence | Run / job | Result |
+|---|---|---|
+| `ci-freeze` | run `29603370881`, attempt 1, job `freeze / 87960571830` | PASS |
+| Dev Loop Validation | run `29603370765`, attempt 1, job `devloop / 87960571279` | PASS |
+| AykenOS Dev Loop CI | run `29603370769`, attempt 1 | PASS |
+| smoke | job `87960571344` | PASS |
+| contract | job `87960802257` | PASS |
+| full | job `87961208974` | PASS |
+| isolation | job `87961712078` | PASS |
+| performance | job `87962174595` | PASS |
+
+The Phase-23 Concrete Accepted-Evidence Set Membership Assignment
+Candidate remains bound to:
+
+```text
+e9cb4866ce57240de34ef669b6822097473f9830
+```
+
+That candidate recorded only that a later concrete accepted-evidence set
+membership assignment path may be evaluated as a candidate topic.
+
+That candidate was not a decision.
+
+That candidate was not an authority grant.
+
+That candidate did not assign accepted-evidence set membership.
+
+That candidate did not create accepted-evidence set membership.
+
+That candidate did not create accepted evidence.
+
+That candidate did not accept any evidence item.
+
+That candidate did not accept validator output.
+
+That candidate did not accept receipt evidence.
+
+This decision candidate consumes that exact subject as governance input
+only. It does not replace, broaden, reinterpret, or supersede the
+concrete assignment candidate or any earlier Phase-23 governance
+boundary.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped subject readings fail closed.
+
+## Core Rule
+
+```text
+concrete accepted-evidence set membership assignment decision candidate != concrete accepted-evidence set membership assignment decision
+concrete accepted-evidence set membership assignment decision candidate != concrete accepted-evidence set membership assignment
+concrete accepted-evidence set membership assignment decision candidate != accepted-evidence set membership assignment
+concrete accepted-evidence set membership assignment decision candidate != accepted-evidence set membership
+concrete accepted-evidence set membership assignment decision candidate != accepted-evidence set
+concrete accepted-evidence set membership assignment decision candidate != accepted evidence
+concrete accepted-evidence set membership assignment decision candidate != evidence item acceptance
+concrete accepted-evidence set membership assignment decision candidate != validator output acceptance
+concrete accepted-evidence set membership assignment decision candidate != receipt evidence acceptance
+concrete accepted-evidence set membership assignment decision candidate != runtime implementation procedure
+concrete accepted-evidence set membership assignment decision candidate != source modification
+concrete accepted-evidence set membership assignment decision candidate != package loading
+concrete accepted-evidence set membership assignment decision candidate != package execution
+concrete accepted-evidence set membership assignment decision candidate != source acceptance
+concrete accepted-evidence set membership assignment decision candidate != source merge
+concrete accepted-evidence set membership assignment decision candidate != decision
+concrete accepted-evidence set membership assignment decision candidate != authority grant
+assignment decision candidate != assignment decision
+assignment decision candidate != assignment
+assignment decision candidate != membership assignment
+assignment decision candidate != accepted-evidence set membership
+assignment decision candidate != accepted evidence
+assignment decision candidate != evidence item acceptance
+assignment candidate != assignment decision candidate unless separately reviewed
+assignment candidate publication != assignment decision
+assignment candidate publication != concrete assignment
+concrete assignment record boundary != concrete assignment
+concrete assignment record boundary != membership assignment
+concrete record publication != membership assignment
+accepted-evidence set membership assignment != accepted-evidence set membership unless separately reviewed
+accepted-evidence set membership assignment != accepted evidence unless separately reviewed
+accepted-evidence set membership assignment != evidence item acceptance unless separately reviewed
+accepted-evidence set membership != accepted evidence unless separately reviewed
+accepted-evidence set membership != evidence item acceptance unless separately reviewed
+accepted-evidence set != accepted evidence unless separately reviewed
+accepted evidence != validator output unless separately reviewed
+accepted evidence != receipt evidence unless separately reviewed
+validator output != accepted evidence
+receipt evidence != accepted evidence
+receipt evidence != validator output
+CI PASS != concrete accepted-evidence set membership assignment decision
+CI PASS != concrete accepted-evidence set membership assignment
+CI PASS != accepted-evidence set membership assignment
+CI PASS != accepted evidence
+ci-freeze PASS != concrete accepted-evidence set membership assignment decision
+ci-freeze PASS != concrete accepted-evidence set membership assignment
+ci-freeze PASS != accepted-evidence set membership assignment
+ci-freeze PASS != accepted evidence
+Dev Loop PASS != concrete accepted-evidence set membership assignment decision
+Dev Loop PASS != concrete accepted-evidence set membership assignment
+Dev Loop PASS != accepted-evidence set membership assignment
+Dev Loop PASS != accepted evidence
+AykenOS Dev Loop CI PASS != concrete accepted-evidence set membership assignment decision
+AykenOS Dev Loop CI PASS != concrete accepted-evidence set membership assignment
+AykenOS Dev Loop CI PASS != accepted-evidence set membership assignment
+AykenOS Dev Loop CI PASS != accepted evidence
+post-merge exact-main verification != concrete accepted-evidence set membership assignment decision
+post-merge exact-main verification != concrete accepted-evidence set membership assignment
+post-merge exact-main verification != accepted-evidence set membership assignment
+post-merge exact-main verification != accepted evidence
+clean-fixed != concrete accepted-evidence set membership assignment decision
+clean-fixed != concrete accepted-evidence set membership assignment
+clean-fixed != accepted-evidence set membership assignment
+clean-fixed != accepted evidence
+CURRENT_PHASE=23 != concrete accepted-evidence set membership assignment decision
+CURRENT_PHASE=23 != concrete accepted-evidence set membership assignment
+CURRENT_PHASE=23 != accepted-evidence set membership assignment
+CURRENT_PHASE=23 != accepted-evidence set membership
+CURRENT_PHASE=23 != accepted evidence
+CURRENT_PHASE=23 != evidence item acceptance
+CURRENT_PHASE=23 != validator output acceptance
+CURRENT_PHASE=23 != receipt evidence acceptance
+CURRENT_PHASE=23 != runtime implementation procedure
+CURRENT_PHASE=23 != source modification
+CURRENT_PHASE=23 != execution authority
+CURRENT_PHASE=23 != package loading
+CURRENT_PHASE=23 != source merge authority
+historical PASS != inherited evidence
+previous PR evidence != later PR evidence
+```
+
+The safe default remains no concrete accepted-evidence set membership
+assignment decision, no concrete accepted-evidence set membership
+assignment, no accepted-evidence set membership assignment, no
+accepted-evidence set membership, no accepted evidence, no evidence item
+acceptance, no validator output acceptance, no receipt evidence
+acceptance, no runtime behavior, no implementation procedure, no source
+modification, no code execution, no runtime state, and no package,
+capability, registry, trust, distribution, deployment, source
+acceptance, source merge, kernel ABI, syscall, workflow-threshold,
+baseline, dependency, or Ring0 authority unless a later reviewed Phase-23
+decision or record grants a specific bounded authority with its own
+exact-SHA evidence.
+
+Unknown authority readings fail closed.
+
+## Decision-Candidate Boundary
+
+This decision candidate may be used only to evaluate whether a later
+bounded concrete accepted-evidence set membership assignment decision path
+can be reviewed.
+
+The only later-evaluable boundary is:
+
+```text
+bounded concrete accepted-evidence set membership assignment decision path
+as a future reviewed decision
+```
+
+This decision candidate does not create a concrete assignment decision.
+
+This decision candidate does not assign membership.
+
+This decision candidate does not create accepted-evidence set membership.
+
+This decision candidate does not identify any evidence item as accepted
+evidence.
+
+This decision candidate does not accept any evidence item.
+
+This decision candidate does not accept validator output.
+
+This decision candidate does not accept receipt evidence.
+
+This decision candidate does not make a later concrete assignment
+decision inevitable.
+
+Any later concrete assignment decision requires a separate reviewed
+decision path with its own exact subject, changed-file scope,
+non-authorization boundary, and post-merge exact-main verification.
+
+## Candidate Scope
+
+This candidate scope is limited to:
+
+1. Mapping concrete accepted-evidence set membership assignment decision
+   as a later candidate topic.
+2. Binding this decision candidate to PR #283 as the clean-fixed concrete
+   assignment-candidate input.
+3. Preserving the distinction between assignment candidate and assignment
+   decision candidate.
+4. Preserving the distinction between assignment decision candidate and
+   assignment decision.
+5. Preserving the distinction between membership assignment, accepted
+   evidence, and evidence item acceptance.
+6. Preserving separation from validator output acceptance and receipt
+   evidence acceptance.
+7. Establishing post-merge exact-main verification expectations for this
+   decision-candidate publication.
+
+Candidate scope is governance text only.
+
+Candidate scope is decision-candidate only.
+
+Candidate scope is not a decision.
+
+Candidate scope is not an authority grant.
+
+Candidate scope is not concrete accepted-evidence set membership
+assignment.
+
+Candidate scope is not accepted-evidence set membership assignment.
+
+Candidate scope is not accepted-evidence set membership.
+
+Candidate scope is not accepted evidence.
+
+Candidate scope is not evidence item acceptance.
+
+Candidate scope is not validator output acceptance.
+
+Candidate scope is not receipt evidence acceptance.
+
+Candidate scope is not runtime implementation procedure.
+
+Candidate scope is not package loading authority.
+
+Candidate scope is not execution authority.
+
+Candidate scope is not source merge authority.
+
+## Current Phase Pointer Boundary
+
+The current phase pointer remains:
+
+```text
+CURRENT_PHASE=23
+```
+
+This decision candidate does not modify:
+
+```text
+docs/roadmap/CURRENT_PHASE
+```
+
+This decision candidate does not change the active phase pointer.
+
+`CURRENT_PHASE=23` does not authorize concrete accepted-evidence set
+membership assignment decision, concrete accepted-evidence set membership
+assignment, accepted-evidence set membership assignment, accepted-evidence
+set membership, accepted evidence, evidence item acceptance, validator
+output acceptance, receipt evidence acceptance, runtime implementation
+procedure, source modification, code implementation, code execution,
+process start, runtime state creation, package loading, package
+execution, capability issuance, registry publication, trust assignment,
+deployment, distribution, source acceptance, source merge, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+## Concrete Assignment Candidate Input
+
+This decision candidate consumes the clean-fixed Phase-23 Concrete
+Accepted-Evidence Set Membership Assignment Candidate as its exact
+governance prerequisite.
+
+The concrete assignment candidate remains bound to:
+
+```text
+e9cb4866ce57240de34ef669b6822097473f9830
+```
+
+The concrete assignment candidate recorded that it was not a decision,
+not an authority grant, not concrete accepted-evidence set membership
+assignment, not accepted-evidence set membership assignment, not
+accepted-evidence set membership, not accepted evidence, not evidence
+item acceptance, not validator output acceptance, and not receipt
+evidence acceptance.
+
+This decision candidate does not reinterpret that candidate as a
+concrete assignment decision, assignment authority, accepted-evidence set
+membership, accepted evidence, evidence item acceptance, validator output
+acceptance, receipt evidence acceptance, runtime implementation
+procedure, execution authority, package loading authority, source
+acceptance, source merge authority, capability issuance, registry
+publication, trust assignment, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold change, baseline change,
+dependency change, or Ring0 authority.
+
+Any concrete assignment candidate conflict fails closed.
+
+## Relationship To Assignment, Membership, And Accepted Evidence
+
+Concrete accepted-evidence set membership assignment remains separate
+from accepted-evidence set membership unless a separate reviewed decision
+or record explicitly grants that narrower authority.
+
+Concrete accepted-evidence set membership assignment remains separate
+from accepted evidence unless a separate reviewed decision or record
+explicitly grants that narrower authority.
+
+Concrete accepted-evidence set membership assignment remains separate
+from evidence item acceptance unless a separate reviewed decision or
+record explicitly grants that narrower authority.
+
+This decision candidate does not create a concrete assignment decision.
+
+This decision candidate does not assign accepted-evidence set membership.
+
+This decision candidate does not create accepted-evidence set membership.
+
+This decision candidate does not create accepted evidence.
+
+This decision candidate does not identify accepted evidence.
+
+This decision candidate does not accept any evidence item.
+
+This decision candidate does not define accepted-evidence membership.
+
+This decision candidate does not make concrete assignment inevitable.
+
+This decision candidate does not make accepted evidence inevitable.
+
+This decision candidate does not make evidence item acceptance inevitable.
+
+Any attempt to treat this decision candidate as concrete assignment,
+accepted evidence, or evidence item acceptance fails closed.
+
+## Relationship To Validator Output And Receipt Evidence
+
+This decision candidate consumes the clean-fixed Phase-23
+Validator-Output Boundary Planning and Receipt-Evidence Boundary Planning
+records as exact governance prerequisites only.
+
+The Phase-23 Validator-Output Boundary Planning publication-status sync
+remains bound to:
+
+```text
+d225b2b5ffcd83fe12c70bf0150b60f8f288f329
+```
+
+The Phase-23 Receipt-Evidence Boundary Planning publication-status sync
+remains bound to:
+
+```text
+9153d858c8ca99b09beb2fa60c6c7bcc565445a9
+```
+
+This decision candidate does not convert validator output into accepted
+evidence.
+
+This decision candidate does not convert receipt evidence into accepted
+evidence.
+
+This decision candidate does not accept validator output.
+
+This decision candidate does not accept receipt evidence.
+
+This decision candidate does not grant assignment authority over
+validator output, receipt evidence, package review output, source review
+output, historical PASS results, or clean-fixed claims.
+
+Any validator-output or receipt-evidence boundary conflict fails closed.
+
+## Relationship To Phase-19 Runtime Authority
+
+This decision candidate remains subordinate to Phase-19 runtime authority
+records.
+
+This decision candidate must not broaden, replace, supersede, weaken, or
+reinterpret Phase-19 runtime authority records.
+
+This decision candidate must not use concrete membership-assignment
+decision-candidate planning to infer runtime authority.
+
+This decision candidate must not use concrete assignment candidate
+planning to infer runtime authority.
+
+This decision candidate must not use accepted-evidence authority to infer
+runtime authority.
+
+This decision candidate must not use validator-output planning to infer
+runtime authority.
+
+This decision candidate must not use receipt-evidence planning to infer
+runtime authority.
+
+This decision candidate must not use exact-SHA evidence expectations to
+infer runtime authority.
+
+This decision candidate must not use `CURRENT_PHASE=23` to infer runtime
+authority.
+
+Any Phase-23 concrete assignment decision-candidate reading that
+conflicts with Phase-19 runtime authority records fails closed.
+
+## Not Authorized By This Decision Candidate
+
+This decision candidate does not authorize:
+
+1. Concrete accepted-evidence set membership assignment decision.
+2. Concrete accepted-evidence set membership assignment.
+3. Accepted-evidence set membership assignment.
+4. Accepted-evidence set membership.
+5. Accepted evidence.
+6. Evidence item acceptance.
+7. Validator output acceptance.
+8. Receipt evidence acceptance.
+9. Runtime implementation procedure.
+10. Source modification.
+11. Source acceptance.
+12. Source merge.
+13. Code implementation.
+14. Code execution.
+15. Process start.
+16. Runtime state creation.
+17. Package installation.
+18. Package loading.
+19. Package execution.
+20. Module loading.
+21. Workspace runtime or real mounts.
+22. Plugin loading or plugin instantiation.
+23. Capability token minting.
+24. Capability issuance.
+25. Registry publication.
+26. Trust assignment.
+27. Distribution execution.
+28. Deployment.
+29. Semantic CLI authority.
+30. AI Runtime authority.
+31. Agent authority.
+32. Syscall expansion.
+33. Kernel ABI expansion.
+34. Ring0 policy movement.
+35. Workflow-threshold changes.
+36. Baseline changes.
+37. Dependency changes.
+38. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this decision candidate is published, the publication may change only
+this file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md
+```
+
+The publication must not change:
+
+1. `docs/roadmap/CURRENT_PHASE`.
+2. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+3. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+4. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+5. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+6. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+7. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`.
+8. `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`.
+9. `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`.
+10. Prior Phase-23 accepted-evidence, membership, assignment,
+    validator-output, or receipt-evidence records.
+11. CI workflows.
+12. Baselines.
+13. Dependencies.
+14. Runtime source or kernel source.
+15. Syscalls or kernel ABI.
+16. Package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution paths.
+17. `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md`.
+
+Any changed-file expansion beyond this decision candidate requires
+separate review and fails this candidate scope.
+
+## Post-Merge Exact-Main Evidence Rule
+
+If this decision candidate is later published, the candidate publication
+subject must receive its own post-merge exact-main verification:
+
+1. `ci-freeze` PASS for the exact candidate publication SHA.
+2. Dev Loop Validation PASS for the exact candidate publication SHA.
+3. AykenOS Dev Loop CI PASS for the exact candidate publication SHA.
+4. smoke PASS.
+5. contract PASS.
+6. full PASS.
+7. isolation PASS.
+8. performance PASS.
+9. Exact changed-file list confirmation.
+10. No `docs/roadmap/CURRENT_PHASE` change.
+11. No `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`
+    change.
+12. No `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`
+    change.
+13. No prior Phase-23 accepted-evidence, membership, assignment,
+    validator-output, or receipt-evidence record change.
+14. No CI workflow change.
+15. No baseline change.
+16. No dependency change.
+17. No runtime source or kernel source change.
+18. No syscall or kernel ABI change.
+19. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution change.
+
+Until that exact-main post-merge verification exists, this decision
+candidate must not be recorded as clean-fixed.
+
+Historical PASS results may be cited as context only.
+
+Failed attempts may be cited as transparent non-clean context only.
+
+They cannot be inherited as concrete accepted-evidence set membership
+assignment decision, concrete accepted-evidence set membership
+assignment, accepted-evidence set membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime authority, package loading authority, package execution
+authority, source merge authority, capability authority, registry
+authority, trust authority, kernel ABI authority, syscall authority,
+workflow-threshold authority, baseline authority, dependency authority,
+or Ring0 authority.
+
+## Later Concrete Assignment Decision Dependency
+
+This decision candidate is a prerequisite input for a possible later
+bounded concrete accepted-evidence set membership assignment decision.
+
+A later concrete accepted-evidence set membership assignment decision, if
+ever proposed, must define:
+
+1. Exact concrete accepted-evidence set membership assignment decision
+   subject.
+2. Exact Phase-23 concrete accepted-evidence set membership assignment
+   decision-candidate prerequisite.
+3. Exact changed-file boundary.
+4. Exact accepted-evidence set membership assignment scope, if any.
+5. Exact accepted-evidence set membership proposed for assignment, if
+   any, without accepted-evidence set membership status unless separately
+   reviewed.
+6. Exact evidence item reference proposed for membership assignment, if
+   any, without evidence item acceptance unless separately reviewed.
+7. Exact evidence item acceptance denial or separate evidence item
+   acceptance scope.
+8. Exact accepted-evidence creation denial or separate accepted-evidence
+   scope.
+9. Exact validator-output acceptance denial or separate validator-output
+   acceptance scope.
+10. Exact receipt-evidence acceptance denial or separate receipt-evidence
+    acceptance scope.
+11. Exact runtime implementation procedure denial.
+12. Exact package loading and package execution denials.
+13. Exact source acceptance and source merge denials.
+14. Exact capability, registry, trust, deployment, distribution, kernel
+    ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+    denials.
+15. Exact post-merge verification requirements.
+
+Until such a later reviewed concrete assignment decision is published, no
+concrete accepted-evidence set membership assignment decision exists from
+this decision candidate.
+
+Until such a later reviewed membership-assignment record is published, no
+concrete accepted-evidence set membership assignment exists from this
+decision candidate.
+
+Until such a later reviewed accepted-evidence set membership record is
+published, no accepted-evidence set membership exists from this decision
+candidate.
+
+Until such a later reviewed evidence-item acceptance record is published,
+no evidence item acceptance exists from this decision candidate.
+
+Until such a later reviewed accepted-evidence record is published, no
+accepted evidence exists from this decision candidate.
+
+Until such a later reviewed validator-output acceptance record is
+published, no validator output acceptance exists from this decision
+candidate.
+
+Until such a later reviewed receipt-evidence acceptance record is
+published, no receipt evidence acceptance exists from this decision
+candidate.
+
+## Excluded Local Draft
+
+This decision candidate does not consume:
+
+```text
+PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md
+```
+
+If that file exists locally as an untracked file, it remains:
+
+```text
+untracked
+PR-disjoint
+not candidate input
+not decision input
+not record input
+not assignment input
+not evidence input
+not accepted-evidence set membership assignment
+not accepted-evidence set membership
+not accepted evidence
+not evidence item acceptance
+not validator output
+not receipt evidence
+not source authority
+not package acceptance
+not runtime authority
+```
+
+It must not be staged, committed, or included in any Phase-23 concrete
+accepted-evidence set membership assignment decision-candidate PR unless
+a separate reviewed scope explicitly authorizes that file.
+
+## Governance Boundary Invariants
+
+Every later RFC must preserve these Phase-23 concrete assignment
+decision-candidate invariants:
+
+1. This decision candidate is candidate-only.
+2. This decision candidate is not a decision.
+3. This decision candidate is not an authority grant.
+4. This decision candidate is not concrete accepted-evidence set
+   membership assignment decision.
+5. This decision candidate is not concrete accepted-evidence set
+   membership assignment.
+6. This decision candidate is not accepted-evidence set membership
+   assignment.
+7. This decision candidate is not accepted-evidence set membership.
+8. This decision candidate is not an accepted-evidence set.
+9. This decision candidate is not accepted evidence.
+10. This decision candidate is not evidence item acceptance.
+11. This decision candidate is not validator output acceptance.
+12. This decision candidate is not receipt evidence acceptance.
+13. Assignment decision candidate is not assignment decision.
+14. Assignment candidate publication is not assignment decision.
+15. Membership assignment is not accepted-evidence set membership unless
+    separately reviewed.
+16. Membership assignment is not accepted evidence unless separately
+    reviewed.
+17. Membership assignment is not evidence item acceptance unless
+    separately reviewed.
+18. This decision candidate is not runtime implementation procedure.
+19. This decision candidate is not source modification.
+20. This decision candidate is not code implementation.
+21. This decision candidate is not code execution.
+22. This decision candidate is not process start.
+23. This decision candidate is not runtime state creation.
+24. This decision candidate is not package installation.
+25. This decision candidate is not package loading.
+26. This decision candidate is not package execution.
+27. This decision candidate is not capability issuance.
+28. This decision candidate is not registry publication.
+29. This decision candidate is not trust assignment.
+30. This decision candidate is not deployment.
+31. This decision candidate is not distribution authority.
+32. This decision candidate is not source acceptance.
+33. This decision candidate is not source merge authority.
+34. This decision candidate does not modify `docs/roadmap/CURRENT_PHASE`.
+35. This decision candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+36. This decision candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+37. This decision candidate does not modify prior Phase-23
+    accepted-evidence, membership, assignment, validator-output, or
+    receipt-evidence records.
+38. `CURRENT_PHASE=23` is not concrete accepted-evidence set membership
+    assignment decision.
+39. `CURRENT_PHASE=23` is not concrete accepted-evidence set membership
+    assignment.
+40. `CURRENT_PHASE=23` is not accepted-evidence set membership
+    assignment.
+41. `CURRENT_PHASE=23` is not accepted-evidence set membership.
+42. `CURRENT_PHASE=23` is not accepted evidence.
+43. `CURRENT_PHASE=23` is not evidence item acceptance.
+44. `CURRENT_PHASE=23` is not validator output acceptance.
+45. `CURRENT_PHASE=23` is not receipt evidence acceptance.
+46. `CURRENT_PHASE=23` is not runtime implementation procedure.
+47. `CURRENT_PHASE=23` is not source modification.
+48. `CURRENT_PHASE=23` is not execution authority.
+49. `CURRENT_PHASE=23` is not package loading.
+50. `CURRENT_PHASE=23` is not source merge authority.
+51. This decision candidate does not broaden Phase-19 runtime authority.
+52. This decision candidate does not reopen Phase-20.
+53. This decision candidate does not reopen Phase-21.
+54. This decision candidate does not reopen Phase-22.
+55. This decision candidate does not expand kernel ABI or syscalls.
+56. This decision candidate does not change workflow thresholds,
+    baselines, or dependencies.
+57. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-23 concrete accepted-evidence set membership
+assignment decision candidate
+**Architecture status:** Local draft concrete accepted-evidence set
+membership assignment decision candidate / pending separate reviewed
+publication
+**Authority notice:** This signature identifies the architectural
+authorship of this decision candidate. It grants no concrete
+accepted-evidence set membership assignment decision authority, concrete
+accepted-evidence set membership assignment authority, accepted-evidence
+set membership assignment authority, accepted-evidence set membership
+status, accepted evidence status, evidence item acceptance authority,
+validator output acceptance authority, receipt evidence acceptance
+authority, runtime implementation procedure authority, source
+modification authority, code implementation authority, code execution
+authority, process start authority, general runtime authority, unbounded
+execution authority, runtime state authority, package installation
+authority, package loading authority, package execution authority, source
+merge authority, trust authority, registry authority, distribution
+authority, publication authority, capability issuance authority,
+deployment authority, module authority, plugin authority, Semantic CLI
+authority, AI Runtime authority, agent authority, kernel ABI authority,
+syscall authority, workflow-threshold authority, baseline authority,
+dependency authority, or Ring0 authority.
+
+## Conclusion
+
+This Phase-23 concrete accepted-evidence set membership assignment
+decision candidate is based on the clean-fixed Phase-23 Concrete
+Accepted-Evidence Set Membership Assignment Candidate publication
+subject:
+
+```text
+e9cb4866ce57240de34ef669b6822097473f9830
+```
+
+It defines only the governance-only decision-candidate boundary for
+whether a later concrete accepted-evidence set membership assignment
+decision path may be evaluated after the concrete assignment candidate
+publication is clean-fixed.
+
+It does not create a concrete accepted-evidence set membership assignment
+decision.
+
+It does not assign accepted-evidence set membership.
+
+It does not create accepted-evidence set membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize accepted-evidence set membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime implementation procedure, source modification, code
+implementation, code execution, process start, runtime state creation,
+package installation, package loading, package execution, capability
+issuance, registry publication, trust assignment, deployment,
+distribution, source acceptance, source merge, kernel ABI expansion,
+syscall expansion, workflow-threshold changes, baseline changes,
+dependency changes, or Ring0 authority.
+
+Any later Phase-23 concrete assignment decision, concrete assignment,
+membership, accepted-evidence, evidence-item, validator-output,
+receipt-evidence, package-review, source-review,
+runtime-implementation-procedure, or non-authorization boundary record
+requires its own exact-SHA evidence, changed-file scope,
+non-authorization boundary, and reviewed decision path.


### PR DESCRIPTION
This PR changes only PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md and defines only a governance-only decision-candidate boundary for whether a later concrete accepted-evidence set membership assignment decision path may be evaluated. It does not create a concrete assignment decision, assign membership, create accepted-evidence set membership, create accepted evidence, accept any evidence item, accept validator output, accept receipt evidence, or authorize runtime/source/package/source-merge/capability/registry/trust/deployment/distribution/kernel ABI/syscall/workflow-threshold/baseline/dependency/Ring0 authority.