### PR TITLE
Phase-23 concrete accepted-evidence set membership assignment decision

### DIFF
--- a/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md
+++ b/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md
@@ -1,0 +1,1214 @@
+# Phase-23 Concrete Accepted-Evidence Set Membership Assignment Decision
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY_CLEAN_RECOVERY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_FIRST_BOUNDED_IMPLEMENTATION.md`,
+`PHASE22_CLOSURE_DECISION.md`,
+`PHASE23_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE23_POINTER_TRANSITION_DECISION.md`,
+`docs/roadmap/CURRENT_PHASE`,
+`PHASE23_GOVERNANCE_OVERVIEW.md`,
+`PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`,
+`PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`,
+`PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+and
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`.
+In case of conflict, those documents prevail unless this document is the
+narrower Phase-23 concrete accepted-evidence set membership assignment
+decision for the exact governance-only bounded concrete-assignment
+decision boundary identified below.
+
+**Status:** PHASE-23 CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT
+DECISION / LOCAL DRAFT / GOVERNANCE-ONLY CONCRETE ACCEPTED-EVIDENCE SET
+MEMBERSHIP ASSIGNMENT DECISION ONLY / BOUNDED CONCRETE ACCEPTED-EVIDENCE
+SET MEMBERSHIP ASSIGNMENT DECISION BOUNDARY ONLY / NO CONCRETE
+ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT / NO ACCEPTED-EVIDENCE SET
+MEMBERSHIP ASSIGNMENT / NO ACCEPTED-EVIDENCE SET MEMBERSHIP / NO
+ACCEPTED-EVIDENCE SET / NO ACCEPTED EVIDENCE / NO EVIDENCE ITEM
+ACCEPTANCE / NO VALIDATOR OUTPUT ACCEPTANCE / NO RECEIPT EVIDENCE
+ACCEPTANCE / NO RUNTIME IMPLEMENTATION PROCEDURE / NO SOURCE
+MODIFICATION / NO CODE IMPLEMENTATION / NO CODE EXECUTION / NO PROCESS
+START / NO RUNTIME STATE CREATION / NO PACKAGE INSTALLATION / NO PACKAGE
+LOADING / NO PACKAGE EXECUTION / NO DEPLOYMENT / NO CAPABILITY ISSUANCE /
+NO TRUST ASSIGNMENT / NO REGISTRY PUBLICATION / NO DISTRIBUTION
+AUTHORITY / NO SOURCE ACCEPTANCE / NO SOURCE MERGE AUTHORITY / NO KERNEL
+ABI EXPANSION / NO SYSCALL EXPANSION / NO WORKFLOW-THRESHOLD CHANGE / NO
+BASELINE CHANGE / NO DEPENDENCY CHANGE / NO RING0 AUTHORITY
+**Decision date:** 2026-07-18
+**Decision id:**
+`ayken.phase23.concrete_accepted_evidence_set_membership_assignment_decision.v1`
+**Decision drafting base main SHA:**
+`7a1b5b0210cd045647596c8dbd7d23c1427d6f4f`
+**Decision publication subject:** pending separate reviewed publication
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision candidate publication subject:**
+`7a1b5b0210cd045647596c8dbd7d23c1427d6f4f`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision candidate PR:** PR #284
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision candidate exact-main ci-freeze run:** `29606701936`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision candidate exact-main ci-freeze attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision candidate exact-main ci-freeze job:** `freeze / 87971563529`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision candidate exact-main ci-freeze result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision candidate exact-main Dev Loop Validation run:** `29606701940`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision candidate exact-main Dev Loop Validation attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision candidate exact-main Dev Loop Validation job:**
+`devloop / 87971563362`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision candidate exact-main Dev Loop Validation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision candidate exact-main Dev Loop CI run:** `29606701901`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision candidate exact-main Dev Loop CI attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision candidate exact-main Dev Loop CI result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision candidate exact-main smoke job:** `smoke / 87971563189`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision candidate exact-main smoke result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision candidate exact-main contract job:** `contract / 87971811441`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision candidate exact-main contract result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision candidate exact-main full job:** `full / 87972227817`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision candidate exact-main full result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision candidate exact-main isolation job:** `isolation / 87972739254`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision candidate exact-main isolation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision candidate exact-main performance job:** `performance / 87973208358`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision candidate exact-main performance result:** PASS
+**Phase-23 concrete accepted-evidence set membership assignment candidate
+publication subject:** `e9cb4866ce57240de34ef669b6822097473f9830`
+**Phase-23 concrete accepted-evidence set membership assignment record
+publication subject:** `1d2ec43580e3c919b995365bdb058b852f6b3450`
+**Phase-23 concrete accepted-evidence set membership assignment record
+candidate publication subject:** `c20309a39c91d08dab1df3163a204ab80bc767a5`
+**Phase-23 accepted-evidence set membership assignment record publication
+subject:** `91a24c007276f1ff8804f6b92bda052f4c16bb2c`
+**Phase-23 accepted-evidence set membership assignment decision
+publication subject:** `f60e093a53865fb2e03ce3ded375ed7bace763e5`
+**Phase-23 accepted-evidence set membership decision publication
+subject:** `6f8326a895ebdd3e07b4dc73d8be849bfe0df7fc`
+**Phase-23 accepted-evidence set decision publication-status sync
+subject:** `1e6c2e1af515a57ef2be910dbf6aa61d5fc081ff`
+**Phase-23 evidence acceptance decision publication subject:**
+`1fe089b141af09e9f98be2a153589e68ab015c18`
+**Phase-23 accepted-evidence authority decision publication subject:**
+`d9ac910c24601002971e7d06cf94463d739b1358`
+**Current phase pointer:** `CURRENT_PHASE=23`
+**Accepted Phase-23 concrete assignment decision boundary:** bounded
+concrete accepted-evidence set membership assignment decision boundary
+as a governance decision boundary only; concrete assignment, membership
+assignment, accepted-evidence set membership, accepted evidence, evidence
+item acceptance, validator output acceptance, and receipt evidence
+acceptance remain pending separate reviewed records if ever authorized.
+**Authority boundary:** Concrete accepted-evidence set membership
+assignment decision boundary only; bounded concrete assignment decision
+boundary only; not concrete accepted-evidence set membership assignment,
+not accepted-evidence set membership assignment, not accepted-evidence
+set membership, not an accepted-evidence set, not accepted evidence, not
+evidence item acceptance, not validator output acceptance, not receipt
+evidence acceptance, not runtime implementation procedure, not source
+modification, not code implementation, not code execution, not process
+start, not runtime state creation, not general runtime authority, not
+unbounded execution authority, not package authority, not package
+installation, not package loading, not package execution, not source
+acceptance, not source merge authority, not source repository authority,
+not module loading, not workspace runtime, not plugin loading, not
+capability token minting, not capability issuance, not trust assignment,
+not trust issuer authority, not registry authority, not registry
+publication, not publication authority, not deployment authority, not
+distribution authority, not distribution execution, not Semantic CLI
+authority, not AI Runtime authority, not agent authority, not syscall
+expansion, not kernel ABI expansion, not workflow-threshold, baseline,
+dependency, or Ring0 authority.
+
+## Purpose
+
+This document records a Phase-23 governance-only concrete
+accepted-evidence set membership assignment decision after the
+clean-fixed Phase-23 Concrete Accepted-Evidence Set Membership Assignment
+Decision Candidate publication.
+
+It evaluates only:
+
+```text
+May a bounded concrete accepted-evidence set membership assignment
+decision boundary be defined during Phase-23 without assigning
+membership, accepting any evidence item, or creating accepted evidence?
+```
+
+It accepts only the bounded concrete accepted-evidence set membership
+assignment decision boundary as a governance decision boundary.
+
+It does not create a concrete accepted-evidence set membership
+assignment.
+
+It does not assign accepted-evidence set membership.
+
+It does not create accepted-evidence set membership.
+
+It does not create an accepted-evidence set.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not convert CI PASS results, receipts, validator output, package
+review output, source review output, historical results, concrete record
+boundaries, assignment candidates, decision candidates, or clean-fixed
+claims into a concrete assignment, membership assignment, accepted
+evidence, or evidence item acceptance.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, source acceptance, source merge, registry publication, trust
+assignment, capability issuance, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+It does not answer:
+
+```text
+Which evidence item is assigned?
+Which accepted-evidence set membership is assigned?
+How is accepted-evidence set membership assigned?
+How is accepted-evidence set membership created?
+How is accepted evidence created?
+How is an evidence item accepted?
+How is validator output accepted?
+How is receipt evidence accepted?
+How is runtime implementation procedure defined?
+How is source modified?
+How is code implemented or executed?
+How is a process started?
+How is runtime state created?
+How is a package installed, loaded, executed, deployed, or distributed?
+How is source accepted or merged?
+How is a capability issued?
+How is trust assigned?
+How is a registry entry published?
+How is kernel ABI or syscall surface expanded?
+How are workflow thresholds, baselines, or dependencies changed?
+```
+
+Those questions require later reviewed decision or record paths, if ever
+authorized.
+
+## Exact Subject
+
+This decision draft is based on exact main SHA:
+
+```text
+7a1b5b0210cd045647596c8dbd7d23c1427d6f4f
+```
+
+That subject is the squash merge of PR #284:
+
+```text
+Phase-23 concrete accepted-evidence set membership assignment decision candidate
+```
+
+PR #284 changed only:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md
+```
+
+PR #284 produced post-merge exact-main verification:
+
+| Evidence | Run / job | Result |
+|---|---|---|
+| `ci-freeze` | run `29606701936`, attempt 1, job `freeze / 87971563529` | PASS |
+| Dev Loop Validation | run `29606701940`, attempt 1, job `devloop / 87971563362` | PASS |
+| AykenOS Dev Loop CI | run `29606701901`, attempt 1 | PASS |
+| smoke | job `87971563189` | PASS |
+| contract | job `87971811441` | PASS |
+| full | job `87972227817` | PASS |
+| isolation | job `87972739254` | PASS |
+| performance | job `87973208358` | PASS |
+
+The Phase-23 Concrete Accepted-Evidence Set Membership Assignment
+Decision Candidate remains bound to:
+
+```text
+7a1b5b0210cd045647596c8dbd7d23c1427d6f4f
+```
+
+That decision candidate recorded only that a later bounded concrete
+accepted-evidence set membership assignment decision path may be
+evaluated as a candidate topic.
+
+That decision candidate was not a decision.
+
+That decision candidate was not an authority grant.
+
+That decision candidate did not assign membership.
+
+That decision candidate did not create accepted-evidence set membership.
+
+That decision candidate did not create accepted evidence.
+
+That decision candidate did not accept any evidence item.
+
+This decision consumes that exact subject as governance input only. It
+does not replace, broaden, reinterpret, or supersede the decision
+candidate or any earlier Phase-23 governance boundary.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped subject readings fail closed.
+
+## Core Rule
+
+```text
+concrete accepted-evidence set membership assignment decision == bounded concrete accepted-evidence set membership assignment decision boundary only
+concrete accepted-evidence set membership assignment decision != concrete accepted-evidence set membership assignment
+concrete accepted-evidence set membership assignment decision != accepted-evidence set membership assignment
+concrete accepted-evidence set membership assignment decision != accepted-evidence set membership
+concrete accepted-evidence set membership assignment decision != accepted-evidence set
+concrete accepted-evidence set membership assignment decision != accepted evidence
+concrete accepted-evidence set membership assignment decision != evidence item acceptance
+concrete accepted-evidence set membership assignment decision != validator output acceptance
+concrete accepted-evidence set membership assignment decision != receipt evidence acceptance
+concrete accepted-evidence set membership assignment decision != runtime implementation procedure
+concrete accepted-evidence set membership assignment decision != source modification
+concrete accepted-evidence set membership assignment decision != package loading
+concrete accepted-evidence set membership assignment decision != package execution
+concrete accepted-evidence set membership assignment decision != source acceptance
+concrete accepted-evidence set membership assignment decision != source merge
+bounded concrete accepted-evidence set membership assignment decision boundary != concrete accepted-evidence set membership assignment
+bounded concrete accepted-evidence set membership assignment decision boundary != accepted-evidence set membership assignment
+bounded concrete accepted-evidence set membership assignment decision boundary != accepted-evidence set membership
+bounded concrete accepted-evidence set membership assignment decision boundary != accepted evidence
+bounded concrete accepted-evidence set membership assignment decision boundary != evidence item acceptance
+concrete assignment decision publication != concrete assignment
+concrete assignment decision publication != membership assignment
+assignment decision != assignment unless separately reviewed
+assignment decision != accepted-evidence set membership unless separately reviewed
+assignment decision != accepted evidence unless separately reviewed
+assignment decision != evidence item acceptance unless separately reviewed
+accepted-evidence set membership assignment != accepted-evidence set membership unless separately reviewed
+accepted-evidence set membership assignment != accepted evidence unless separately reviewed
+accepted-evidence set membership assignment != evidence item acceptance unless separately reviewed
+concrete accepted-evidence set membership assignment decision candidate != concrete accepted-evidence set membership assignment decision
+concrete accepted-evidence set membership assignment decision candidate != concrete accepted-evidence set membership assignment
+decision candidate != decision
+decision candidate != authority grant
+accepted-evidence set membership != accepted evidence unless separately reviewed
+accepted evidence != evidence item acceptance unless separately reviewed
+accepted evidence != validator output unless separately reviewed
+accepted evidence != receipt evidence unless separately reviewed
+validator output != accepted evidence
+receipt evidence != accepted evidence
+receipt evidence != validator output
+CI PASS != concrete accepted-evidence set membership assignment decision
+CI PASS != concrete accepted-evidence set membership assignment
+CI PASS != accepted-evidence set membership
+CI PASS != accepted evidence
+ci-freeze PASS != concrete accepted-evidence set membership assignment decision
+ci-freeze PASS != concrete accepted-evidence set membership assignment
+ci-freeze PASS != accepted-evidence set membership
+ci-freeze PASS != accepted evidence
+Dev Loop PASS != concrete accepted-evidence set membership assignment decision
+Dev Loop PASS != concrete accepted-evidence set membership assignment
+Dev Loop PASS != accepted-evidence set membership
+Dev Loop PASS != accepted evidence
+AykenOS Dev Loop CI PASS != concrete accepted-evidence set membership assignment decision
+AykenOS Dev Loop CI PASS != concrete accepted-evidence set membership assignment
+AykenOS Dev Loop CI PASS != accepted-evidence set membership
+AykenOS Dev Loop CI PASS != accepted evidence
+post-merge exact-main verification != concrete accepted-evidence set membership assignment decision
+post-merge exact-main verification != concrete accepted-evidence set membership assignment
+post-merge exact-main verification != accepted-evidence set membership
+post-merge exact-main verification != accepted evidence
+clean-fixed != concrete accepted-evidence set membership assignment decision
+clean-fixed != concrete accepted-evidence set membership assignment
+clean-fixed != accepted-evidence set membership
+clean-fixed != accepted evidence
+publication-status sync != concrete accepted-evidence set membership assignment decision
+publication-status sync != concrete accepted-evidence set membership assignment
+publication-status sync != accepted-evidence set membership
+publication-status sync != accepted evidence
+CURRENT_PHASE=23 != concrete accepted-evidence set membership assignment decision
+CURRENT_PHASE=23 != concrete accepted-evidence set membership assignment
+CURRENT_PHASE=23 != accepted-evidence set membership
+CURRENT_PHASE=23 != accepted evidence
+CURRENT_PHASE=23 != evidence item acceptance
+CURRENT_PHASE=23 != validator output acceptance
+CURRENT_PHASE=23 != receipt evidence acceptance
+CURRENT_PHASE=23 != runtime implementation procedure
+CURRENT_PHASE=23 != source modification
+CURRENT_PHASE=23 != execution authority
+CURRENT_PHASE=23 != package loading
+CURRENT_PHASE=23 != source merge authority
+CURRENT_PHASE=23 != kernel ABI expansion
+CURRENT_PHASE=23 != syscall expansion
+historical PASS != inherited evidence
+previous PR evidence != later PR evidence
+```
+
+The safe default remains no concrete assignment, no membership
+assignment, no accepted-evidence set membership, no accepted evidence, no
+evidence item acceptance, no validator output acceptance, no receipt
+evidence acceptance, no runtime behavior, no implementation procedure,
+no source modification, no code execution, no runtime state, and no
+package, capability, registry, trust, distribution, deployment, source
+acceptance, source merge, kernel ABI, syscall, workflow-threshold,
+baseline, dependency, or Ring0 authority unless a later reviewed
+Phase-23 decision or record grants a specific bounded authority with its
+own exact-SHA evidence.
+
+Unknown authority readings fail closed.
+
+## Concrete Assignment Decision
+
+The Phase-23 concrete accepted-evidence set membership assignment
+decision is accepted only as:
+
+```text
+bounded concrete accepted-evidence set membership assignment decision boundary
+```
+
+This decision may define a bounded concrete accepted-evidence set
+membership assignment decision boundary, but it does not assign
+membership.
+
+This decision does not create a concrete accepted-evidence set membership
+assignment.
+
+This decision does not create accepted-evidence set membership.
+
+This decision does not identify any evidence item as accepted evidence.
+
+This decision does not accept any evidence item.
+
+This decision does not accept validator output.
+
+This decision does not accept receipt evidence.
+
+This decision does not authorize package loading.
+
+This decision does not authorize source acceptance or source merge.
+
+This decision does not authorize runtime implementation procedure, code
+execution, process start, runtime state creation, capability issuance,
+registry publication, trust assignment, deployment, distribution, kernel
+ABI expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Any later concrete assignment, membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, or receipt evidence acceptance
+requires a separate reviewed decision or record path with its own exact
+subject, changed-file scope, non-authorization boundary, and post-merge
+exact-main verification.
+
+## Decision Scope
+
+This decision scope is limited to:
+
+1. Accepting the Phase-23 concrete accepted-evidence set membership
+   assignment boundary only as a bounded governance decision boundary.
+2. Binding this decision to PR #284 as the clean-fixed concrete
+   assignment decision-candidate input.
+3. Preserving the distinction between a concrete assignment decision and
+   a concrete assignment.
+4. Preserving the distinction between membership assignment and
+   accepted-evidence set membership.
+5. Preserving the distinction between accepted-evidence set membership
+   and accepted evidence.
+6. Preserving the distinction between accepted evidence and evidence
+   item acceptance.
+7. Preserving separation from validator output acceptance and receipt
+   evidence acceptance.
+8. Establishing post-merge exact-main verification expectations for this
+   concrete assignment decision publication.
+
+Decision scope is governance text only.
+
+Decision scope is bounded concrete accepted-evidence set membership
+assignment decision boundary only.
+
+Decision scope is not a concrete assignment.
+
+Decision scope is not accepted-evidence set membership assignment.
+
+Decision scope is not accepted-evidence set membership.
+
+Decision scope is not accepted evidence.
+
+Decision scope is not evidence item acceptance.
+
+Decision scope is not validator output acceptance.
+
+Decision scope is not receipt evidence acceptance.
+
+Decision scope is not runtime implementation procedure.
+
+Decision scope is not package loading authority.
+
+Decision scope is not execution authority.
+
+Decision scope is not source merge authority.
+
+## Current Phase Pointer Boundary
+
+The current phase pointer remains:
+
+```text
+CURRENT_PHASE=23
+```
+
+This decision does not modify:
+
+```text
+docs/roadmap/CURRENT_PHASE
+```
+
+This decision does not change the active phase pointer.
+
+`CURRENT_PHASE=23` does not authorize a concrete assignment, membership
+assignment, accepted-evidence set membership, accepted evidence, evidence
+item acceptance, validator output acceptance, receipt evidence
+acceptance, runtime implementation procedure, source modification, code
+implementation, code execution, process start, runtime state creation,
+package loading, package execution, capability issuance, registry
+publication, trust assignment, deployment, distribution, source
+acceptance, source merge, kernel ABI expansion, syscall expansion,
+workflow-threshold changes, baseline changes, dependency changes, or
+Ring0 authority.
+
+## Decision Candidate Input
+
+This decision consumes the clean-fixed Phase-23 Concrete
+Accepted-Evidence Set Membership Assignment Decision Candidate as its
+exact governance prerequisite.
+
+The decision candidate remains bound to:
+
+```text
+7a1b5b0210cd045647596c8dbd7d23c1427d6f4f
+```
+
+The decision candidate recorded that it was not a concrete assignment
+decision, not a concrete assignment, not membership assignment, not
+accepted-evidence set membership, not accepted evidence, not evidence
+item acceptance, not validator output acceptance, not receipt evidence
+acceptance, and not an authority grant.
+
+This decision accepts only the later bounded concrete assignment
+decision boundary after that decision-candidate publication is
+clean-fixed.
+
+This decision does not reinterpret the decision candidate as concrete
+assignment, accepted-evidence set membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime implementation procedure, execution authority, package loading
+authority, source acceptance, source merge authority, capability
+issuance, registry publication, trust assignment, deployment,
+distribution, kernel ABI expansion, syscall expansion,
+workflow-threshold change, baseline change, dependency change, or Ring0
+authority.
+
+Any concrete assignment decision-candidate conflict fails closed.
+
+## Relationship To Concrete Assignment Records
+
+This decision consumes the clean-fixed Phase-23 Concrete
+Accepted-Evidence Set Membership Assignment Record and Candidate records
+as exact governance prerequisites only.
+
+The Phase-23 Concrete Accepted-Evidence Set Membership Assignment Record
+remains bound to:
+
+```text
+1d2ec43580e3c919b995365bdb058b852f6b3450
+```
+
+The Phase-23 Concrete Accepted-Evidence Set Membership Assignment Record
+Candidate remains bound to:
+
+```text
+c20309a39c91d08dab1df3163a204ab80bc767a5
+```
+
+Those records opened only bounded record-boundary paths.
+
+This decision does not convert a concrete assignment record boundary into
+a concrete assignment.
+
+This decision does not convert a concrete assignment record boundary into
+accepted-evidence set membership.
+
+This decision does not convert a concrete assignment record boundary into
+accepted evidence.
+
+This decision does not convert a concrete assignment record boundary into
+evidence item acceptance.
+
+Any concrete assignment record conflict fails closed.
+
+## Relationship To Assignment And Membership
+
+This decision accepts only the bounded concrete assignment decision
+boundary.
+
+It does not assign accepted-evidence set membership.
+
+It does not create accepted-evidence set membership.
+
+It does not define accepted-evidence set membership status.
+
+It does not define accepted-evidence set membership output.
+
+It does not make membership assignment inevitable.
+
+It does not make accepted-evidence set membership inevitable.
+
+Membership assignment remains separate from accepted-evidence set
+membership unless a separate reviewed record explicitly grants that
+narrower status.
+
+Any attempt to treat this decision as a concrete assignment, membership
+assignment, or accepted-evidence set membership fails closed.
+
+## Relationship To Accepted Evidence And Evidence Item Acceptance
+
+Accepted-evidence set membership remains separate from accepted evidence
+unless a separate reviewed decision explicitly grants that narrower
+status.
+
+Accepted evidence remains separate from evidence item acceptance unless a
+separate reviewed decision explicitly grants that narrower status.
+
+This decision does not create accepted evidence.
+
+This decision does not identify accepted evidence.
+
+This decision does not accept any evidence item.
+
+This decision does not define evidence item acceptance procedure.
+
+This decision does not make accepted evidence inevitable.
+
+This decision does not make evidence item acceptance inevitable.
+
+Any attempt to treat this decision as accepted evidence or evidence item
+acceptance fails closed.
+
+## Relationship To Validator Output And Receipt Evidence
+
+This decision consumes the clean-fixed Phase-23 Validator-Output Boundary
+Planning and Receipt-Evidence Boundary Planning records as exact
+governance prerequisites only.
+
+The Phase-23 Validator-Output Boundary Planning publication-status sync
+remains bound to:
+
+```text
+d225b2b5ffcd83fe12c70bf0150b60f8f288f329
+```
+
+The Phase-23 Receipt-Evidence Boundary Planning publication-status sync
+remains bound to:
+
+```text
+9153d858c8ca99b09beb2fa60c6c7bcc565445a9
+```
+
+This decision does not convert validator output into accepted evidence.
+
+This decision does not convert receipt evidence into accepted evidence.
+
+This decision does not accept validator output.
+
+This decision does not accept receipt evidence.
+
+This decision does not grant accepted-evidence membership or evidence
+item acceptance over validator output, receipt evidence, package review
+output, source review output, historical PASS results, concrete record
+boundaries, assignment candidates, or clean-fixed claims.
+
+Any validator-output or receipt-evidence boundary conflict fails closed.
+
+## Relationship To Phase-23 Evidence Acceptance And Accepted-Evidence Set
+
+This decision consumes the clean-fixed Phase-23 Evidence Acceptance
+Decision, Accepted-Evidence Set Decision, and Accepted-Evidence Set
+Membership Assignment Decision as exact governance prerequisites.
+
+The Phase-23 Evidence Acceptance Decision remains bound to:
+
+```text
+1fe089b141af09e9f98be2a153589e68ab015c18
+```
+
+The Phase-23 Accepted-Evidence Set Decision publication-status sync
+remains bound to:
+
+```text
+1e6c2e1af515a57ef2be910dbf6aa61d5fc081ff
+```
+
+The Phase-23 Accepted-Evidence Set Membership Assignment Decision remains
+bound to:
+
+```text
+f60e093a53865fb2e03ce3ded375ed7bace763e5
+```
+
+Those records opened only bounded governance decision or record
+boundaries.
+
+This decision does not convert evidence acceptance into accepted
+evidence.
+
+This decision does not convert accepted-evidence set boundaries into
+membership assignment.
+
+This decision does not convert membership assignment decision boundaries
+into concrete assignment.
+
+Any evidence acceptance, accepted-evidence set, or membership-assignment
+decision conflict fails closed.
+
+## Relationship To Phase-23 Accepted-Evidence Authority Decision
+
+This decision consumes the clean-fixed Phase-23 Accepted-Evidence
+Authority Decision as an exact governance prerequisite.
+
+The Phase-23 Accepted-Evidence Authority Decision remains bound to:
+
+```text
+d9ac910c24601002971e7d06cf94463d739b1358
+```
+
+The accepted-evidence authority decision accepted only bounded accepted
+evidence authority as a governance authority class.
+
+This concrete assignment decision does not convert that bounded
+authority class into accepted evidence.
+
+This concrete assignment decision does not convert that bounded authority
+class into evidence item acceptance.
+
+This concrete assignment decision does not broaden the accepted-evidence
+authority decision record.
+
+Any accepted-evidence authority decision conflict fails closed.
+
+## Relationship To Phase-22 Closure
+
+This decision consumes the Phase-22 Closure Decision and the Phase-22
+closure publication-status sync as exact governance prerequisites.
+
+The Phase-22 Closure Decision remains bound to:
+
+```text
+9b19c94a01170d105bd7a7e9fb198df05be17fdf
+```
+
+The latest Phase-22 closure publication-status sync remains bound to:
+
+```text
+6c0a0c878d54ebc6a768e1c708a68d7eb5898b15
+```
+
+Phase-22 remains closed only as:
+
+```text
+actual skeleton reviewed;
+static package acceptance boundary defined and clean-recovered;
+Phase-21 First Bounded Implementation actual skeleton exact 12-file set
+accepted as a static package subject only.
+```
+
+This decision does not reopen Phase-22.
+
+This decision does not reinterpret Phase-22 closure as Phase-23 concrete
+assignment, accepted-evidence set membership, accepted evidence, evidence
+item acceptance, validator output acceptance, receipt evidence
+acceptance, runtime implementation procedure, package loading, package
+execution, source acceptance, source merge authority, capability
+issuance, registry publication, trust assignment, deployment,
+distribution, kernel ABI expansion, syscall expansion,
+workflow-threshold changes, baseline changes, dependency changes, or
+Ring0 authority.
+
+Any Phase-22 closure conflict fails closed.
+
+## Relationship To Phase-19 Runtime Authority
+
+This decision remains subordinate to Phase-19 runtime authority records.
+
+This decision must not broaden, replace, supersede, weaken, or
+reinterpret Phase-19 runtime authority records.
+
+This decision must not use concrete assignment decision authority to
+infer runtime authority.
+
+This decision must not use accepted-evidence authority to infer runtime
+authority.
+
+This decision must not use accepted-evidence decision records to infer
+runtime authority.
+
+This decision must not use validator-output planning to infer runtime
+authority.
+
+This decision must not use receipt-evidence planning to infer runtime
+authority.
+
+This decision must not use exact-SHA evidence expectations to infer
+runtime authority.
+
+This decision must not use `CURRENT_PHASE=23` to infer runtime authority.
+
+Any Phase-23 concrete assignment decision reading that conflicts with
+Phase-19 runtime authority records fails closed.
+
+## Not Authorized By This Decision
+
+This decision does not authorize:
+
+1. Concrete accepted-evidence set membership assignment.
+2. Accepted-evidence set membership assignment.
+3. Accepted-evidence set membership.
+4. Accepted-evidence set creation.
+5. Accepted evidence.
+6. Evidence item acceptance.
+7. Validator output acceptance.
+8. Receipt evidence acceptance.
+9. Runtime implementation procedure.
+10. Source modification.
+11. Source acceptance.
+12. Source merge.
+13. Code implementation.
+14. Code execution.
+15. Process start.
+16. Runtime state creation.
+17. Package installation.
+18. Package loading.
+19. Package execution.
+20. Module loading.
+21. Workspace runtime or real mounts.
+22. Plugin loading or plugin instantiation.
+23. Capability token minting.
+24. Capability issuance.
+25. Registry publication.
+26. Trust assignment.
+27. Distribution execution.
+28. Deployment.
+29. Semantic CLI authority.
+30. AI Runtime authority.
+31. Agent authority.
+32. Syscall expansion.
+33. Kernel ABI expansion.
+34. Ring0 policy movement.
+35. Workflow-threshold changes.
+36. Baseline changes.
+37. Dependency changes.
+38. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this decision is published, the publication may change only this file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md
+```
+
+The publication must not change:
+
+1. `docs/roadmap/CURRENT_PHASE`.
+2. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`.
+3. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+4. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+5. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+6. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+7. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+8. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+9. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`.
+10. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`.
+11. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`.
+12. `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`.
+13. `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`.
+14. `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`.
+15. CI workflows.
+16. Baselines.
+17. Dependencies.
+18. Runtime source or kernel source.
+19. Syscalls or kernel ABI.
+20. Package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution paths.
+21. `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md`.
+
+Any changed-file expansion beyond this decision publication requires
+separate review and fails this decision scope.
+
+## Post-Merge Exact-Main Evidence Rule
+
+If this decision is later published, the decision publication subject
+must receive its own post-merge exact-main verification:
+
+1. `ci-freeze` PASS for the exact decision publication SHA.
+2. Dev Loop Validation PASS for the exact decision publication SHA.
+3. AykenOS Dev Loop CI PASS for the exact decision publication SHA.
+4. smoke PASS.
+5. contract PASS.
+6. full PASS.
+7. isolation PASS.
+8. performance PASS.
+9. Exact changed-file list confirmation.
+10. No `docs/roadmap/CURRENT_PHASE` change.
+11. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`
+    change.
+12. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`
+    change.
+13. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`
+    change.
+14. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`
+    change.
+15. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`
+    change.
+16. No
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`
+    change.
+17. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`
+    change.
+18. No
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`
+    change.
+19. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md` change.
+20. No `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md` change.
+21. No `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md` change.
+22. No `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md` change.
+23. No CI workflow change.
+24. No baseline change.
+25. No dependency change.
+26. No runtime source or kernel source change.
+27. No syscall or kernel ABI change.
+28. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution change.
+
+Until that exact-main post-merge verification exists, this decision must
+not be recorded as clean-fixed.
+
+Historical PASS results may be cited as context only.
+
+Failed attempts may be cited as transparent non-clean context only.
+
+They cannot be inherited as concrete assignment, membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime authority, package loading authority, package execution
+authority, source merge authority, capability authority, registry
+authority, trust authority, kernel ABI authority, syscall authority,
+workflow-threshold authority, baseline authority, dependency authority,
+or Ring0 authority.
+
+## Later Concrete Assignment Dependency
+
+This decision is a prerequisite input for a possible later bounded
+concrete accepted-evidence set membership assignment record or decision,
+if ever proposed.
+
+A later concrete accepted-evidence set membership assignment record, if
+ever proposed, must define:
+
+1. Exact concrete accepted-evidence set membership assignment record
+   subject.
+2. Exact Phase-23 concrete accepted-evidence set membership assignment
+   decision prerequisite.
+3. Exact changed-file boundary.
+4. Exact concrete assignment scope, if any.
+5. Exact accepted-evidence set membership proposed for assignment, if
+   any, without accepted-evidence set membership status unless separately
+   reviewed.
+6. Exact evidence item reference proposed for membership assignment, if
+   any, without evidence item acceptance unless separately reviewed.
+7. Exact membership-assignment denial or separately reviewed concrete
+   membership-assignment scope.
+8. Exact accepted-evidence set membership denial or separately reviewed
+   accepted-evidence set membership scope.
+9. Exact evidence item acceptance denial or separate evidence item
+   acceptance scope.
+10. Exact accepted-evidence creation denial or separate accepted-evidence
+    scope.
+11. Exact validator-output acceptance denial or separate validator-output
+    acceptance scope.
+12. Exact receipt-evidence acceptance denial or separate receipt-evidence
+    acceptance scope.
+13. Exact runtime implementation procedure denial.
+14. Exact package loading and package execution denials.
+15. Exact source acceptance and source merge denials.
+16. Exact capability, registry, trust, deployment, distribution, kernel
+    ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+    denials.
+17. Exact post-merge verification requirements.
+
+Until such a later reviewed concrete assignment record is published, no
+concrete accepted-evidence set membership assignment exists from this
+decision.
+
+Until such a later reviewed accepted-evidence set membership record is
+published, no accepted-evidence set membership exists from this
+decision.
+
+Until such a later reviewed evidence-item acceptance record is published,
+no evidence item acceptance exists from this decision.
+
+Until such a later reviewed accepted-evidence record is published, no
+accepted evidence exists from this decision.
+
+Until such a later reviewed validator-output acceptance record is
+published, no validator output acceptance exists from this decision.
+
+Until such a later reviewed receipt-evidence acceptance record is
+published, no receipt evidence acceptance exists from this decision.
+
+## Excluded Local Draft
+
+This decision does not consume:
+
+```text
+PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md
+```
+
+If that file exists locally as an untracked file, it remains:
+
+```text
+untracked
+PR-disjoint
+not decision input
+not evidence input
+not concrete assignment input
+not membership assignment
+not accepted-evidence set membership
+not accepted evidence
+not evidence item acceptance
+not validator output
+not receipt evidence
+not source authority
+not package acceptance
+not runtime authority
+```
+
+It must not be staged, committed, or included in any Phase-23 concrete
+assignment decision PR unless a separate reviewed scope explicitly
+authorizes that file.
+
+## Governance Boundary Invariants
+
+Every later RFC must preserve these Phase-23 concrete assignment decision
+invariants:
+
+1. This decision is bounded concrete accepted-evidence set membership
+   assignment decision boundary only.
+2. This decision is not a concrete accepted-evidence set membership
+   assignment.
+3. This decision is not accepted-evidence set membership assignment.
+4. This decision is not accepted-evidence set membership.
+5. This decision is not an accepted-evidence set.
+6. This decision is not accepted evidence.
+7. This decision is not evidence item acceptance.
+8. This decision is not validator output acceptance.
+9. This decision is not receipt evidence acceptance.
+10. Assignment decision is not assignment unless separately reviewed.
+11. Assignment decision is not accepted-evidence set membership unless
+    separately reviewed.
+12. Accepted-evidence set membership assignment is not accepted-evidence
+    set membership unless separately reviewed.
+13. Accepted-evidence set membership is not accepted evidence unless
+    separately reviewed.
+14. Accepted evidence is not evidence item acceptance unless separately
+    reviewed.
+15. This decision is not runtime implementation procedure.
+16. This decision is not source modification.
+17. This decision is not code implementation.
+18. This decision is not code execution.
+19. This decision is not process start.
+20. This decision is not runtime state creation.
+21. This decision is not package installation.
+22. This decision is not package loading.
+23. This decision is not package execution.
+24. This decision is not capability issuance.
+25. This decision is not registry publication.
+26. This decision is not trust assignment.
+27. This decision is not deployment.
+28. This decision is not distribution authority.
+29. This decision is not source acceptance.
+30. This decision is not source merge authority.
+31. This decision does not modify `docs/roadmap/CURRENT_PHASE`.
+32. This decision does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`.
+33. This decision does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+34. This decision does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+35. This decision does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+36. This decision does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+37. This decision does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+38. This decision does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`.
+39. This decision does not modify `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`.
+40. This decision does not modify `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`.
+41. This decision does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`.
+42. `CURRENT_PHASE=23` is not a concrete assignment.
+43. `CURRENT_PHASE=23` is not accepted-evidence set membership.
+44. `CURRENT_PHASE=23` is not accepted evidence.
+45. `CURRENT_PHASE=23` is not evidence item acceptance.
+46. `CURRENT_PHASE=23` is not validator output acceptance.
+47. `CURRENT_PHASE=23` is not receipt evidence acceptance.
+48. `CURRENT_PHASE=23` is not runtime implementation procedure.
+49. `CURRENT_PHASE=23` is not source modification.
+50. `CURRENT_PHASE=23` is not execution authority.
+51. `CURRENT_PHASE=23` is not package loading.
+52. `CURRENT_PHASE=23` is not source merge authority.
+53. This decision does not broaden Phase-19 runtime authority.
+54. This decision does not reopen Phase-20.
+55. This decision does not reopen Phase-21.
+56. This decision does not reopen Phase-22.
+57. This decision does not expand kernel ABI or syscalls.
+58. This decision does not change workflow thresholds, baselines, or
+    dependencies.
+59. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-23 concrete accepted-evidence set membership
+assignment decision
+**Architecture status:** Local draft concrete accepted-evidence set
+membership assignment decision / pending separate reviewed publication
+**Authority notice:** This signature identifies the architectural
+authorship of this decision. It grants only the bounded concrete
+accepted-evidence set membership assignment decision boundary defined in
+this record. It grants no concrete accepted-evidence set membership
+assignment, accepted-evidence set membership assignment,
+accepted-evidence set membership, accepted-evidence set status, accepted
+evidence status, evidence item acceptance authority, validator output
+acceptance authority, receipt evidence acceptance authority, runtime
+implementation procedure authority, source modification authority, code
+implementation authority, code execution authority, process start
+authority, general runtime authority, unbounded execution authority,
+runtime state authority, package installation authority, package loading
+authority, package execution authority, source merge authority, trust
+authority, registry authority, distribution authority, publication
+authority, capability issuance authority, deployment authority, module
+authority, plugin authority, Semantic CLI authority, AI Runtime
+authority, agent authority, kernel ABI authority, syscall authority,
+workflow-threshold authority, baseline authority, dependency authority,
+or Ring0 authority.
+
+## Conclusion
+
+This Phase-23 concrete accepted-evidence set membership assignment
+decision is based on the clean-fixed Phase-23 Concrete Accepted-Evidence
+Set Membership Assignment Decision Candidate publication subject:
+
+```text
+7a1b5b0210cd045647596c8dbd7d23c1427d6f4f
+```
+
+It accepts only the bounded concrete accepted-evidence set membership
+assignment decision boundary.
+
+It does not create a concrete accepted-evidence set membership
+assignment.
+
+It does not assign accepted-evidence set membership.
+
+It does not create accepted-evidence set membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize accepted-evidence set membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime implementation procedure, source modification, code
+implementation, code execution, process start, runtime state creation,
+package installation, package loading, package execution, capability
+issuance, registry publication, trust assignment, deployment,
+distribution, source acceptance, source merge, kernel ABI expansion,
+syscall expansion, workflow-threshold changes, baseline changes,
+dependency changes, or Ring0 authority.
+
+Any later Phase-23 concrete assignment, accepted-evidence set membership,
+accepted-evidence, evidence-item-acceptance, validator-output,
+receipt-evidence, package-review, source-review,
+runtime-implementation-procedure, or non-authorization boundary record
+requires its own exact-SHA evidence, changed-file scope,
+non-authorization boundary, and reviewed decision path.


### PR DESCRIPTION
This PR changes only PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md and accepts only a bounded concrete accepted-evidence set membership assignment decision boundary.

It does not create a concrete assignment, assign membership, create accepted-evidence set membership, create accepted evidence, accept any evidence item, accept validator output, accept receipt evidence, or authorize runtime/source/package/source-merge/capability/registry/trust/deployment/distribution/kernel ABI/syscall/workflow-threshold/baseline/dependency/Ring0 authority.

Validation:
- git diff --check HEAD~1 HEAD
- Commit scope confirmed as PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md only
- PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md remains untracked / PR-disjoint