### PR TITLE
Phase-23 concrete accepted-evidence set membership assignment publication record candidate

### DIFF
--- a/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md
+++ b/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md
@@ -1,0 +1,1108 @@
+# Phase-23 Concrete Accepted-Evidence Set Membership Assignment Publication Record Candidate
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY_CLEAN_RECOVERY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_FIRST_BOUNDED_IMPLEMENTATION.md`,
+`PHASE22_CLOSURE_DECISION.md`,
+`PHASE23_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE23_POINTER_TRANSITION_DECISION.md`,
+`docs/roadmap/CURRENT_PHASE`,
+`PHASE23_GOVERNANCE_OVERVIEW.md`,
+`PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`,
+`PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`,
+`PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+and
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+In case of conflict, those documents prevail unless this document is the
+narrower Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate for the exact governance-only
+publication-record-candidate boundary identified below.
+
+**Status:** PHASE-23 CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT
+PUBLICATION RECORD CANDIDATE / LOCAL DRAFT / GOVERNANCE-ONLY PUBLICATION
+RECORD CANDIDATE ONLY / BOUNDED CONCRETE ACCEPTED-EVIDENCE SET
+MEMBERSHIP ASSIGNMENT PUBLICATION RECORD PATH CANDIDATE ONLY / NO
+CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT PUBLICATION RECORD /
+NO CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT / NO
+ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT / NO ACCEPTED-EVIDENCE SET
+MEMBERSHIP / NO ACCEPTED-EVIDENCE SET / NO ACCEPTED EVIDENCE / NO
+EVIDENCE ITEM ACCEPTANCE / NO VALIDATOR OUTPUT ACCEPTANCE / NO RECEIPT
+EVIDENCE ACCEPTANCE / NO RUNTIME IMPLEMENTATION PROCEDURE / NO SOURCE
+MODIFICATION / NO CODE IMPLEMENTATION / NO CODE EXECUTION / NO PROCESS
+START / NO RUNTIME STATE CREATION / NO PACKAGE INSTALLATION / NO PACKAGE
+LOADING / NO PACKAGE EXECUTION / NO DEPLOYMENT / NO CAPABILITY ISSUANCE /
+NO TRUST ASSIGNMENT / NO REGISTRY PUBLICATION / NO DISTRIBUTION
+AUTHORITY / NO SOURCE ACCEPTANCE / NO SOURCE MERGE AUTHORITY / NO KERNEL
+ABI EXPANSION / NO SYSCALL EXPANSION / NO WORKFLOW-THRESHOLD CHANGE / NO
+BASELINE CHANGE / NO DEPENDENCY CHANGE / NO RING0 AUTHORITY
+**Candidate date:** 2026-07-18
+**Candidate id:**
+`ayken.phase23.concrete_accepted_evidence_set_membership_assignment_publication_record_candidate.v1`
+**Candidate drafting base main SHA:**
+`a9533551e7fe0e278e0299b8a60e60632b4c5162`
+**Candidate publication subject:** pending separate reviewed publication
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision publication subject:**
+`a9533551e7fe0e278e0299b8a60e60632b4c5162`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision PR:** PR #285
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision exact-main ci-freeze run:** `29640315035`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision exact-main ci-freeze attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision exact-main ci-freeze job:** `freeze / 88069635062`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision exact-main ci-freeze result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision exact-main Dev Loop Validation run:** `29640315037`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision exact-main Dev Loop Validation attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision exact-main Dev Loop Validation job:** `devloop / 88069635014`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision exact-main Dev Loop Validation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision exact-main Dev Loop CI run:** `29640315088`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision exact-main Dev Loop CI attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision exact-main Dev Loop CI result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision exact-main smoke job:** `smoke / 88069635141`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision exact-main smoke result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision exact-main contract job:** `contract / 88069718769`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision exact-main contract result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision exact-main full job:** `full / 88069892330`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision exact-main full result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision exact-main isolation job:** `isolation / 88070079539`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision exact-main isolation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision exact-main performance job:** `performance / 88070239965`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+decision exact-main performance result:** PASS
+**Phase-23 concrete accepted-evidence set membership assignment decision
+candidate publication subject:** `7a1b5b0210cd045647596c8dbd7d23c1427d6f4f`
+**Phase-23 concrete accepted-evidence set membership assignment candidate
+publication subject:** `e9cb4866ce57240de34ef669b6822097473f9830`
+**Phase-23 concrete accepted-evidence set membership assignment record
+publication subject:** `1d2ec43580e3c919b995365bdb058b852f6b3450`
+**Phase-23 concrete accepted-evidence set membership assignment record
+candidate publication subject:** `c20309a39c91d08dab1df3163a204ab80bc767a5`
+**Phase-23 accepted-evidence set membership assignment record publication
+subject:** `91a24c007276f1ff8804f6b92bda052f4c16bb2c`
+**Phase-23 accepted-evidence set membership assignment decision
+publication subject:** `f60e093a53865fb2e03ce3ded375ed7bace763e5`
+**Current phase pointer:** `CURRENT_PHASE=23`
+**Candidate theme:** Governance-only candidate boundary for whether a
+later concrete accepted-evidence set membership assignment publication
+record path may be evaluated after the bounded concrete assignment
+decision boundary is clean-fixed.
+**Authority boundary:** Concrete accepted-evidence set membership
+assignment publication record candidate only; not a concrete assignment
+publication record, not a publication-status sync, not concrete
+accepted-evidence set membership assignment, not accepted-evidence set
+membership assignment, not accepted-evidence set membership, not an
+accepted-evidence set, not accepted evidence, not evidence item
+acceptance, not validator output acceptance, not receipt evidence
+acceptance, not runtime implementation procedure, not source
+modification, not code implementation, not code execution, not process
+start, not runtime state creation, not general runtime authority, not
+unbounded execution authority, not package authority, not package
+installation, not package loading, not package execution, not source
+acceptance, not source merge authority, not source repository authority,
+not module loading, not workspace runtime, not plugin loading, not
+capability token minting, not capability issuance, not trust assignment,
+not trust issuer authority, not registry authority, not registry
+publication, not publication authority, not deployment authority, not
+distribution authority, not distribution execution, not Semantic CLI
+authority, not AI Runtime authority, not agent authority, not syscall
+expansion, not kernel ABI expansion, not workflow-threshold, baseline,
+dependency, or Ring0 authority.
+
+## Purpose
+
+This document records a Phase-23 governance-only concrete
+accepted-evidence set membership assignment publication record candidate
+after the clean-fixed Phase-23 Concrete Accepted-Evidence Set Membership
+Assignment Decision publication.
+
+It answers only:
+
+```text
+May a later concrete accepted-evidence set membership assignment
+publication record path be evaluated after the bounded concrete
+assignment decision boundary?
+```
+
+It maps only the fail-closed candidate prerequisites for that future
+publication record path.
+
+It does not publish a concrete accepted-evidence set membership
+assignment record.
+
+It does not create a publication-status sync.
+
+It does not create a concrete accepted-evidence set membership
+assignment.
+
+It does not assign accepted-evidence set membership.
+
+It does not create accepted-evidence set membership.
+
+It does not create an accepted-evidence set.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not convert CI PASS results, receipts, validator output, package
+review output, source review output, historical results, concrete record
+boundaries, concrete assignment candidates, concrete assignment
+decisions, or clean-fixed claims into a publication record, concrete
+assignment, membership assignment, accepted evidence, or evidence item
+acceptance.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, source acceptance, source merge, registry publication, trust
+assignment, capability issuance, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Those questions require later reviewed decision or record paths, if ever
+authorized.
+
+## Exact Subject
+
+This publication record candidate is based on exact main SHA:
+
+```text
+a9533551e7fe0e278e0299b8a60e60632b4c5162
+```
+
+That subject is the squash merge of PR #285:
+
+```text
+Phase-23 concrete accepted-evidence set membership assignment decision
+```
+
+PR #285 changed only:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md
+```
+
+PR #285 produced post-merge exact-main verification:
+
+| Evidence | Run / job | Result |
+|---|---|---|
+| `ci-freeze` | run `29640315035`, attempt 1, job `freeze / 88069635062` | PASS |
+| Dev Loop Validation | run `29640315037`, attempt 1, job `devloop / 88069635014` | PASS |
+| AykenOS Dev Loop CI | run `29640315088`, attempt 1 | PASS |
+| smoke | job `88069635141` | PASS |
+| contract | job `88069718769` | PASS |
+| full | job `88069892330` | PASS |
+| isolation | job `88070079539` | PASS |
+| performance | job `88070239965` | PASS |
+
+The Phase-23 Concrete Accepted-Evidence Set Membership Assignment
+Decision remains bound to:
+
+```text
+a9533551e7fe0e278e0299b8a60e60632b4c5162
+```
+
+That decision accepted only the bounded concrete accepted-evidence set
+membership assignment decision boundary as a governance decision
+boundary.
+
+That decision did not create a concrete assignment.
+
+That decision did not assign membership.
+
+That decision did not create accepted-evidence set membership.
+
+That decision did not create accepted evidence.
+
+That decision did not accept any evidence item.
+
+This candidate consumes that exact subject as governance input only. It
+does not replace, broaden, reinterpret, or supersede the concrete
+assignment decision or any earlier Phase-23 governance boundary.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped subject readings fail closed.
+
+## Existing Record Name Boundary
+
+The file name:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md
+```
+
+is already consumed by the clean-fixed Phase-23 concrete assignment
+record boundary.
+
+That record remains bound to:
+
+```text
+1d2ec43580e3c919b995365bdb058b852f6b3450
+```
+
+This candidate does not reuse that file name.
+
+This candidate does not reinterpret that record boundary as a concrete
+assignment publication record.
+
+This candidate does not reinterpret that record boundary as a concrete
+assignment.
+
+This candidate does not reinterpret that record boundary as membership
+assignment, accepted-evidence set membership, accepted evidence, or
+evidence item acceptance.
+
+Any existing-record-name conflict fails closed.
+
+## Core Rule
+
+```text
+concrete accepted-evidence set membership assignment publication record candidate == bounded concrete accepted-evidence set membership assignment publication record path candidate only
+concrete accepted-evidence set membership assignment publication record candidate != concrete accepted-evidence set membership assignment publication record
+concrete accepted-evidence set membership assignment publication record candidate != publication-status sync
+concrete accepted-evidence set membership assignment publication record candidate != concrete accepted-evidence set membership assignment
+concrete accepted-evidence set membership assignment publication record candidate != accepted-evidence set membership assignment
+concrete accepted-evidence set membership assignment publication record candidate != accepted-evidence set membership
+concrete accepted-evidence set membership assignment publication record candidate != accepted-evidence set
+concrete accepted-evidence set membership assignment publication record candidate != accepted evidence
+concrete accepted-evidence set membership assignment publication record candidate != evidence item acceptance
+concrete accepted-evidence set membership assignment publication record candidate != validator output acceptance
+concrete accepted-evidence set membership assignment publication record candidate != receipt evidence acceptance
+concrete accepted-evidence set membership assignment publication record candidate != runtime implementation procedure
+concrete accepted-evidence set membership assignment publication record candidate != source modification
+concrete accepted-evidence set membership assignment publication record candidate != package loading
+concrete accepted-evidence set membership assignment publication record candidate != package execution
+concrete accepted-evidence set membership assignment publication record candidate != source acceptance
+concrete accepted-evidence set membership assignment publication record candidate != source merge
+publication record candidate != publication record
+publication record candidate != decision
+publication record candidate != authority grant
+publication record candidate != publication-status sync
+publication record candidate != concrete assignment
+publication record candidate != membership assignment
+publication record candidate != accepted-evidence set membership
+publication record candidate != accepted evidence
+publication record candidate != evidence item acceptance
+publication record != concrete assignment unless separately reviewed
+publication record != membership assignment unless separately reviewed
+publication record != accepted-evidence set membership unless separately reviewed
+publication record != accepted evidence unless separately reviewed
+publication record != evidence item acceptance unless separately reviewed
+concrete assignment decision != concrete assignment unless separately reviewed
+concrete assignment decision != membership assignment unless separately reviewed
+accepted-evidence set membership assignment != accepted-evidence set membership unless separately reviewed
+accepted-evidence set membership != accepted evidence unless separately reviewed
+accepted evidence != evidence item acceptance unless separately reviewed
+accepted evidence != validator output unless separately reviewed
+accepted evidence != receipt evidence unless separately reviewed
+validator output != accepted evidence
+receipt evidence != accepted evidence
+receipt evidence != validator output
+CI PASS != concrete accepted-evidence set membership assignment publication record
+CI PASS != concrete accepted-evidence set membership assignment
+CI PASS != accepted-evidence set membership
+CI PASS != accepted evidence
+ci-freeze PASS != concrete accepted-evidence set membership assignment publication record
+ci-freeze PASS != concrete accepted-evidence set membership assignment
+ci-freeze PASS != accepted-evidence set membership
+ci-freeze PASS != accepted evidence
+Dev Loop PASS != concrete accepted-evidence set membership assignment publication record
+Dev Loop PASS != concrete accepted-evidence set membership assignment
+Dev Loop PASS != accepted-evidence set membership
+Dev Loop PASS != accepted evidence
+AykenOS Dev Loop CI PASS != concrete accepted-evidence set membership assignment publication record
+AykenOS Dev Loop CI PASS != concrete accepted-evidence set membership assignment
+AykenOS Dev Loop CI PASS != accepted-evidence set membership
+AykenOS Dev Loop CI PASS != accepted evidence
+post-merge exact-main verification != concrete accepted-evidence set membership assignment publication record
+post-merge exact-main verification != concrete accepted-evidence set membership assignment
+post-merge exact-main verification != accepted-evidence set membership
+post-merge exact-main verification != accepted evidence
+clean-fixed != concrete accepted-evidence set membership assignment publication record
+clean-fixed != concrete accepted-evidence set membership assignment
+clean-fixed != accepted-evidence set membership
+clean-fixed != accepted evidence
+publication-status sync != concrete accepted-evidence set membership assignment publication record
+publication-status sync != concrete accepted-evidence set membership assignment
+publication-status sync != accepted-evidence set membership
+publication-status sync != accepted evidence
+CURRENT_PHASE=23 != concrete accepted-evidence set membership assignment publication record
+CURRENT_PHASE=23 != concrete accepted-evidence set membership assignment
+CURRENT_PHASE=23 != accepted-evidence set membership
+CURRENT_PHASE=23 != accepted evidence
+CURRENT_PHASE=23 != evidence item acceptance
+CURRENT_PHASE=23 != validator output acceptance
+CURRENT_PHASE=23 != receipt evidence acceptance
+CURRENT_PHASE=23 != runtime implementation procedure
+CURRENT_PHASE=23 != source modification
+CURRENT_PHASE=23 != execution authority
+CURRENT_PHASE=23 != package loading
+CURRENT_PHASE=23 != source merge authority
+CURRENT_PHASE=23 != kernel ABI expansion
+CURRENT_PHASE=23 != syscall expansion
+historical PASS != inherited evidence
+previous PR evidence != later PR evidence
+```
+
+The safe default remains no publication record, no concrete assignment,
+no membership assignment, no accepted-evidence set membership, no
+accepted evidence, no evidence item acceptance, no validator output
+acceptance, no receipt evidence acceptance, no runtime behavior, no
+implementation procedure, no source modification, no code execution, no
+runtime state, and no package, capability, registry, trust,
+distribution, deployment, source acceptance, source merge, kernel ABI,
+syscall, workflow-threshold, baseline, dependency, or Ring0 authority
+unless a later reviewed Phase-23 decision or record grants a specific
+bounded authority with its own exact-SHA evidence.
+
+Unknown authority readings fail closed.
+
+## Publication Record Candidate Boundary
+
+This candidate may be used only to evaluate whether a later concrete
+accepted-evidence set membership assignment publication record path can
+be reviewed.
+
+The only later-evaluable boundary is:
+
+```text
+bounded concrete accepted-evidence set membership assignment publication
+record path as a future reviewed record
+```
+
+This candidate does not publish a concrete assignment publication record.
+
+This candidate does not create a publication-status sync.
+
+This candidate does not create a concrete assignment.
+
+This candidate does not assign membership.
+
+This candidate does not create accepted-evidence set membership.
+
+This candidate does not create accepted evidence.
+
+This candidate does not accept any evidence item.
+
+This candidate does not accept validator output.
+
+This candidate does not accept receipt evidence.
+
+This candidate does not make a later publication record inevitable.
+
+Any later concrete assignment publication record requires a separate
+reviewed record path with its own exact subject, changed-file scope,
+non-authorization boundary, and post-merge exact-main verification.
+
+## Candidate Scope
+
+This candidate scope is limited to:
+
+1. Mapping a concrete assignment publication record path as a later
+   candidate topic.
+2. Binding this candidate to PR #285 as the clean-fixed concrete
+   assignment decision input.
+3. Preserving the distinction between publication record candidate and
+   publication record.
+4. Preserving the distinction between publication record and concrete
+   assignment.
+5. Preserving the distinction between concrete assignment and membership
+   assignment.
+6. Preserving the distinction between accepted-evidence set membership
+   and accepted evidence.
+7. Preserving the distinction between accepted evidence and evidence item
+   acceptance.
+8. Preserving separation from validator output acceptance and receipt
+   evidence acceptance.
+9. Establishing post-merge exact-main verification expectations for this
+   publication record candidate.
+
+Candidate scope is governance text only.
+
+Candidate scope is bounded concrete assignment publication record path
+candidate only.
+
+Candidate scope is not a publication record.
+
+Candidate scope is not a concrete assignment.
+
+Candidate scope is not membership assignment.
+
+Candidate scope is not accepted-evidence set membership.
+
+Candidate scope is not accepted evidence.
+
+Candidate scope is not evidence item acceptance.
+
+Candidate scope is not validator output acceptance.
+
+Candidate scope is not receipt evidence acceptance.
+
+Candidate scope is not runtime implementation procedure.
+
+Candidate scope is not package loading authority.
+
+Candidate scope is not execution authority.
+
+Candidate scope is not source merge authority.
+
+## Current Phase Pointer Boundary
+
+The current phase pointer remains:
+
+```text
+CURRENT_PHASE=23
+```
+
+This candidate does not modify:
+
+```text
+docs/roadmap/CURRENT_PHASE
+```
+
+This candidate does not change the active phase pointer.
+
+`CURRENT_PHASE=23` does not authorize a publication record, concrete
+assignment, membership assignment, accepted-evidence set membership,
+accepted evidence, evidence item acceptance, validator output
+acceptance, receipt evidence acceptance, runtime implementation
+procedure, source modification, code implementation, code execution,
+process start, runtime state creation, package loading, package
+execution, capability issuance, registry publication, trust assignment,
+deployment, distribution, source acceptance, source merge, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+## Concrete Assignment Decision Input
+
+This candidate consumes the clean-fixed Phase-23 Concrete
+Accepted-Evidence Set Membership Assignment Decision as its exact
+governance prerequisite.
+
+The concrete assignment decision remains bound to:
+
+```text
+a9533551e7fe0e278e0299b8a60e60632b4c5162
+```
+
+The concrete assignment decision accepted only the bounded concrete
+accepted-evidence set membership assignment decision boundary as a
+governance decision boundary.
+
+This candidate does not reinterpret that decision boundary as a
+publication record, concrete assignment, membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime implementation procedure, execution authority, package loading
+authority, source acceptance, source merge authority, capability
+issuance, registry publication, trust assignment, deployment,
+distribution, kernel ABI expansion, syscall expansion,
+workflow-threshold change, baseline change, dependency change, or Ring0
+authority.
+
+Any concrete assignment decision conflict fails closed.
+
+## Relationship To Publication Status Sync
+
+This candidate is not a publication-status sync.
+
+This candidate does not update the publication status of any prior
+record.
+
+This candidate does not make the clean-fixed PR #285 decision self-update
+its own publication subject.
+
+This candidate does not create metadata authority.
+
+This candidate does not convert publication metadata into concrete
+assignment, membership assignment, accepted-evidence set membership,
+accepted evidence, or evidence item acceptance.
+
+Any publication-status reading outside this candidate scope fails closed.
+
+## Relationship To Assignment And Membership
+
+This candidate maps only a later publication record path.
+
+It does not create a concrete assignment.
+
+It does not assign accepted-evidence set membership.
+
+It does not create accepted-evidence set membership.
+
+It does not define accepted-evidence set membership status.
+
+It does not define accepted-evidence set membership output.
+
+It does not make membership assignment inevitable.
+
+It does not make accepted-evidence set membership inevitable.
+
+Membership assignment remains separate from accepted-evidence set
+membership unless a separate reviewed record explicitly grants that
+narrower status.
+
+Any attempt to treat this candidate as a concrete assignment, membership
+assignment, or accepted-evidence set membership fails closed.
+
+## Relationship To Accepted Evidence And Evidence Item Acceptance
+
+Accepted-evidence set membership remains separate from accepted evidence
+unless a separate reviewed decision explicitly grants that narrower
+status.
+
+Accepted evidence remains separate from evidence item acceptance unless a
+separate reviewed decision explicitly grants that narrower status.
+
+This candidate does not create accepted evidence.
+
+This candidate does not identify accepted evidence.
+
+This candidate does not accept any evidence item.
+
+This candidate does not define evidence item acceptance procedure.
+
+This candidate does not make accepted evidence inevitable.
+
+This candidate does not make evidence item acceptance inevitable.
+
+Any attempt to treat this candidate as accepted evidence or evidence item
+acceptance fails closed.
+
+## Relationship To Validator Output And Receipt Evidence
+
+This candidate consumes the clean-fixed Phase-23 Validator-Output
+Boundary Planning and Receipt-Evidence Boundary Planning records as exact
+governance prerequisites only.
+
+The Phase-23 Validator-Output Boundary Planning publication-status sync
+remains bound to:
+
+```text
+d225b2b5ffcd83fe12c70bf0150b60f8f288f329
+```
+
+The Phase-23 Receipt-Evidence Boundary Planning publication-status sync
+remains bound to:
+
+```text
+9153d858c8ca99b09beb2fa60c6c7bcc565445a9
+```
+
+This candidate does not convert validator output into accepted evidence.
+
+This candidate does not convert receipt evidence into accepted evidence.
+
+This candidate does not accept validator output.
+
+This candidate does not accept receipt evidence.
+
+This candidate does not grant accepted-evidence membership or evidence
+item acceptance over validator output, receipt evidence, package review
+output, source review output, historical PASS results, concrete record
+boundaries, concrete assignment decisions, or clean-fixed claims.
+
+Any validator-output or receipt-evidence boundary conflict fails closed.
+
+## Relationship To Phase-19 Runtime Authority
+
+This candidate remains subordinate to Phase-19 runtime authority records.
+
+This candidate must not broaden, replace, supersede, weaken, or
+reinterpret Phase-19 runtime authority records.
+
+This candidate must not use concrete assignment publication-record
+candidate planning to infer runtime authority.
+
+This candidate must not use accepted-evidence authority to infer runtime
+authority.
+
+This candidate must not use accepted-evidence decision records to infer
+runtime authority.
+
+This candidate must not use validator-output planning to infer runtime
+authority.
+
+This candidate must not use receipt-evidence planning to infer runtime
+authority.
+
+This candidate must not use exact-SHA evidence expectations to infer
+runtime authority.
+
+This candidate must not use `CURRENT_PHASE=23` to infer runtime
+authority.
+
+Any Phase-23 publication-record-candidate reading that conflicts with
+Phase-19 runtime authority records fails closed.
+
+## Not Authorized By This Candidate
+
+This candidate does not authorize:
+
+1. Concrete accepted-evidence set membership assignment publication
+   record.
+2. Publication-status sync.
+3. Concrete accepted-evidence set membership assignment.
+4. Accepted-evidence set membership assignment.
+5. Accepted-evidence set membership.
+6. Accepted-evidence set creation.
+7. Accepted evidence.
+8. Evidence item acceptance.
+9. Validator output acceptance.
+10. Receipt evidence acceptance.
+11. Runtime implementation procedure.
+12. Source modification.
+13. Source acceptance.
+14. Source merge.
+15. Code implementation.
+16. Code execution.
+17. Process start.
+18. Runtime state creation.
+19. Package installation.
+20. Package loading.
+21. Package execution.
+22. Module loading.
+23. Workspace runtime or real mounts.
+24. Plugin loading or plugin instantiation.
+25. Capability token minting.
+26. Capability issuance.
+27. Registry publication.
+28. Trust assignment.
+29. Distribution execution.
+30. Deployment.
+31. Semantic CLI authority.
+32. AI Runtime authority.
+33. Agent authority.
+34. Syscall expansion.
+35. Kernel ABI expansion.
+36. Ring0 policy movement.
+37. Workflow-threshold changes.
+38. Baseline changes.
+39. Dependency changes.
+40. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this candidate is published, the publication may change only this
+file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md
+```
+
+The publication must not change:
+
+1. `docs/roadmap/CURRENT_PHASE`.
+2. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+3. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`.
+4. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+5. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+6. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+7. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+8. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+9. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`.
+10. `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`.
+11. `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`.
+12. `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`.
+13. CI workflows.
+14. Baselines.
+15. Dependencies.
+16. Runtime source or kernel source.
+17. Syscalls or kernel ABI.
+18. Package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution paths.
+19. `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md`.
+
+Any changed-file expansion beyond this candidate requires separate
+review and fails this candidate scope.
+
+## Post-Merge Exact-Main Evidence Rule
+
+If this candidate is later published, the candidate publication subject
+must receive its own post-merge exact-main verification:
+
+1. `ci-freeze` PASS for the exact candidate publication SHA.
+2. Dev Loop Validation PASS for the exact candidate publication SHA.
+3. AykenOS Dev Loop CI PASS for the exact candidate publication SHA.
+4. smoke PASS.
+5. contract PASS.
+6. full PASS.
+7. isolation PASS.
+8. performance PASS.
+9. Exact changed-file list confirmation.
+10. No `docs/roadmap/CURRENT_PHASE` change.
+11. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`
+    change.
+12. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`
+    change.
+13. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`
+    change.
+14. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`
+    change.
+15. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`
+    change.
+16. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`
+    change.
+17. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`
+    change.
+18. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md` change.
+19. No `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md` change.
+20. No `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md` change.
+21. No `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md` change.
+22. No CI workflow change.
+23. No baseline change.
+24. No dependency change.
+25. No runtime source or kernel source change.
+26. No syscall or kernel ABI change.
+27. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution change.
+
+Until that exact-main post-merge verification exists, this candidate
+must not be recorded as clean-fixed.
+
+Historical PASS results may be cited as context only.
+
+Failed attempts may be cited as transparent non-clean context only.
+
+They cannot be inherited as publication record, concrete assignment,
+membership assignment, accepted-evidence set membership, accepted
+evidence, evidence item acceptance, validator output acceptance, receipt
+evidence acceptance, runtime authority, package loading authority,
+package execution authority, source merge authority, capability
+authority, registry authority, trust authority, kernel ABI authority,
+syscall authority, workflow-threshold authority, baseline authority,
+dependency authority, or Ring0 authority.
+
+## Later Publication Record Dependency
+
+This candidate is a prerequisite input for a possible later bounded
+concrete accepted-evidence set membership assignment publication record.
+
+A later concrete assignment publication record, if ever proposed, must
+define:
+
+1. Exact concrete assignment publication record subject.
+2. Exact Phase-23 concrete assignment publication-record candidate
+   prerequisite.
+3. Exact Phase-23 concrete assignment decision prerequisite.
+4. Exact changed-file boundary.
+5. Exact publication-record scope, if any.
+6. Exact concrete assignment denial or separately reviewed concrete
+   assignment scope.
+7. Exact accepted-evidence set membership proposed for assignment, if
+   any, without accepted-evidence set membership status unless separately
+   reviewed.
+8. Exact evidence item reference proposed for membership assignment, if
+   any, without evidence item acceptance unless separately reviewed.
+9. Exact accepted-evidence set membership denial or separately reviewed
+   accepted-evidence set membership scope.
+10. Exact evidence item acceptance denial or separate evidence item
+    acceptance scope.
+11. Exact accepted-evidence creation denial or separate accepted-evidence
+    scope.
+12. Exact validator-output acceptance denial or separate validator-output
+    acceptance scope.
+13. Exact receipt-evidence acceptance denial or separate receipt-evidence
+    acceptance scope.
+14. Exact runtime implementation procedure denial.
+15. Exact package loading and package execution denials.
+16. Exact source acceptance and source merge denials.
+17. Exact capability, registry, trust, deployment, distribution, kernel
+    ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+    denials.
+18. Exact post-merge verification requirements.
+
+Until such a later reviewed publication record is published, no concrete
+accepted-evidence set membership assignment publication record exists
+from this candidate.
+
+Until such a later reviewed concrete assignment record is published, no
+concrete accepted-evidence set membership assignment exists from this
+candidate.
+
+Until such a later reviewed accepted-evidence set membership record is
+published, no accepted-evidence set membership exists from this
+candidate.
+
+Until such a later reviewed evidence-item acceptance record is published,
+no evidence item acceptance exists from this candidate.
+
+Until such a later reviewed accepted-evidence record is published, no
+accepted evidence exists from this candidate.
+
+Until such a later reviewed validator-output acceptance record is
+published, no validator output acceptance exists from this candidate.
+
+Until such a later reviewed receipt-evidence acceptance record is
+published, no receipt evidence acceptance exists from this candidate.
+
+## Excluded Local Draft
+
+This candidate does not consume:
+
+```text
+PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md
+```
+
+If that file exists locally as an untracked file, it remains:
+
+```text
+untracked
+PR-disjoint
+not candidate input
+not decision input
+not evidence input
+not publication record input
+not concrete assignment input
+not membership assignment
+not accepted-evidence set membership
+not accepted evidence
+not evidence item acceptance
+not validator output
+not receipt evidence
+not source authority
+not package acceptance
+not runtime authority
+```
+
+It must not be staged, committed, or included in any Phase-23 concrete
+assignment publication-record-candidate PR unless a separate reviewed
+scope explicitly authorizes that file.
+
+## Governance Boundary Invariants
+
+Every later RFC must preserve these Phase-23 publication-record-candidate
+invariants:
+
+1. This candidate is bounded concrete accepted-evidence set membership
+   assignment publication record path candidate only.
+2. This candidate is not a concrete accepted-evidence set membership
+   assignment publication record.
+3. This candidate is not a publication-status sync.
+4. This candidate is not a concrete accepted-evidence set membership
+   assignment.
+5. This candidate is not accepted-evidence set membership assignment.
+6. This candidate is not accepted-evidence set membership.
+7. This candidate is not an accepted-evidence set.
+8. This candidate is not accepted evidence.
+9. This candidate is not evidence item acceptance.
+10. This candidate is not validator output acceptance.
+11. This candidate is not receipt evidence acceptance.
+12. Publication record candidate is not publication record.
+13. Publication record candidate is not authority grant.
+14. Publication record is not concrete assignment unless separately
+    reviewed.
+15. Publication record is not membership assignment unless separately
+    reviewed.
+16. Publication record is not accepted-evidence set membership unless
+    separately reviewed.
+17. Accepted-evidence set membership assignment is not accepted-evidence
+    set membership unless separately reviewed.
+18. Accepted-evidence set membership is not accepted evidence unless
+    separately reviewed.
+19. Accepted evidence is not evidence item acceptance unless separately
+    reviewed.
+20. This candidate is not runtime implementation procedure.
+21. This candidate is not source modification.
+22. This candidate is not code implementation.
+23. This candidate is not code execution.
+24. This candidate is not process start.
+25. This candidate is not runtime state creation.
+26. This candidate is not package installation.
+27. This candidate is not package loading.
+28. This candidate is not package execution.
+29. This candidate is not capability issuance.
+30. This candidate is not registry publication.
+31. This candidate is not trust assignment.
+32. This candidate is not deployment.
+33. This candidate is not distribution authority.
+34. This candidate is not source acceptance.
+35. This candidate is not source merge authority.
+36. This candidate does not modify `docs/roadmap/CURRENT_PHASE`.
+37. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+38. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+39. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+40. This candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+41. This candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+42. This candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`.
+43. This candidate does not modify `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`.
+44. This candidate does not modify `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`.
+45. This candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`.
+46. `CURRENT_PHASE=23` is not a publication record.
+47. `CURRENT_PHASE=23` is not a concrete assignment.
+48. `CURRENT_PHASE=23` is not accepted-evidence set membership.
+49. `CURRENT_PHASE=23` is not accepted evidence.
+50. `CURRENT_PHASE=23` is not evidence item acceptance.
+51. `CURRENT_PHASE=23` is not validator output acceptance.
+52. `CURRENT_PHASE=23` is not receipt evidence acceptance.
+53. `CURRENT_PHASE=23` is not runtime implementation procedure.
+54. `CURRENT_PHASE=23` is not source modification.
+55. `CURRENT_PHASE=23` is not execution authority.
+56. `CURRENT_PHASE=23` is not package loading.
+57. `CURRENT_PHASE=23` is not source merge authority.
+58. This candidate does not broaden Phase-19 runtime authority.
+59. This candidate does not reopen Phase-20.
+60. This candidate does not reopen Phase-21.
+61. This candidate does not reopen Phase-22.
+62. This candidate does not expand kernel ABI or syscalls.
+63. This candidate does not change workflow thresholds, baselines, or
+    dependencies.
+64. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-23 concrete accepted-evidence set membership
+assignment publication record candidate
+**Architecture status:** Local draft concrete accepted-evidence set
+membership assignment publication record candidate / pending separate
+reviewed publication
+**Authority notice:** This signature identifies the architectural
+authorship of this candidate. It grants no concrete assignment
+publication record authority, publication-status sync authority,
+concrete accepted-evidence set membership assignment authority,
+accepted-evidence set membership assignment authority, accepted-evidence
+set membership authority, accepted-evidence set status, accepted evidence
+status, evidence item acceptance authority, validator output acceptance
+authority, receipt evidence acceptance authority, runtime implementation
+procedure authority, source modification authority, code implementation
+authority, code execution authority, process start authority, general
+runtime authority, unbounded execution authority, runtime state
+authority, package installation authority, package loading authority,
+package execution authority, source merge authority, trust authority,
+registry authority, distribution authority, publication authority,
+capability issuance authority, deployment authority, module authority,
+plugin authority, Semantic CLI authority, AI Runtime authority, agent
+authority, kernel ABI authority, syscall authority, workflow-threshold
+authority, baseline authority, dependency authority, or Ring0 authority.
+
+## Conclusion
+
+This Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate is based on the clean-fixed Phase-23
+Concrete Accepted-Evidence Set Membership Assignment Decision publication
+subject:
+
+```text
+a9533551e7fe0e278e0299b8a60e60632b4c5162
+```
+
+It defines only the governance-only candidate boundary for whether a
+later concrete accepted-evidence set membership assignment publication
+record path may be evaluated after the bounded concrete assignment
+decision boundary exists.
+
+It does not publish a concrete assignment publication record.
+
+It does not create a publication-status sync.
+
+It does not create a concrete accepted-evidence set membership
+assignment.
+
+It does not assign accepted-evidence set membership.
+
+It does not create accepted-evidence set membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize concrete assignment, accepted-evidence set
+membership assignment, accepted-evidence set membership, accepted
+evidence, evidence item acceptance, validator output acceptance, receipt
+evidence acceptance, runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, capability issuance, registry publication, trust assignment,
+deployment, distribution, source acceptance, source merge, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Any later Phase-23 concrete assignment publication record, concrete
+assignment, accepted-evidence set membership, accepted-evidence,
+evidence-item-acceptance, validator-output, receipt-evidence,
+package-review, source-review, runtime-implementation-procedure, or
+non-authorization boundary record requires its own exact-SHA evidence,
+changed-file scope, non-authorization boundary, and reviewed decision
+path.


### PR DESCRIPTION
This PR changes only PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md and defines only a governance-only publication-record-candidate boundary for whether a later concrete accepted-evidence set membership assignment publication record path may be evaluated.

It does not publish a concrete assignment publication record, create a publication-status sync, create a concrete assignment, assign membership, create accepted-evidence set membership, create accepted evidence, accept any evidence item, accept validator output, accept receipt evidence, or authorize runtime/source/package/source-merge/capability/registry/trust/deployment/distribution/kernel ABI/syscall/workflow-threshold/baseline/dependency/Ring0 authority.

Validation:
- git diff --check HEAD~1 HEAD
- Commit scope confirmed as PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md only
- PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md remains untracked / PR-disjoint