### PR TITLE
Phase-23 concrete accepted-evidence set membership assignment publication record

### DIFF
--- a/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md
+++ b/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md
@@ -1,0 +1,1164 @@
+# Phase-23 Concrete Accepted-Evidence Set Membership Assignment Publication Record
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY_CLEAN_RECOVERY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_FIRST_BOUNDED_IMPLEMENTATION.md`,
+`PHASE22_CLOSURE_DECISION.md`,
+`PHASE23_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE23_POINTER_TRANSITION_DECISION.md`,
+`docs/roadmap/CURRENT_PHASE`,
+`PHASE23_GOVERNANCE_OVERVIEW.md`,
+`PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`,
+`PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`,
+`PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+and
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`.
+In case of conflict, those documents prevail unless this document is the
+narrower Phase-23 concrete accepted-evidence set membership assignment
+publication record for the exact governance-only publication-record
+boundary identified below.
+
+**Status:** PHASE-23 CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT
+PUBLICATION RECORD / LOCAL DRAFT / GOVERNANCE-ONLY PUBLICATION RECORD
+ONLY / BOUNDED CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT
+PUBLICATION RECORD BOUNDARY ONLY / NO PUBLICATION-STATUS SYNC / NO
+CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT / NO
+ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT / NO ACCEPTED-EVIDENCE SET
+MEMBERSHIP / NO ACCEPTED-EVIDENCE SET / NO ACCEPTED EVIDENCE / NO
+EVIDENCE ITEM ACCEPTANCE / NO VALIDATOR OUTPUT ACCEPTANCE / NO RECEIPT
+EVIDENCE ACCEPTANCE / NO RUNTIME IMPLEMENTATION PROCEDURE / NO SOURCE
+MODIFICATION / NO CODE IMPLEMENTATION / NO CODE EXECUTION / NO PROCESS
+START / NO RUNTIME STATE CREATION / NO PACKAGE INSTALLATION / NO PACKAGE
+LOADING / NO PACKAGE EXECUTION / NO DEPLOYMENT / NO CAPABILITY ISSUANCE /
+NO TRUST ASSIGNMENT / NO REGISTRY PUBLICATION / NO DISTRIBUTION
+AUTHORITY / NO SOURCE ACCEPTANCE / NO SOURCE MERGE AUTHORITY / NO KERNEL
+ABI EXPANSION / NO SYSCALL EXPANSION / NO WORKFLOW-THRESHOLD CHANGE / NO
+BASELINE CHANGE / NO DEPENDENCY CHANGE / NO RING0 AUTHORITY
+**Record date:** 2026-07-18
+**Record id:**
+`ayken.phase23.concrete_accepted_evidence_set_membership_assignment_publication_record.v1`
+**Record drafting base main SHA:**
+`485b8fafa89ab0df777365e3dd5d3f6ac698364b`
+**Record publication subject:** pending separate reviewed publication
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate publication subject:**
+`485b8fafa89ab0df777365e3dd5d3f6ac698364b`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate PR:** PR #286
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate exact-main ci-freeze run:** `29651212758`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate exact-main ci-freeze attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate exact-main ci-freeze job:**
+`freeze / 88097759741`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate exact-main ci-freeze result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate exact-main Dev Loop Validation run:**
+`29651212653`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate exact-main Dev Loop Validation attempt:**
+attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate exact-main Dev Loop Validation job:**
+`devloop / 88097759493`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate exact-main Dev Loop Validation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate exact-main Dev Loop CI run:** `29651212655`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate exact-main Dev Loop CI attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate exact-main Dev Loop CI result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate exact-main smoke job:** `smoke / 88097759512`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate exact-main smoke result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate exact-main contract job:**
+`contract / 88097840155`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate exact-main contract result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate exact-main full job:** `full / 88098043015`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate exact-main full result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate exact-main isolation job:**
+`isolation / 88098256544`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate exact-main isolation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate exact-main performance job:**
+`performance / 88098459788`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate exact-main performance result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate pre-merge non-clean context:** first
+pre-merge `ci-freeze` attempt failed `alias-proof` with missing
+`AYKEN_ALIAS_PROOF_OK`; this is transparent non-clean context only and
+is not clean-fixed evidence
+**Phase-23 concrete accepted-evidence set membership assignment decision
+publication subject:** `a9533551e7fe0e278e0299b8a60e60632b4c5162`
+**Phase-23 concrete accepted-evidence set membership assignment decision
+candidate publication subject:** `7a1b5b0210cd045647596c8dbd7d23c1427d6f4f`
+**Phase-23 concrete accepted-evidence set membership assignment candidate
+publication subject:** `e9cb4866ce57240de34ef669b6822097473f9830`
+**Phase-23 concrete accepted-evidence set membership assignment record
+publication subject:** `1d2ec43580e3c919b995365bdb058b852f6b3450`
+**Phase-23 concrete accepted-evidence set membership assignment record
+candidate publication subject:** `c20309a39c91d08dab1df3163a204ab80bc767a5`
+**Phase-23 accepted-evidence set membership assignment record publication
+subject:** `91a24c007276f1ff8804f6b92bda052f4c16bb2c`
+**Phase-23 accepted-evidence set membership assignment decision
+publication subject:** `f60e093a53865fb2e03ce3ded375ed7bace763e5`
+**Current phase pointer:** `CURRENT_PHASE=23`
+**Accepted Phase-23 concrete assignment publication record boundary:**
+bounded concrete accepted-evidence set membership assignment publication
+record boundary as a governance record boundary only; publication-status
+sync, concrete assignment, membership assignment, accepted-evidence set
+membership, accepted evidence, evidence item acceptance, validator
+output acceptance, and receipt evidence acceptance remain pending
+separate reviewed records if ever authorized.
+**Authority boundary:** Concrete accepted-evidence set membership
+assignment publication record boundary only; not a publication-status
+sync, not concrete accepted-evidence set membership assignment, not
+accepted-evidence set membership assignment, not accepted-evidence set
+membership, not an accepted-evidence set, not accepted evidence, not
+evidence item acceptance, not validator output acceptance, not receipt
+evidence acceptance, not runtime implementation procedure, not source
+modification, not code implementation, not code execution, not process
+start, not runtime state creation, not general runtime authority, not
+unbounded execution authority, not package authority, not package
+installation, not package loading, not package execution, not source
+acceptance, not source merge authority, not source repository authority,
+not module loading, not workspace runtime, not plugin loading, not
+capability token minting, not capability issuance, not trust assignment,
+not trust issuer authority, not registry authority, not registry
+publication, not publication authority, not deployment authority, not
+distribution authority, not distribution execution, not Semantic CLI
+authority, not AI Runtime authority, not agent authority, not syscall
+expansion, not kernel ABI expansion, not workflow-threshold, baseline,
+dependency, or Ring0 authority.
+
+## Purpose
+
+This document records a Phase-23 governance-only concrete
+accepted-evidence set membership assignment publication record after the
+clean-fixed Phase-23 Concrete Accepted-Evidence Set Membership Assignment
+Publication Record Candidate publication.
+
+It evaluates only:
+
+```text
+May a bounded concrete accepted-evidence set membership assignment
+publication record boundary be defined during Phase-23 without creating
+a publication-status sync, assigning membership, accepting any evidence
+item, or creating accepted evidence?
+```
+
+It records only the bounded concrete accepted-evidence set membership
+assignment publication record boundary as a governance record boundary.
+
+This publication record records only a bounded publication record
+boundary, and it does not create a publication-status sync.
+
+It does not create a concrete accepted-evidence set membership
+assignment.
+
+It does not assign accepted-evidence set membership.
+
+It does not create accepted-evidence set membership.
+
+It does not create an accepted-evidence set.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not convert CI PASS results, receipts, validator output, package
+review output, source review output, historical results, concrete record
+boundaries, concrete assignment candidates, concrete assignment
+decisions, publication record candidates, or clean-fixed claims into
+publication-status sync, concrete assignment, membership assignment,
+accepted evidence, or evidence item acceptance.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, source acceptance, source merge, registry publication, trust
+assignment, capability issuance, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Those questions require later reviewed decision or record paths, if ever
+authorized.
+
+## Exact Subject
+
+This publication record is based on exact main SHA:
+
+```text
+485b8fafa89ab0df777365e3dd5d3f6ac698364b
+```
+
+That subject is the squash merge of PR #286:
+
+```text
+Phase-23 concrete accepted-evidence set membership assignment publication
+record candidate
+```
+
+PR #286 changed only:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md
+```
+
+PR #286 produced post-merge exact-main verification:
+
+| Evidence | Run / job | Result |
+|---|---|---|
+| `ci-freeze` | run `29651212758`, attempt 1, job `freeze / 88097759741` | PASS |
+| Dev Loop Validation | run `29651212653`, attempt 1, job `devloop / 88097759493` | PASS |
+| AykenOS Dev Loop CI | run `29651212655`, attempt 1 | PASS |
+| smoke | job `88097759512` | PASS |
+| contract | job `88097840155` | PASS |
+| full | job `88098043015` | PASS |
+| isolation | job `88098256544` | PASS |
+| performance | job `88098459788` | PASS |
+
+PR #286 also had a pre-merge failed `ci-freeze` attempt in `alias-proof`
+with missing `AYKEN_ALIAS_PROOF_OK`. That failed attempt is transparent
+non-clean context only. It is not inherited as clean-fixed evidence,
+publication record, publication-status sync, concrete assignment,
+membership assignment, accepted-evidence set membership, accepted
+evidence, evidence item acceptance, validator output acceptance, receipt
+evidence acceptance, runtime authority, source authority, package
+authority, source-merge authority, kernel ABI authority, syscall
+authority, workflow-threshold authority, baseline authority, dependency
+authority, or Ring0 authority.
+
+The Phase-23 Concrete Accepted-Evidence Set Membership Assignment
+Publication Record Candidate remains bound to:
+
+```text
+485b8fafa89ab0df777365e3dd5d3f6ac698364b
+```
+
+That candidate recorded that it was not a publication record, not a
+publication-status sync, not concrete assignment, not membership
+assignment, not accepted-evidence set membership, not accepted evidence,
+not evidence item acceptance, not a decision, and not an authority grant.
+
+This record consumes that exact subject as governance input only. It
+does not replace, broaden, reinterpret, or supersede the publication
+record candidate or any earlier Phase-23 governance boundary.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped subject readings fail closed.
+
+## Existing Record Name Boundary
+
+The file name:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md
+```
+
+is already consumed by the clean-fixed Phase-23 concrete assignment
+record boundary.
+
+That record remains bound to:
+
+```text
+1d2ec43580e3c919b995365bdb058b852f6b3450
+```
+
+This publication record does not reuse that file name.
+
+This publication record does not reinterpret that record boundary as a
+concrete assignment publication record.
+
+This publication record does not reinterpret that record boundary as a
+concrete assignment.
+
+This publication record does not reinterpret that record boundary as
+membership assignment, accepted-evidence set membership, accepted
+evidence, or evidence item acceptance.
+
+Any existing-record-name conflict fails closed.
+
+## Core Rule
+
+```text
+concrete accepted-evidence set membership assignment publication record == bounded concrete accepted-evidence set membership assignment publication record boundary only
+concrete accepted-evidence set membership assignment publication record != publication-status sync
+concrete accepted-evidence set membership assignment publication record != concrete accepted-evidence set membership assignment
+concrete accepted-evidence set membership assignment publication record != accepted-evidence set membership assignment
+concrete accepted-evidence set membership assignment publication record != accepted-evidence set membership
+concrete accepted-evidence set membership assignment publication record != accepted-evidence set
+concrete accepted-evidence set membership assignment publication record != accepted evidence
+concrete accepted-evidence set membership assignment publication record != evidence item acceptance
+concrete accepted-evidence set membership assignment publication record != validator output acceptance
+concrete accepted-evidence set membership assignment publication record != receipt evidence acceptance
+concrete accepted-evidence set membership assignment publication record != runtime implementation procedure
+concrete accepted-evidence set membership assignment publication record != source modification
+concrete accepted-evidence set membership assignment publication record != package loading
+concrete accepted-evidence set membership assignment publication record != package execution
+concrete accepted-evidence set membership assignment publication record != source acceptance
+concrete accepted-evidence set membership assignment publication record != source merge
+publication record != publication-status sync unless separately reviewed
+publication record != concrete assignment unless separately reviewed
+publication record != membership assignment unless separately reviewed
+publication record != accepted-evidence set membership unless separately reviewed
+publication record != accepted evidence unless separately reviewed
+publication record != evidence item acceptance unless separately reviewed
+publication record candidate != publication record
+publication record candidate != decision
+publication record candidate != authority grant
+publication record candidate != publication-status sync
+publication record candidate != concrete assignment
+publication record candidate != membership assignment
+publication record candidate != accepted-evidence set membership
+publication record candidate != accepted evidence
+publication record candidate != evidence item acceptance
+concrete assignment decision != concrete assignment unless separately reviewed
+concrete assignment decision != membership assignment unless separately reviewed
+accepted-evidence set membership assignment != accepted-evidence set membership unless separately reviewed
+accepted-evidence set membership != accepted evidence unless separately reviewed
+accepted evidence != evidence item acceptance unless separately reviewed
+accepted evidence != validator output unless separately reviewed
+accepted evidence != receipt evidence unless separately reviewed
+validator output != accepted evidence
+receipt evidence != accepted evidence
+receipt evidence != validator output
+CI PASS != concrete accepted-evidence set membership assignment publication record
+CI PASS != publication-status sync
+CI PASS != concrete accepted-evidence set membership assignment
+CI PASS != accepted-evidence set membership
+CI PASS != accepted evidence
+ci-freeze PASS != concrete accepted-evidence set membership assignment publication record
+ci-freeze PASS != publication-status sync
+ci-freeze PASS != concrete accepted-evidence set membership assignment
+ci-freeze PASS != accepted-evidence set membership
+ci-freeze PASS != accepted evidence
+Dev Loop PASS != concrete accepted-evidence set membership assignment publication record
+Dev Loop PASS != publication-status sync
+Dev Loop PASS != concrete accepted-evidence set membership assignment
+Dev Loop PASS != accepted-evidence set membership
+Dev Loop PASS != accepted evidence
+AykenOS Dev Loop CI PASS != concrete accepted-evidence set membership assignment publication record
+AykenOS Dev Loop CI PASS != publication-status sync
+AykenOS Dev Loop CI PASS != concrete accepted-evidence set membership assignment
+AykenOS Dev Loop CI PASS != accepted-evidence set membership
+AykenOS Dev Loop CI PASS != accepted evidence
+post-merge exact-main verification != concrete accepted-evidence set membership assignment publication record
+post-merge exact-main verification != publication-status sync
+post-merge exact-main verification != concrete accepted-evidence set membership assignment
+post-merge exact-main verification != accepted-evidence set membership
+post-merge exact-main verification != accepted evidence
+clean-fixed != concrete accepted-evidence set membership assignment publication record
+clean-fixed != publication-status sync
+clean-fixed != concrete accepted-evidence set membership assignment
+clean-fixed != accepted-evidence set membership
+clean-fixed != accepted evidence
+publication-status sync != concrete accepted-evidence set membership assignment publication record
+publication-status sync != concrete accepted-evidence set membership assignment
+publication-status sync != accepted-evidence set membership
+publication-status sync != accepted evidence
+CURRENT_PHASE=23 != concrete accepted-evidence set membership assignment publication record
+CURRENT_PHASE=23 != publication-status sync
+CURRENT_PHASE=23 != concrete accepted-evidence set membership assignment
+CURRENT_PHASE=23 != accepted-evidence set membership
+CURRENT_PHASE=23 != accepted evidence
+CURRENT_PHASE=23 != evidence item acceptance
+CURRENT_PHASE=23 != validator output acceptance
+CURRENT_PHASE=23 != receipt evidence acceptance
+CURRENT_PHASE=23 != runtime implementation procedure
+CURRENT_PHASE=23 != source modification
+CURRENT_PHASE=23 != execution authority
+CURRENT_PHASE=23 != package loading
+CURRENT_PHASE=23 != source merge authority
+CURRENT_PHASE=23 != kernel ABI expansion
+CURRENT_PHASE=23 != syscall expansion
+historical PASS != inherited evidence
+previous PR evidence != later PR evidence
+```
+
+The safe default remains no publication-status sync, no concrete
+assignment, no membership assignment, no accepted-evidence set
+membership, no accepted evidence, no evidence item acceptance, no
+validator output acceptance, no receipt evidence acceptance, no runtime
+behavior, no implementation procedure, no source modification, no code
+execution, no runtime state, and no package, capability, registry,
+trust, distribution, deployment, source acceptance, source merge, kernel
+ABI, syscall, workflow-threshold, baseline, dependency, or Ring0
+authority unless a later reviewed Phase-23 decision or record grants a
+specific bounded authority with its own exact-SHA evidence.
+
+Unknown authority readings fail closed.
+
+## Publication Record Boundary
+
+The Phase-23 concrete accepted-evidence set membership assignment
+publication record is accepted only as:
+
+```text
+bounded concrete accepted-evidence set membership assignment publication
+record boundary
+```
+
+This publication record records only a bounded publication record
+boundary, and it does not create a publication-status sync.
+
+This publication record does not create a concrete assignment.
+
+This publication record does not assign membership.
+
+This publication record does not create accepted-evidence set
+membership.
+
+This publication record does not create accepted evidence.
+
+This publication record does not accept any evidence item.
+
+This publication record does not accept validator output.
+
+This publication record does not accept receipt evidence.
+
+This publication record does not authorize package loading.
+
+This publication record does not authorize source acceptance or source
+merge.
+
+This publication record does not authorize runtime implementation
+procedure, code execution, process start, runtime state creation,
+capability issuance, registry publication, trust assignment, deployment,
+distribution, kernel ABI expansion, syscall expansion,
+workflow-threshold changes, baseline changes, dependency changes, or
+Ring0 authority.
+
+Any later publication-status sync, concrete assignment, membership
+assignment, accepted-evidence set membership, accepted evidence,
+evidence item acceptance, validator output acceptance, or receipt
+evidence acceptance requires a separate reviewed decision or record path
+with its own exact subject, changed-file scope, non-authorization
+boundary, and post-merge exact-main verification.
+
+## Record Scope
+
+This record scope is limited to:
+
+1. Recording the Phase-23 concrete assignment publication record only as
+   a bounded governance record boundary.
+2. Binding this record to PR #286 as the clean-fixed publication record
+   candidate input.
+3. Preserving the distinction between publication record and
+   publication-status sync.
+4. Preserving the distinction between publication record and concrete
+   assignment.
+5. Preserving the distinction between concrete assignment and membership
+   assignment.
+6. Preserving the distinction between accepted-evidence set membership
+   and accepted evidence.
+7. Preserving the distinction between accepted evidence and evidence
+   item acceptance.
+8. Preserving separation from validator output acceptance and receipt
+   evidence acceptance.
+9. Establishing post-merge exact-main verification expectations for this
+   publication record.
+
+Record scope is governance text only.
+
+Record scope is bounded concrete assignment publication record boundary
+only.
+
+Record scope is not a publication-status sync.
+
+Record scope is not a concrete assignment.
+
+Record scope is not membership assignment.
+
+Record scope is not accepted-evidence set membership.
+
+Record scope is not accepted evidence.
+
+Record scope is not evidence item acceptance.
+
+Record scope is not validator output acceptance.
+
+Record scope is not receipt evidence acceptance.
+
+Record scope is not runtime implementation procedure.
+
+Record scope is not package loading authority.
+
+Record scope is not execution authority.
+
+Record scope is not source merge authority.
+
+## Current Phase Pointer Boundary
+
+The current phase pointer remains:
+
+```text
+CURRENT_PHASE=23
+```
+
+This record does not modify:
+
+```text
+docs/roadmap/CURRENT_PHASE
+```
+
+This record does not change the active phase pointer.
+
+`CURRENT_PHASE=23` does not authorize a publication-status sync,
+concrete assignment, membership assignment, accepted-evidence set
+membership, accepted evidence, evidence item acceptance, validator
+output acceptance, receipt evidence acceptance, runtime implementation
+procedure, source modification, code implementation, code execution,
+process start, runtime state creation, package loading, package
+execution, capability issuance, registry publication, trust assignment,
+deployment, distribution, source acceptance, source merge, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+## Publication Record Candidate Input
+
+This record consumes the clean-fixed Phase-23 Concrete Accepted-Evidence
+Set Membership Assignment Publication Record Candidate as its exact
+governance prerequisite.
+
+The publication record candidate remains bound to:
+
+```text
+485b8fafa89ab0df777365e3dd5d3f6ac698364b
+```
+
+The publication record candidate recorded that it was not a publication
+record, not a publication-status sync, not concrete assignment, not
+membership assignment, not accepted-evidence set membership, not
+accepted evidence, not evidence item acceptance, not a decision, and not
+an authority grant.
+
+This record accepts only the bounded concrete accepted-evidence set
+membership assignment publication record boundary after that candidate
+publication is clean-fixed.
+
+This record does not reinterpret the publication record candidate as a
+publication-status sync, concrete assignment, membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime implementation procedure, execution authority, package loading
+authority, source acceptance, source merge authority, capability
+issuance, registry publication, trust assignment, deployment,
+distribution, kernel ABI expansion, syscall expansion,
+workflow-threshold change, baseline change, dependency change, or Ring0
+authority.
+
+Any publication-record-candidate conflict fails closed.
+
+## Relationship To Publication Status Sync
+
+This publication record is not a publication-status sync.
+
+This publication record does not update the publication status of any
+prior record.
+
+This publication record does not make the clean-fixed PR #286 candidate
+self-update its own publication subject.
+
+This publication record does not create metadata authority.
+
+This publication record does not convert publication metadata into
+concrete assignment, membership assignment, accepted-evidence set
+membership, accepted evidence, or evidence item acceptance.
+
+Any publication-status reading outside this record scope fails closed.
+
+## Relationship To Assignment And Membership
+
+This publication record records only a bounded publication record
+boundary.
+
+It does not create a concrete assignment.
+
+It does not assign accepted-evidence set membership.
+
+It does not create accepted-evidence set membership.
+
+It does not define accepted-evidence set membership status.
+
+It does not define accepted-evidence set membership output.
+
+It does not make membership assignment inevitable.
+
+It does not make accepted-evidence set membership inevitable.
+
+Membership assignment remains separate from accepted-evidence set
+membership unless a separate reviewed record explicitly grants that
+narrower status.
+
+Any attempt to treat this publication record as a concrete assignment,
+membership assignment, or accepted-evidence set membership fails closed.
+
+## Relationship To Accepted Evidence And Evidence Item Acceptance
+
+Accepted-evidence set membership remains separate from accepted evidence
+unless a separate reviewed decision explicitly grants that narrower
+status.
+
+Accepted evidence remains separate from evidence item acceptance unless a
+separate reviewed decision explicitly grants that narrower status.
+
+This publication record does not create accepted evidence.
+
+This publication record does not identify accepted evidence.
+
+This publication record does not accept any evidence item.
+
+This publication record does not define evidence item acceptance
+procedure.
+
+This publication record does not make accepted evidence inevitable.
+
+This publication record does not make evidence item acceptance
+inevitable.
+
+Any attempt to treat this publication record as accepted evidence or
+evidence item acceptance fails closed.
+
+## Relationship To Validator Output And Receipt Evidence
+
+This publication record consumes the clean-fixed Phase-23
+Validator-Output Boundary Planning and Receipt-Evidence Boundary
+Planning records as exact governance prerequisites only.
+
+The Phase-23 Validator-Output Boundary Planning publication-status sync
+remains bound to:
+
+```text
+d225b2b5ffcd83fe12c70bf0150b60f8f288f329
+```
+
+The Phase-23 Receipt-Evidence Boundary Planning publication-status sync
+remains bound to:
+
+```text
+9153d858c8ca99b09beb2fa60c6c7bcc565445a9
+```
+
+This publication record does not convert validator output into accepted
+evidence.
+
+This publication record does not convert receipt evidence into accepted
+evidence.
+
+This publication record does not accept validator output.
+
+This publication record does not accept receipt evidence.
+
+This publication record does not grant accepted-evidence membership or
+evidence item acceptance over validator output, receipt evidence,
+package review output, source review output, historical PASS results,
+concrete record boundaries, concrete assignment decisions,
+publication-record candidates, or clean-fixed claims.
+
+Any validator-output or receipt-evidence boundary conflict fails closed.
+
+## Relationship To Phase-19 Runtime Authority
+
+This publication record remains subordinate to Phase-19 runtime authority
+records.
+
+This publication record must not broaden, replace, supersede, weaken, or
+reinterpret Phase-19 runtime authority records.
+
+This publication record must not use concrete assignment
+publication-record authority to infer runtime authority.
+
+This publication record must not use accepted-evidence authority to infer
+runtime authority.
+
+This publication record must not use accepted-evidence decision records
+to infer runtime authority.
+
+This publication record must not use validator-output planning to infer
+runtime authority.
+
+This publication record must not use receipt-evidence planning to infer
+runtime authority.
+
+This publication record must not use exact-SHA evidence expectations to
+infer runtime authority.
+
+This publication record must not use `CURRENT_PHASE=23` to infer runtime
+authority.
+
+Any Phase-23 publication-record reading that conflicts with Phase-19
+runtime authority records fails closed.
+
+## Not Authorized By This Publication Record
+
+This publication record does not authorize:
+
+1. Publication-status sync.
+2. Concrete accepted-evidence set membership assignment.
+3. Accepted-evidence set membership assignment.
+4. Accepted-evidence set membership.
+5. Accepted-evidence set creation.
+6. Accepted evidence.
+7. Evidence item acceptance.
+8. Validator output acceptance.
+9. Receipt evidence acceptance.
+10. Runtime implementation procedure.
+11. Source modification.
+12. Source acceptance.
+13. Source merge.
+14. Code implementation.
+15. Code execution.
+16. Process start.
+17. Runtime state creation.
+18. Package installation.
+19. Package loading.
+20. Package execution.
+21. Module loading.
+22. Workspace runtime or real mounts.
+23. Plugin loading or plugin instantiation.
+24. Capability token minting.
+25. Capability issuance.
+26. Registry publication.
+27. Trust assignment.
+28. Distribution execution.
+29. Deployment.
+30. Semantic CLI authority.
+31. AI Runtime authority.
+32. Agent authority.
+33. Syscall expansion.
+34. Kernel ABI expansion.
+35. Ring0 policy movement.
+36. Workflow-threshold changes.
+37. Baseline changes.
+38. Dependency changes.
+39. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this publication record is published, the publication may change only
+this file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md
+```
+
+The publication must not change:
+
+1. `docs/roadmap/CURRENT_PHASE`.
+2. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`.
+3. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+4. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`.
+5. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+6. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+7. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+8. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+9. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+10. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`.
+11. `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`.
+12. `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`.
+13. `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`.
+14. CI workflows.
+15. Baselines.
+16. Dependencies.
+17. Runtime source or kernel source.
+18. Syscalls or kernel ABI.
+19. Package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution paths.
+20. `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md`.
+
+Any changed-file expansion beyond this publication record requires
+separate review and fails this record scope.
+
+## Post-Merge Exact-Main Evidence Rule
+
+If this publication record is later published, the record publication
+subject must receive its own post-merge exact-main verification:
+
+1. `ci-freeze` PASS for the exact record publication SHA.
+2. Dev Loop Validation PASS for the exact record publication SHA.
+3. AykenOS Dev Loop CI PASS for the exact record publication SHA.
+4. smoke PASS.
+5. contract PASS.
+6. full PASS.
+7. isolation PASS.
+8. performance PASS.
+9. Exact changed-file list confirmation.
+10. No `docs/roadmap/CURRENT_PHASE` change.
+11. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`
+    change.
+12. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`
+    change.
+13. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`
+    change.
+14. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`
+    change.
+15. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`
+    change.
+16. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`
+    change.
+17. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`
+    change.
+18. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`
+    change.
+19. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md` change.
+20. No `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md` change.
+21. No `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md` change.
+22. No `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md` change.
+23. No CI workflow change.
+24. No baseline change.
+25. No dependency change.
+26. No runtime source or kernel source change.
+27. No syscall or kernel ABI change.
+28. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution change.
+
+Until that exact-main post-merge verification exists, this publication
+record must not be recorded as clean-fixed.
+
+Historical PASS results may be cited as context only.
+
+Failed attempts may be cited as transparent non-clean context only.
+
+They cannot be inherited as publication-status sync, concrete
+assignment, membership assignment, accepted-evidence set membership,
+accepted evidence, evidence item acceptance, validator output
+acceptance, receipt evidence acceptance, runtime authority, package
+loading authority, package execution authority, source merge authority,
+capability authority, registry authority, trust authority, kernel ABI
+authority, syscall authority, workflow-threshold authority, baseline
+authority, dependency authority, or Ring0 authority.
+
+## Later Publication-Status Sync Or Concrete Assignment Dependency
+
+This publication record is a prerequisite input for a possible later
+bounded publication-status sync candidate, concrete assignment candidate,
+or concrete assignment record.
+
+A later publication-status sync, if ever proposed, must define:
+
+1. Exact publication-status sync subject.
+2. Exact Phase-23 concrete assignment publication record prerequisite.
+3. Exact changed-file boundary.
+4. Exact metadata scope.
+5. Exact denial that publication-status sync is concrete assignment.
+6. Exact denial that publication-status sync is membership assignment.
+7. Exact denial that publication-status sync is accepted-evidence set
+   membership.
+8. Exact denial that publication-status sync is accepted evidence.
+9. Exact denial that publication-status sync is evidence item acceptance.
+10. Exact post-merge verification requirements.
+
+A later concrete assignment record, if ever proposed, must define:
+
+1. Exact concrete assignment record subject.
+2. Exact Phase-23 concrete assignment publication record prerequisite.
+3. Exact changed-file boundary.
+4. Exact concrete assignment scope, if any.
+5. Exact accepted-evidence set membership proposed for assignment, if
+   any, without accepted-evidence set membership status unless separately
+   reviewed.
+6. Exact evidence item reference proposed for membership assignment, if
+   any, without evidence item acceptance unless separately reviewed.
+7. Exact accepted-evidence set membership denial or separately reviewed
+   accepted-evidence set membership scope.
+8. Exact evidence item acceptance denial or separate evidence item
+   acceptance scope.
+9. Exact accepted-evidence creation denial or separate accepted-evidence
+   scope.
+10. Exact validator-output acceptance denial or separate
+    validator-output acceptance scope.
+11. Exact receipt-evidence acceptance denial or separate receipt-evidence
+    acceptance scope.
+12. Exact runtime implementation procedure denial.
+13. Exact package loading and package execution denials.
+14. Exact source acceptance and source merge denials.
+15. Exact capability, registry, trust, deployment, distribution, kernel
+    ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+    denials.
+16. Exact post-merge verification requirements.
+
+Until such a later reviewed publication-status sync is published, no
+publication-status sync exists from this publication record.
+
+Until such a later reviewed concrete assignment record is published, no
+concrete accepted-evidence set membership assignment exists from this
+publication record.
+
+Until such a later reviewed accepted-evidence set membership record is
+published, no accepted-evidence set membership exists from this
+publication record.
+
+Until such a later reviewed evidence-item acceptance record is published,
+no evidence item acceptance exists from this publication record.
+
+Until such a later reviewed accepted-evidence record is published, no
+accepted evidence exists from this publication record.
+
+Until such a later reviewed validator-output acceptance record is
+published, no validator output acceptance exists from this publication
+record.
+
+Until such a later reviewed receipt-evidence acceptance record is
+published, no receipt evidence acceptance exists from this publication
+record.
+
+## Excluded Local Draft
+
+This publication record does not consume:
+
+```text
+PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md
+```
+
+If that file exists locally as an untracked file, it remains:
+
+```text
+untracked
+PR-disjoint
+not record input
+not decision input
+not evidence input
+not publication-status sync
+not concrete assignment input
+not membership assignment
+not accepted-evidence set membership
+not accepted evidence
+not evidence item acceptance
+not validator output
+not receipt evidence
+not source authority
+not package acceptance
+not runtime authority
+```
+
+It must not be staged, committed, or included in any Phase-23 concrete
+assignment publication-record PR unless a separate reviewed scope
+explicitly authorizes that file.
+
+## Governance Boundary Invariants
+
+Every later RFC must preserve these Phase-23 publication-record
+invariants:
+
+1. This publication record is bounded concrete accepted-evidence set
+   membership assignment publication record boundary only.
+2. This publication record is not a publication-status sync.
+3. This publication record is not concrete accepted-evidence set
+   membership assignment.
+4. This publication record is not accepted-evidence set membership
+   assignment.
+5. This publication record is not accepted-evidence set membership.
+6. This publication record is not an accepted-evidence set.
+7. This publication record is not accepted evidence.
+8. This publication record is not evidence item acceptance.
+9. This publication record is not validator output acceptance.
+10. This publication record is not receipt evidence acceptance.
+11. Publication record is not publication-status sync unless separately
+    reviewed.
+12. Publication record is not concrete assignment unless separately
+    reviewed.
+13. Publication record is not membership assignment unless separately
+    reviewed.
+14. Publication record is not accepted-evidence set membership unless
+    separately reviewed.
+15. Accepted-evidence set membership assignment is not accepted-evidence
+    set membership unless separately reviewed.
+16. Accepted-evidence set membership is not accepted evidence unless
+    separately reviewed.
+17. Accepted evidence is not evidence item acceptance unless separately
+    reviewed.
+18. This publication record is not runtime implementation procedure.
+19. This publication record is not source modification.
+20. This publication record is not code implementation.
+21. This publication record is not code execution.
+22. This publication record is not process start.
+23. This publication record is not runtime state creation.
+24. This publication record is not package installation.
+25. This publication record is not package loading.
+26. This publication record is not package execution.
+27. This publication record is not capability issuance.
+28. This publication record is not registry publication.
+29. This publication record is not trust assignment.
+30. This publication record is not deployment.
+31. This publication record is not distribution authority.
+32. This publication record is not source acceptance.
+33. This publication record is not source merge authority.
+34. This publication record does not modify `docs/roadmap/CURRENT_PHASE`.
+35. This publication record does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`.
+36. This publication record does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+37. This publication record does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`.
+38. This publication record does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+39. This publication record does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+40. This publication record does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+41. This publication record does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+42. This publication record does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+43. `CURRENT_PHASE=23` is not publication-status sync.
+44. `CURRENT_PHASE=23` is not concrete assignment.
+45. `CURRENT_PHASE=23` is not accepted-evidence set membership.
+46. `CURRENT_PHASE=23` is not accepted evidence.
+47. `CURRENT_PHASE=23` is not evidence item acceptance.
+48. `CURRENT_PHASE=23` is not validator output acceptance.
+49. `CURRENT_PHASE=23` is not receipt evidence acceptance.
+50. `CURRENT_PHASE=23` is not runtime implementation procedure.
+51. `CURRENT_PHASE=23` is not source modification.
+52. `CURRENT_PHASE=23` is not execution authority.
+53. `CURRENT_PHASE=23` is not package loading.
+54. `CURRENT_PHASE=23` is not source merge authority.
+55. This publication record does not broaden Phase-19 runtime authority.
+56. This publication record does not reopen Phase-20.
+57. This publication record does not reopen Phase-21.
+58. This publication record does not reopen Phase-22.
+59. This publication record does not expand kernel ABI or syscalls.
+60. This publication record does not change workflow thresholds,
+    baselines, or dependencies.
+61. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-23 concrete accepted-evidence set membership
+assignment publication record
+**Architecture status:** Local draft concrete accepted-evidence set
+membership assignment publication record / pending separate reviewed
+publication
+**Authority notice:** This signature identifies the architectural
+authorship of this publication record. It grants only the bounded
+concrete accepted-evidence set membership assignment publication record
+boundary defined in this record. It grants no publication-status sync
+authority, concrete assignment authority, membership assignment
+authority, accepted-evidence set membership status, accepted evidence
+status, evidence item acceptance authority, validator output acceptance
+authority, receipt evidence acceptance authority, runtime implementation
+procedure authority, source modification authority, code implementation
+authority, code execution authority, process start authority, general
+runtime authority, unbounded execution authority, runtime state
+authority, package installation authority, package loading authority,
+package execution authority, source merge authority, trust authority,
+registry authority, distribution authority, publication authority,
+capability issuance authority, deployment authority, module authority,
+plugin authority, Semantic CLI authority, AI Runtime authority, agent
+authority, kernel ABI authority, syscall authority, workflow-threshold
+authority, baseline authority, dependency authority, or Ring0 authority.
+
+## Conclusion
+
+This Phase-23 concrete accepted-evidence set membership assignment
+publication record is based on the clean-fixed Phase-23 Concrete
+Accepted-Evidence Set Membership Assignment Publication Record Candidate
+publication subject:
+
+```text
+485b8fafa89ab0df777365e3dd5d3f6ac698364b
+```
+
+It records only the bounded concrete accepted-evidence set membership
+assignment publication record boundary.
+
+This publication record records only a bounded publication record
+boundary, and it does not create a publication-status sync.
+
+It does not create concrete assignment.
+
+It does not assign membership.
+
+It does not create accepted-evidence set membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize publication-status sync, concrete assignment,
+membership assignment, accepted-evidence set membership, accepted
+evidence, evidence item acceptance, validator output acceptance, receipt
+evidence acceptance, runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, capability issuance, registry publication, trust assignment,
+deployment, distribution, source acceptance, source merge, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Any later Phase-23 publication-status sync, concrete-assignment,
+membership-assignment, accepted-evidence-set-membership,
+accepted-evidence, evidence-item-acceptance, validator-output,
+receipt-evidence, package-review, source-review,
+runtime-implementation-procedure, or non-authorization boundary record
+requires its own exact-SHA evidence, changed-file scope,
+non-authorization boundary, and reviewed decision path.


### PR DESCRIPTION
This PR changes only PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md and records only a bounded concrete accepted-evidence set membership assignment publication record boundary. It does not create a publication-status sync, create a concrete assignment, assign membership, create accepted-evidence set membership, create accepted evidence, accept any evidence item, accept validator output, accept receipt evidence, or authorize runtime/source/package/source-merge/capability/registry/trust/deployment/distribution/kernel ABI/syscall/workflow-threshold/baseline/dependency/Ring0 authority.