### PR TITLE
Phase-23 concrete assignment publication-status sync candidate

### DIFF
--- a/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md
+++ b/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md
@@ -1,0 +1,1116 @@
+# Phase-23 Concrete Accepted-Evidence Set Membership Assignment Publication Status Sync Candidate
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY_CLEAN_RECOVERY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_FIRST_BOUNDED_IMPLEMENTATION.md`,
+`PHASE22_CLOSURE_DECISION.md`,
+`PHASE23_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE23_POINTER_TRANSITION_DECISION.md`,
+`docs/roadmap/CURRENT_PHASE`,
+`PHASE23_GOVERNANCE_OVERVIEW.md`,
+`PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`,
+`PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`,
+`PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`,
+and
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`.
+In case of conflict, those documents prevail unless this document is the
+narrower Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync candidate for the exact governance-only
+publication-status-sync-candidate boundary identified below.
+
+**Status:** PHASE-23 CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT
+PUBLICATION STATUS SYNC CANDIDATE / LOCAL DRAFT / GOVERNANCE-ONLY
+PUBLICATION-STATUS SYNC CANDIDATE ONLY / BOUNDED CONCRETE
+ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT PUBLICATION-STATUS SYNC
+PATH CANDIDATE ONLY / NO PUBLICATION-STATUS SYNC / NO PUBLICATION
+STATUS UPDATE / NO CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT
+PUBLICATION RECORD / NO CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP
+ASSIGNMENT / NO ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT / NO
+ACCEPTED-EVIDENCE SET MEMBERSHIP / NO ACCEPTED-EVIDENCE SET / NO
+ACCEPTED EVIDENCE / NO EVIDENCE ITEM ACCEPTANCE / NO VALIDATOR OUTPUT
+ACCEPTANCE / NO RECEIPT EVIDENCE ACCEPTANCE / NO RUNTIME IMPLEMENTATION
+PROCEDURE / NO SOURCE MODIFICATION / NO CODE IMPLEMENTATION / NO CODE
+EXECUTION / NO PROCESS START / NO RUNTIME STATE CREATION / NO PACKAGE
+INSTALLATION / NO PACKAGE LOADING / NO PACKAGE EXECUTION / NO
+DEPLOYMENT / NO CAPABILITY ISSUANCE / NO TRUST ASSIGNMENT / NO REGISTRY
+PUBLICATION / NO DISTRIBUTION AUTHORITY / NO SOURCE ACCEPTANCE / NO
+SOURCE MERGE AUTHORITY / NO KERNEL ABI EXPANSION / NO SYSCALL EXPANSION
+/ NO WORKFLOW-THRESHOLD CHANGE / NO BASELINE CHANGE / NO DEPENDENCY
+CHANGE / NO RING0 AUTHORITY
+**Candidate date:** 2026-07-18
+**Candidate id:**
+`ayken.phase23.concrete_accepted_evidence_set_membership_assignment_publication_status_sync_candidate.v1`
+**Candidate drafting base main SHA:**
+`a7a9d592d91037fbfddd62c861a19664fa8f20e8`
+**Candidate publication subject:** pending separate reviewed publication
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record publication subject:**
+`a7a9d592d91037fbfddd62c861a19664fa8f20e8`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record PR:** PR #287
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record exact-main ci-freeze run:** `29652679534`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record exact-main ci-freeze attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record exact-main ci-freeze job:** `freeze / 88101566112`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record exact-main ci-freeze result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record exact-main Dev Loop Validation run:** `29652679565`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record exact-main Dev Loop Validation attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record exact-main Dev Loop Validation job:** `devloop / 88101566119`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record exact-main Dev Loop Validation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record exact-main Dev Loop CI run:** `29652679551`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record exact-main Dev Loop CI attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record exact-main Dev Loop CI result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record exact-main smoke job:** `smoke / 88101566141`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record exact-main smoke result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record exact-main contract job:** `contract / 88101693435`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record exact-main contract result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record exact-main full job:** `full / 88101885404`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record exact-main full result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record exact-main isolation job:** `isolation / 88102107302`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record exact-main isolation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record exact-main performance job:** `performance / 88102319858`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication record exact-main performance result:** PASS
+**Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate publication subject:**
+`485b8fafa89ab0df777365e3dd5d3f6ac698364b`
+**Phase-23 concrete accepted-evidence set membership assignment decision
+publication subject:** `a9533551e7fe0e278e0299b8a60e60632b4c5162`
+**Phase-23 concrete accepted-evidence set membership assignment decision
+candidate publication subject:** `7a1b5b0210cd045647596c8dbd7d23c1427d6f4f`
+**Phase-23 concrete accepted-evidence set membership assignment candidate
+publication subject:** `e9cb4866ce57240de34ef669b6822097473f9830`
+**Phase-23 concrete accepted-evidence set membership assignment record
+publication subject:** `1d2ec43580e3c919b995365bdb058b852f6b3450`
+**Current phase pointer:** `CURRENT_PHASE=23`
+**Candidate theme:** Governance-only candidate boundary for whether a
+later concrete accepted-evidence set membership assignment
+publication-status sync path may be evaluated after the bounded concrete
+assignment publication record boundary is clean-fixed.
+**Authority boundary:** Publication-status sync candidate only; not a
+publication-status sync, not a publication status update, not a concrete
+accepted-evidence set membership assignment publication record, not
+concrete accepted-evidence set membership assignment, not
+accepted-evidence set membership assignment, not accepted-evidence set
+membership, not an accepted-evidence set, not accepted evidence, not
+evidence item acceptance, not validator output acceptance, not receipt
+evidence acceptance, not runtime implementation procedure, not source
+modification, not code implementation, not code execution, not process
+start, not runtime state creation, not general runtime authority, not
+unbounded execution authority, not package authority, not package
+installation, not package loading, not package execution, not source
+acceptance, not source merge authority, not source repository authority,
+not module loading, not workspace runtime, not plugin loading, not
+capability token minting, not capability issuance, not trust assignment,
+not trust issuer authority, not registry authority, not registry
+publication, not publication authority, not deployment authority, not
+distribution authority, not distribution execution, not Semantic CLI
+authority, not AI Runtime authority, not agent authority, not syscall
+expansion, not kernel ABI expansion, not workflow-threshold, baseline,
+dependency, or Ring0 authority.
+
+## Purpose
+
+This document records a Phase-23 governance-only concrete
+accepted-evidence set membership assignment publication-status sync
+candidate after the clean-fixed Phase-23 Concrete Accepted-Evidence Set
+Membership Assignment Publication Record publication.
+
+It answers only:
+
+```text
+May a later publication-status sync path be evaluated for the
+clean-fixed concrete accepted-evidence set membership assignment
+publication record without creating a publication-status sync, assigning
+membership, accepting any evidence item, or creating accepted evidence?
+```
+
+It maps only the fail-closed candidate prerequisites for that future
+publication-status sync path.
+
+It does not create a publication-status sync.
+
+It does not update publication status.
+
+It does not create a concrete accepted-evidence set membership assignment
+publication record.
+
+It does not create a concrete accepted-evidence set membership
+assignment.
+
+It does not assign accepted-evidence set membership.
+
+It does not create accepted-evidence set membership.
+
+It does not create an accepted-evidence set.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not convert CI PASS results, receipts, validator output, package
+review output, source review output, historical results, publication
+records, publication record candidates, or clean-fixed claims into
+publication-status sync, concrete assignment, membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, or receipt evidence acceptance.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, source acceptance, source merge, registry publication, trust
+assignment, capability issuance, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+It does not answer:
+
+```text
+How is publication status synchronized?
+Which publication metadata is updated?
+How is a concrete assignment created?
+How is membership assigned?
+Which accepted-evidence set membership exists?
+Which evidence is accepted?
+Which evidence item is accepted?
+How is validator output accepted?
+How is receipt evidence accepted?
+How is runtime implementation procedure defined?
+How is source modified?
+How is code implemented or executed?
+How is a package installed, loaded, executed, deployed, or distributed?
+How is source accepted or merged?
+How is a capability issued?
+How is trust assigned?
+How is a registry entry published?
+How is kernel ABI or syscall surface expanded?
+How are workflow thresholds, baselines, or dependencies changed?
+```
+
+Those questions require later reviewed decision or record paths, if ever
+authorized.
+
+## Exact Subject
+
+This candidate is based on exact main SHA:
+
+```text
+a7a9d592d91037fbfddd62c861a19664fa8f20e8
+```
+
+That subject is the squash merge of PR #287:
+
+```text
+Phase-23 concrete accepted-evidence set membership assignment publication record
+```
+
+PR #287 changed only:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md
+```
+
+PR #287 produced post-merge exact-main verification:
+
+| Evidence | Run / job | Result |
+|---|---|---|
+| `ci-freeze` | run `29652679534`, attempt 1, job `freeze / 88101566112` | PASS |
+| Dev Loop Validation | run `29652679565`, attempt 1, job `devloop / 88101566119` | PASS |
+| AykenOS Dev Loop CI | run `29652679551`, attempt 1 | PASS |
+| smoke | job `88101566141` | PASS |
+| contract | job `88101693435` | PASS |
+| full | job `88101885404` | PASS |
+| isolation | job `88102107302` | PASS |
+| performance | job `88102319858` | PASS |
+
+The Phase-23 Concrete Accepted-Evidence Set Membership Assignment
+Publication Record remains bound to:
+
+```text
+a7a9d592d91037fbfddd62c861a19664fa8f20e8
+```
+
+That publication record recorded only the bounded concrete
+accepted-evidence set membership assignment publication record boundary
+as a governance record boundary.
+
+That publication record did not create a publication-status sync.
+
+That publication record did not create a concrete assignment.
+
+That publication record did not assign membership.
+
+That publication record did not create accepted-evidence set membership.
+
+That publication record did not create accepted evidence.
+
+That publication record did not accept any evidence item.
+
+This candidate consumes that exact subject as governance input only. It
+does not replace, broaden, reinterpret, or supersede the publication
+record or any earlier Phase-23 governance boundary.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped subject readings fail closed.
+
+## Core Rule
+
+```text
+concrete accepted-evidence set membership assignment publication-status sync candidate != publication-status sync
+concrete accepted-evidence set membership assignment publication-status sync candidate != publication status update
+concrete accepted-evidence set membership assignment publication-status sync candidate != concrete accepted-evidence set membership assignment publication record
+concrete accepted-evidence set membership assignment publication-status sync candidate != concrete accepted-evidence set membership assignment
+concrete accepted-evidence set membership assignment publication-status sync candidate != accepted-evidence set membership assignment
+concrete accepted-evidence set membership assignment publication-status sync candidate != accepted-evidence set membership
+concrete accepted-evidence set membership assignment publication-status sync candidate != accepted-evidence set
+concrete accepted-evidence set membership assignment publication-status sync candidate != accepted evidence
+concrete accepted-evidence set membership assignment publication-status sync candidate != evidence item acceptance
+concrete accepted-evidence set membership assignment publication-status sync candidate != validator output acceptance
+concrete accepted-evidence set membership assignment publication-status sync candidate != receipt evidence acceptance
+concrete accepted-evidence set membership assignment publication-status sync candidate != runtime implementation procedure
+concrete accepted-evidence set membership assignment publication-status sync candidate != source modification
+concrete accepted-evidence set membership assignment publication-status sync candidate != package loading
+concrete accepted-evidence set membership assignment publication-status sync candidate != package execution
+concrete accepted-evidence set membership assignment publication-status sync candidate != source acceptance
+concrete accepted-evidence set membership assignment publication-status sync candidate != source merge
+publication-status sync candidate != publication-status sync
+publication-status sync candidate != decision
+publication-status sync candidate != authority grant
+publication-status sync candidate != publication status update
+publication-status sync != concrete assignment unless separately reviewed
+publication-status sync != membership assignment unless separately reviewed
+publication-status sync != accepted-evidence set membership unless separately reviewed
+publication-status sync != accepted evidence unless separately reviewed
+publication-status sync != evidence item acceptance unless separately reviewed
+publication record != publication-status sync unless separately reviewed
+publication record != concrete assignment unless separately reviewed
+publication record != membership assignment unless separately reviewed
+publication record != accepted-evidence set membership unless separately reviewed
+publication record != accepted evidence unless separately reviewed
+publication record != evidence item acceptance unless separately reviewed
+concrete assignment decision != concrete assignment unless separately reviewed
+concrete assignment decision != membership assignment unless separately reviewed
+accepted-evidence set membership assignment != accepted-evidence set membership unless separately reviewed
+accepted-evidence set membership != accepted evidence unless separately reviewed
+accepted evidence != evidence item acceptance unless separately reviewed
+accepted evidence != validator output unless separately reviewed
+accepted evidence != receipt evidence unless separately reviewed
+validator output != accepted evidence
+receipt evidence != accepted evidence
+receipt evidence != validator output
+CI PASS != publication-status sync
+CI PASS != publication status update
+CI PASS != concrete accepted-evidence set membership assignment
+CI PASS != accepted-evidence set membership
+CI PASS != accepted evidence
+ci-freeze PASS != publication-status sync
+ci-freeze PASS != publication status update
+ci-freeze PASS != concrete accepted-evidence set membership assignment
+ci-freeze PASS != accepted-evidence set membership
+ci-freeze PASS != accepted evidence
+Dev Loop PASS != publication-status sync
+Dev Loop PASS != publication status update
+Dev Loop PASS != concrete accepted-evidence set membership assignment
+Dev Loop PASS != accepted-evidence set membership
+Dev Loop PASS != accepted evidence
+AykenOS Dev Loop CI PASS != publication-status sync
+AykenOS Dev Loop CI PASS != publication status update
+AykenOS Dev Loop CI PASS != concrete accepted-evidence set membership assignment
+AykenOS Dev Loop CI PASS != accepted-evidence set membership
+AykenOS Dev Loop CI PASS != accepted evidence
+post-merge exact-main verification != publication-status sync
+post-merge exact-main verification != publication status update
+post-merge exact-main verification != concrete accepted-evidence set membership assignment
+post-merge exact-main verification != accepted-evidence set membership
+post-merge exact-main verification != accepted evidence
+clean-fixed != publication-status sync
+clean-fixed != publication status update
+clean-fixed != concrete accepted-evidence set membership assignment
+clean-fixed != accepted-evidence set membership
+clean-fixed != accepted evidence
+CURRENT_PHASE=23 != publication-status sync
+CURRENT_PHASE=23 != publication status update
+CURRENT_PHASE=23 != concrete accepted-evidence set membership assignment
+CURRENT_PHASE=23 != accepted-evidence set membership
+CURRENT_PHASE=23 != accepted evidence
+CURRENT_PHASE=23 != evidence item acceptance
+CURRENT_PHASE=23 != validator output acceptance
+CURRENT_PHASE=23 != receipt evidence acceptance
+CURRENT_PHASE=23 != runtime implementation procedure
+CURRENT_PHASE=23 != source modification
+CURRENT_PHASE=23 != execution authority
+CURRENT_PHASE=23 != package loading
+CURRENT_PHASE=23 != source merge authority
+CURRENT_PHASE=23 != kernel ABI expansion
+CURRENT_PHASE=23 != syscall expansion
+historical PASS != inherited evidence
+previous PR evidence != later PR evidence
+```
+
+The safe default remains no publication-status sync, no publication
+status update, no concrete assignment, no membership assignment, no
+accepted-evidence set membership, no accepted evidence, no evidence item
+acceptance, no validator output acceptance, no receipt evidence
+acceptance, no runtime behavior, no implementation procedure, no source
+modification, no code execution, no runtime state, and no package,
+capability, registry, trust, distribution, deployment, source
+acceptance, source merge, kernel ABI, syscall, workflow-threshold,
+baseline, dependency, or Ring0 authority unless a later reviewed
+Phase-23 decision or record grants a specific bounded authority with its
+own exact-SHA evidence.
+
+Unknown authority readings fail closed.
+
+## Publication-Status Sync Candidate Boundary
+
+This candidate may be used only to evaluate whether a later
+publication-status sync path can be reviewed.
+
+The only later-evaluable boundary is:
+
+```text
+bounded concrete accepted-evidence set membership assignment
+publication-status sync path as a future reviewed record
+```
+
+This candidate does not create a publication-status sync.
+
+This candidate does not update publication status.
+
+This candidate does not update the publication subject of any prior
+record.
+
+This candidate does not create a concrete assignment.
+
+This candidate does not assign membership.
+
+This candidate does not create accepted-evidence set membership.
+
+This candidate does not create accepted evidence.
+
+This candidate does not accept any evidence item.
+
+This candidate does not accept validator output.
+
+This candidate does not accept receipt evidence.
+
+This candidate does not make a later publication-status sync inevitable.
+
+Any later publication-status sync requires a separate reviewed record
+with its own exact subject, changed-file scope, metadata scope,
+non-authorization boundary, and post-merge exact-main verification.
+
+## Candidate Scope
+
+This candidate scope is limited to:
+
+1. Mapping publication-status sync as a later candidate topic.
+2. Binding this candidate to PR #287 as the clean-fixed publication
+   record input.
+3. Preserving the distinction between publication-status sync candidate
+   and publication-status sync.
+4. Preserving the distinction between publication-status sync and
+   concrete assignment.
+5. Preserving the distinction between concrete assignment and
+   accepted-evidence set membership.
+6. Preserving the distinction between accepted-evidence set membership
+   and accepted evidence.
+7. Preserving separation from evidence item acceptance, validator output
+   acceptance, and receipt evidence acceptance.
+8. Establishing post-merge exact-main verification expectations for this
+   publication-status sync candidate record.
+
+Candidate scope is governance text only.
+
+Candidate scope is publication-status sync candidate only.
+
+Candidate scope is not publication-status sync.
+
+Candidate scope is not publication status update.
+
+Candidate scope is not concrete assignment.
+
+Candidate scope is not membership assignment.
+
+Candidate scope is not accepted-evidence set membership.
+
+Candidate scope is not accepted evidence.
+
+Candidate scope is not evidence item acceptance.
+
+Candidate scope is not validator output acceptance.
+
+Candidate scope is not receipt evidence acceptance.
+
+Candidate scope is not runtime implementation procedure.
+
+Candidate scope is not package loading authority.
+
+Candidate scope is not execution authority.
+
+Candidate scope is not source merge authority.
+
+## Current Phase Pointer Boundary
+
+The current phase pointer remains:
+
+```text
+CURRENT_PHASE=23
+```
+
+This candidate does not modify:
+
+```text
+docs/roadmap/CURRENT_PHASE
+```
+
+This candidate does not change the active phase pointer.
+
+`CURRENT_PHASE=23` does not authorize publication-status sync,
+publication status update, concrete assignment, membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime implementation procedure, source modification, code
+implementation, code execution, process start, runtime state creation,
+package loading, package execution, capability issuance, registry
+publication, trust assignment, deployment, distribution, source
+acceptance, source merge, kernel ABI expansion, syscall expansion,
+workflow-threshold changes, baseline changes, dependency changes, or
+Ring0 authority.
+
+## Publication Record Input
+
+This candidate consumes the clean-fixed Phase-23 Concrete
+Accepted-Evidence Set Membership Assignment Publication Record as its
+exact governance prerequisite.
+
+The publication record remains bound to:
+
+```text
+a7a9d592d91037fbfddd62c861a19664fa8f20e8
+```
+
+The publication record recorded only the bounded concrete
+accepted-evidence set membership assignment publication record boundary
+as a governance record boundary.
+
+This candidate does not reinterpret the publication record as
+publication-status sync, publication status update, concrete assignment,
+membership assignment, accepted-evidence set membership, accepted
+evidence, evidence item acceptance, validator output acceptance, receipt
+evidence acceptance, runtime implementation procedure, execution
+authority, package loading authority, source acceptance, source merge
+authority, capability issuance, registry publication, trust assignment,
+deployment, distribution, kernel ABI expansion, syscall expansion,
+workflow-threshold change, baseline change, dependency change, or Ring0
+authority.
+
+Any publication-record conflict fails closed.
+
+## Relationship To Publication Status Sync
+
+This candidate is not a publication-status sync.
+
+This candidate does not update publication metadata.
+
+This candidate does not update the publication status of the Phase-23
+Concrete Accepted-Evidence Set Membership Assignment Publication Record.
+
+This candidate does not record PR #287 as status-synced.
+
+This candidate does not create metadata authority.
+
+This candidate does not convert publication metadata into concrete
+assignment, membership assignment, accepted-evidence set membership,
+accepted evidence, evidence item acceptance, validator output
+acceptance, or receipt evidence acceptance.
+
+Any publication-status reading outside this candidate scope fails
+closed.
+
+## Relationship To Concrete Assignment And Membership
+
+Concrete assignment remains separate from publication-status sync unless
+a separate reviewed record explicitly grants that narrower authority.
+
+This candidate does not create a concrete accepted-evidence set
+membership assignment.
+
+This candidate does not assign membership.
+
+This candidate does not create accepted-evidence set membership.
+
+This candidate does not identify any accepted-evidence set membership as
+assigned.
+
+This candidate does not make concrete assignment inevitable.
+
+This candidate does not make accepted-evidence set membership
+inevitable.
+
+Any attempt to treat this candidate as concrete assignment or
+accepted-evidence set membership fails closed.
+
+## Relationship To Accepted Evidence And Evidence Item Acceptance
+
+Accepted evidence remains separate from publication-status sync,
+concrete assignment, membership assignment, and accepted-evidence set
+membership unless a separate reviewed record explicitly grants that
+narrower authority.
+
+This candidate does not create accepted evidence.
+
+This candidate does not identify accepted evidence.
+
+This candidate does not accept any evidence item.
+
+This candidate does not define evidence item acceptance scope.
+
+This candidate does not make accepted evidence inevitable.
+
+This candidate does not make evidence item acceptance inevitable.
+
+Any attempt to treat this candidate as accepted evidence or evidence item
+acceptance fails closed.
+
+## Relationship To Validator Output And Receipt Evidence
+
+This candidate consumes the clean-fixed Phase-23 Validator-Output
+Boundary Planning and Receipt-Evidence Boundary Planning records as exact
+governance prerequisites only.
+
+The Phase-23 Validator-Output Boundary Planning publication-status sync
+remains bound to:
+
+```text
+d225b2b5ffcd83fe12c70bf0150b60f8f288f329
+```
+
+The Phase-23 Receipt-Evidence Boundary Planning publication-status sync
+remains bound to:
+
+```text
+9153d858c8ca99b09beb2fa60c6c7bcc565445a9
+```
+
+This candidate does not convert validator output into accepted evidence.
+
+This candidate does not convert receipt evidence into accepted evidence.
+
+This candidate does not accept validator output.
+
+This candidate does not accept receipt evidence.
+
+This candidate does not grant accepted-evidence membership or accepted
+evidence status over validator output, receipt evidence, package review
+output, source review output, historical PASS results, publication
+records, publication-status sync claims, or clean-fixed claims.
+
+Any validator-output or receipt-evidence boundary conflict fails closed.
+
+## Relationship To Phase-19 Runtime Authority
+
+This candidate remains subordinate to Phase-19 runtime authority records.
+
+This candidate must not broaden, replace, supersede, weaken, or
+reinterpret Phase-19 runtime authority records.
+
+This candidate must not use publication-status sync candidate planning to
+infer runtime authority.
+
+This candidate must not use concrete assignment records to infer runtime
+authority.
+
+This candidate must not use accepted-evidence authority to infer runtime
+authority.
+
+This candidate must not use accepted-evidence decision records to infer
+runtime authority.
+
+This candidate must not use validator-output planning to infer runtime
+authority.
+
+This candidate must not use receipt-evidence planning to infer runtime
+authority.
+
+This candidate must not use exact-SHA evidence expectations to infer
+runtime authority.
+
+This candidate must not use `CURRENT_PHASE=23` to infer runtime
+authority.
+
+Any Phase-23 publication-status sync candidate reading that conflicts
+with Phase-19 runtime authority records fails closed.
+
+## Not Authorized By This Candidate
+
+This candidate does not authorize:
+
+1. Publication-status sync.
+2. Publication status update.
+3. Concrete accepted-evidence set membership assignment.
+4. Accepted-evidence set membership assignment.
+5. Accepted-evidence set membership.
+6. Accepted-evidence set creation.
+7. Accepted evidence.
+8. Evidence item acceptance.
+9. Validator output acceptance.
+10. Receipt evidence acceptance.
+11. Runtime implementation procedure.
+12. Source modification.
+13. Source acceptance.
+14. Source merge.
+15. Code implementation.
+16. Code execution.
+17. Process start.
+18. Runtime state creation.
+19. Package installation.
+20. Package loading.
+21. Package execution.
+22. Module loading.
+23. Workspace runtime or real mounts.
+24. Plugin loading or plugin instantiation.
+25. Capability token minting.
+26. Capability issuance.
+27. Registry publication.
+28. Trust assignment.
+29. Distribution execution.
+30. Deployment.
+31. Semantic CLI authority.
+32. AI Runtime authority.
+33. Agent authority.
+34. Syscall expansion.
+35. Kernel ABI expansion.
+36. Ring0 policy movement.
+37. Workflow-threshold changes.
+38. Baseline changes.
+39. Dependency changes.
+40. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this candidate is published, the publication may change only this
+file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md
+```
+
+The publication must not change:
+
+1. `docs/roadmap/CURRENT_PHASE`.
+2. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`.
+3. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`.
+4. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+5. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`.
+6. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+7. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+8. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+9. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+10. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+11. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`.
+12. `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`.
+13. `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`.
+14. `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`.
+15. CI workflows.
+16. Baselines.
+17. Dependencies.
+18. Runtime source or kernel source.
+19. Syscalls or kernel ABI.
+20. Package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution paths.
+21. `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md`.
+
+Any changed-file expansion beyond this candidate requires separate
+review and fails this candidate scope.
+
+## Post-Merge Exact-Main Evidence Rule
+
+If this candidate is later published, the candidate publication subject
+must receive its own post-merge exact-main verification:
+
+1. `ci-freeze` PASS for the exact candidate publication SHA.
+2. Dev Loop Validation PASS for the exact candidate publication SHA.
+3. AykenOS Dev Loop CI PASS for the exact candidate publication SHA.
+4. smoke PASS.
+5. contract PASS.
+6. full PASS.
+7. isolation PASS.
+8. performance PASS.
+9. Exact changed-file list confirmation.
+10. No `docs/roadmap/CURRENT_PHASE` change.
+11. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`
+    change.
+12. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`
+    change.
+13. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`
+    change.
+14. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`
+    change.
+15. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`
+    change.
+16. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`
+    change.
+17. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`
+    change.
+18. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`
+    change.
+19. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`
+    change.
+20. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md` change.
+21. No `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md` change.
+22. No `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md` change.
+23. No `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md` change.
+24. No CI workflow change.
+25. No baseline change.
+26. No dependency change.
+27. No runtime source or kernel source change.
+28. No syscall or kernel ABI change.
+29. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution change.
+
+Until that exact-main post-merge verification exists, this candidate
+must not be recorded as clean-fixed.
+
+Historical PASS results may be cited as context only.
+
+Failed attempts may be cited as transparent non-clean context only.
+
+They cannot be inherited as publication-status sync, publication status
+update, concrete assignment, membership assignment, accepted-evidence set
+membership, accepted evidence, evidence item acceptance, validator output
+acceptance, receipt evidence acceptance, runtime authority, package
+loading authority, package execution authority, source merge authority,
+capability authority, registry authority, trust authority, kernel ABI
+authority, syscall authority, workflow-threshold authority, baseline
+authority, dependency authority, or Ring0 authority.
+
+## Later Publication-Status Sync Dependency
+
+This candidate is a prerequisite input for a possible later bounded
+publication-status sync record.
+
+A later publication-status sync, if ever proposed, must define:
+
+1. Exact publication-status sync subject.
+2. Exact Phase-23 publication-status sync candidate prerequisite.
+3. Exact changed-file boundary.
+4. Exact metadata scope.
+5. Exact publication record subject being synchronized, if any.
+6. Exact denial that publication-status sync is concrete assignment.
+7. Exact denial that publication-status sync is membership assignment.
+8. Exact denial that publication-status sync is accepted-evidence set
+   membership.
+9. Exact denial that publication-status sync is accepted evidence.
+10. Exact denial that publication-status sync is evidence item
+    acceptance.
+11. Exact validator-output acceptance denial or separate
+    validator-output acceptance scope.
+12. Exact receipt-evidence acceptance denial or separate receipt-evidence
+    acceptance scope.
+13. Exact runtime implementation procedure denial.
+14. Exact package loading and package execution denials.
+15. Exact source acceptance and source merge denials.
+16. Exact capability, registry, trust, deployment, distribution, kernel
+    ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+    denials.
+17. Exact post-merge verification requirements.
+
+Until such a later reviewed publication-status sync is published, no
+publication-status sync exists from this candidate.
+
+Until such a later reviewed concrete assignment record is published, no
+concrete accepted-evidence set membership assignment exists from this
+candidate.
+
+Until such a later reviewed accepted-evidence set membership record is
+published, no accepted-evidence set membership exists from this
+candidate.
+
+Until such a later reviewed evidence-item acceptance record is published,
+no evidence item acceptance exists from this candidate.
+
+Until such a later reviewed accepted-evidence record is published, no
+accepted evidence exists from this candidate.
+
+Until such a later reviewed validator-output acceptance record is
+published, no validator output acceptance exists from this candidate.
+
+Until such a later reviewed receipt-evidence acceptance record is
+published, no receipt evidence acceptance exists from this candidate.
+
+## Excluded Local Draft
+
+This candidate does not consume:
+
+```text
+PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md
+```
+
+If that file exists locally as an untracked file, it remains:
+
+```text
+untracked
+PR-disjoint
+not candidate input
+not publication-status sync input
+not concrete assignment input
+not membership assignment input
+not evidence input
+not accepted evidence
+not evidence item acceptance
+not source authority
+not package acceptance
+not runtime authority
+```
+
+It must not be staged, committed, or included in any Phase-23
+publication-status sync candidate PR unless a separate reviewed scope
+explicitly authorizes that file.
+
+## Governance Boundary Invariants
+
+Every later RFC must preserve these Phase-23 publication-status sync
+candidate invariants:
+
+1. This candidate is publication-status sync candidate only.
+2. This candidate is not publication-status sync.
+3. This candidate is not publication status update.
+4. This candidate is not concrete accepted-evidence set membership
+   assignment.
+5. This candidate is not accepted-evidence set membership assignment.
+6. This candidate is not accepted-evidence set membership.
+7. This candidate is not an accepted-evidence set.
+8. This candidate is not accepted evidence.
+9. This candidate is not evidence item acceptance.
+10. This candidate is not validator output acceptance.
+11. This candidate is not receipt evidence acceptance.
+12. Publication-status sync candidate is not publication-status sync.
+13. Publication-status sync candidate is not a decision.
+14. Publication-status sync candidate is not an authority grant.
+15. Publication-status sync is not concrete assignment unless separately
+    reviewed.
+16. Publication-status sync is not membership assignment unless
+    separately reviewed.
+17. Publication-status sync is not accepted-evidence set membership
+    unless separately reviewed.
+18. Publication-status sync is not accepted evidence unless separately
+    reviewed.
+19. Publication-status sync is not evidence item acceptance unless
+    separately reviewed.
+20. This candidate is not runtime implementation procedure.
+21. This candidate is not source modification.
+22. This candidate is not code implementation.
+23. This candidate is not code execution.
+24. This candidate is not process start.
+25. This candidate is not runtime state creation.
+26. This candidate is not package installation.
+27. This candidate is not package loading.
+28. This candidate is not package execution.
+29. This candidate is not capability issuance.
+30. This candidate is not registry publication.
+31. This candidate is not trust assignment.
+32. This candidate is not deployment.
+33. This candidate is not distribution authority.
+34. This candidate is not source acceptance.
+35. This candidate is not source merge authority.
+36. This candidate does not modify `docs/roadmap/CURRENT_PHASE`.
+37. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`.
+38. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`.
+39. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+40. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`.
+41. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+42. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+43. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+44. This candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+45. This candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+46. This candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`.
+47. This candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`.
+48. This candidate does not modify `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`.
+49. This candidate does not modify
+    `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`.
+50. `CURRENT_PHASE=23` is not publication-status sync.
+51. `CURRENT_PHASE=23` is not publication status update.
+52. `CURRENT_PHASE=23` is not concrete accepted-evidence set membership
+    assignment.
+53. `CURRENT_PHASE=23` is not accepted-evidence set membership.
+54. `CURRENT_PHASE=23` is not accepted evidence.
+55. `CURRENT_PHASE=23` is not evidence item acceptance.
+56. `CURRENT_PHASE=23` is not validator output acceptance.
+57. `CURRENT_PHASE=23` is not receipt evidence acceptance.
+58. `CURRENT_PHASE=23` is not runtime implementation procedure.
+59. `CURRENT_PHASE=23` is not source modification.
+60. `CURRENT_PHASE=23` is not execution authority.
+61. `CURRENT_PHASE=23` is not package loading.
+62. `CURRENT_PHASE=23` is not source merge authority.
+63. This candidate does not broaden Phase-19 runtime authority.
+64. This candidate does not reopen Phase-20.
+65. This candidate does not reopen Phase-21.
+66. This candidate does not reopen Phase-22.
+67. This candidate does not expand kernel ABI or syscalls.
+68. This candidate does not change workflow thresholds, baselines, or
+    dependencies.
+69. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-23 concrete accepted-evidence set membership
+assignment publication-status sync candidate
+**Architecture status:** Local draft publication-status sync candidate /
+pending separate reviewed publication
+**Authority notice:** This signature identifies the architectural
+authorship of this candidate. It grants no publication-status sync
+authority, publication status update authority, concrete assignment
+authority, accepted-evidence set membership assignment authority,
+accepted-evidence set membership authority, accepted-evidence set
+authority, accepted evidence status, evidence item acceptance authority,
+validator output acceptance authority, receipt evidence acceptance
+authority, runtime implementation procedure authority, source
+modification authority, code implementation authority, code execution
+authority, process start authority, general runtime authority, unbounded
+execution authority, runtime state authority, package installation
+authority, package loading authority, package execution authority, source
+merge authority, trust authority, registry authority, distribution
+authority, publication authority, capability issuance authority,
+deployment authority, module authority, plugin authority, Semantic CLI
+authority, AI Runtime authority, agent authority, kernel ABI authority,
+syscall authority, workflow-threshold authority, baseline authority,
+dependency authority, or Ring0 authority.
+
+## Conclusion
+
+This Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync candidate is based on the clean-fixed Phase-23
+Concrete Accepted-Evidence Set Membership Assignment Publication Record
+publication subject:
+
+```text
+a7a9d592d91037fbfddd62c861a19664fa8f20e8
+```
+
+It defines only the governance-only candidate boundary for whether a
+later publication-status sync path may be evaluated after the bounded
+concrete accepted-evidence set membership assignment publication record
+boundary exists.
+
+It does not create a publication-status sync.
+
+It does not update publication status.
+
+It does not create a concrete assignment.
+
+It does not assign membership.
+
+It does not create accepted-evidence set membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize publication-status sync, publication status
+update, concrete assignment, membership assignment, accepted-evidence set
+membership, accepted evidence, evidence item acceptance, validator
+output acceptance, receipt evidence acceptance, runtime implementation
+procedure, source modification, code implementation, code execution,
+process start, runtime state creation, package installation, package
+loading, package execution, capability issuance, registry publication,
+trust assignment, deployment, distribution, source acceptance, source
+merge, kernel ABI expansion, syscall expansion, workflow-threshold
+changes, baseline changes, dependency changes, or Ring0 authority.
+
+Any later Phase-23 publication-status sync, concrete-assignment,
+membership, accepted-evidence, evidence-item, validator-output,
+receipt-evidence, package-review, source-review,
+runtime-implementation-procedure, or non-authorization boundary record
+requires its own exact-SHA evidence, changed-file scope,
+non-authorization boundary, and reviewed decision or record path.


### PR DESCRIPTION
This PR changes only PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md and defines only a governance-only candidate boundary for whether a later concrete accepted-evidence set membership assignment publication-status sync path may be evaluated after PR #287 at a7a9d592d91037fbfddd62c861a19664fa8f20e8. It does not create a publication-status sync, update publication status, create a concrete assignment, assign membership, create accepted-evidence set membership, create accepted evidence, accept any evidence item, accept validator output, accept receipt evidence, or authorize runtime/source/package/source-merge/capability/registry/trust/deployment/distribution/kernel ABI/syscall/workflow-threshold/baseline/dependency/Ring0 authority.