### PR TITLE
Phase-23 concrete accepted-evidence set membership assignment post-sync candidate

### DIFF
--- a/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md
+++ b/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md
@@ -1,0 +1,1158 @@
+# Phase-23 Concrete Accepted-Evidence Set Membership Assignment Post-Sync Candidate
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY_CLEAN_RECOVERY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_FIRST_BOUNDED_IMPLEMENTATION.md`,
+`PHASE22_CLOSURE_DECISION.md`,
+`PHASE23_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE23_POINTER_TRANSITION_DECISION.md`,
+`docs/roadmap/CURRENT_PHASE`,
+`PHASE23_GOVERNANCE_OVERVIEW.md`,
+`PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`,
+`PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`,
+`PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md`,
+and
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`.
+In case of conflict, those documents prevail unless this document is the
+narrower Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate for the exact governance-only post-sync candidate
+boundary identified below.
+
+**Status:** PHASE-23 CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT
+POST-SYNC CANDIDATE / LOCAL DRAFT / GOVERNANCE-ONLY POST-SYNC CANDIDATE
+ONLY / BOUNDED CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT
+POST-SYNC CANDIDATE BOUNDARY ONLY / NO CONCRETE ACCEPTED-EVIDENCE SET
+MEMBERSHIP ASSIGNMENT / NO ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT /
+NO ACCEPTED-EVIDENCE SET MEMBERSHIP / NO ACCEPTED-EVIDENCE SET / NO
+ACCEPTED EVIDENCE / NO EVIDENCE ITEM ACCEPTANCE / NO VALIDATOR OUTPUT
+ACCEPTANCE / NO RECEIPT EVIDENCE ACCEPTANCE / NO RUNTIME IMPLEMENTATION
+PROCEDURE / NO SOURCE MODIFICATION / NO CODE IMPLEMENTATION / NO CODE
+EXECUTION / NO PROCESS START / NO RUNTIME STATE CREATION / NO PACKAGE
+INSTALLATION / NO PACKAGE LOADING / NO PACKAGE EXECUTION / NO DEPLOYMENT /
+NO CAPABILITY ISSUANCE / NO TRUST ASSIGNMENT / NO REGISTRY PUBLICATION /
+NO DISTRIBUTION AUTHORITY / NO SOURCE ACCEPTANCE / NO SOURCE MERGE
+AUTHORITY / NO KERNEL ABI EXPANSION / NO SYSCALL EXPANSION / NO
+WORKFLOW-THRESHOLD CHANGE / NO BASELINE CHANGE / NO DEPENDENCY CHANGE /
+NO RING0 AUTHORITY
+**Candidate date:** 2026-07-18
+**Candidate id:**
+`ayken.phase23.concrete_accepted_evidence_set_membership_assignment_post_sync_candidate.v1`
+**Candidate drafting base main SHA:**
+`5edd974c7d3c40eaf154fb2ae60d69f8aa24f3e6`
+**Candidate publication subject:** pending separate reviewed publication
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync publication subject:**
+`5edd974c7d3c40eaf154fb2ae60d69f8aa24f3e6`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync PR:** PR #289
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync exact-main ci-freeze run:** `29655098287`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync exact-main ci-freeze attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync exact-main ci-freeze job:**
+`freeze / 88107884124`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync exact-main ci-freeze result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync exact-main Dev Loop Validation run:** `29655098326`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync exact-main Dev Loop Validation attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync exact-main Dev Loop Validation job:**
+`devloop / 88107884417`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync exact-main Dev Loop Validation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync exact-main Dev Loop CI run:** `29655098320`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync exact-main Dev Loop CI attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync exact-main Dev Loop CI result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync exact-main smoke job:** `smoke / 88107884229`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync exact-main smoke result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync exact-main contract job:** `contract / 88107970040`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync exact-main contract result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync exact-main full job:** `full / 88108162887`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync exact-main full result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync exact-main isolation job:**
+`isolation / 88108401362`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync exact-main isolation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync exact-main performance job:**
+`performance / 88108604620`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync exact-main performance result:** PASS
+**Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync candidate publication subject:**
+`0c25ace3ef87d830f31d86cb63246755b77cf6e0`
+**Phase-23 concrete accepted-evidence set membership assignment
+publication record publication subject:**
+`a7a9d592d91037fbfddd62c861a19664fa8f20e8`
+**Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate publication subject:**
+`485b8fafa89ab0df777365e3dd5d3f6ac698364b`
+**Phase-23 concrete accepted-evidence set membership assignment decision
+publication subject:** `a9533551e7fe0e278e0299b8a60e60632b4c5162`
+**Phase-23 concrete accepted-evidence set membership assignment decision
+candidate publication subject:** `7a1b5b0210cd045647596c8dbd7d23c1427d6f4f`
+**Phase-23 concrete accepted-evidence set membership assignment candidate
+publication subject:** `e9cb4866ce57240de34ef669b6822097473f9830`
+**Phase-23 concrete accepted-evidence set membership assignment record
+publication subject:** `1d2ec43580e3c919b995365bdb058b852f6b3450`
+**Current phase pointer:** `CURRENT_PHASE=23`
+**Candidate theme:** Governance-only post-sync candidate boundary for
+whether a later bounded concrete accepted-evidence set membership
+assignment candidate path may be evaluated after the clean-fixed
+publication-status sync boundary at
+`5edd974c7d3c40eaf154fb2ae60d69f8aa24f3e6`.
+**Authority boundary:** Post-sync candidate boundary only; not concrete
+accepted-evidence set membership assignment, not accepted-evidence set
+membership assignment, not accepted-evidence set membership, not an
+accepted-evidence set, not accepted evidence, not evidence item
+acceptance, not validator output acceptance, not receipt evidence
+acceptance, not runtime implementation procedure, not source
+modification, not code implementation, not code execution, not process
+start, not runtime state creation, not general runtime authority, not
+unbounded execution authority, not package authority, not package
+installation, not package loading, not package execution, not source
+acceptance, not source merge authority, not source repository authority,
+not module loading, not workspace runtime, not plugin loading, not
+capability token minting, not capability issuance, not trust assignment,
+not trust issuer authority, not registry authority, not registry
+publication, not publication authority, not deployment authority, not
+distribution authority, not distribution execution, not Semantic CLI
+authority, not AI Runtime authority, not agent authority, not syscall
+expansion, not kernel ABI expansion, not workflow-threshold, baseline,
+dependency, or Ring0 authority.
+
+## Purpose
+
+This document records a Phase-23 governance-only concrete
+accepted-evidence set membership assignment post-sync candidate after the
+clean-fixed Phase-23 Concrete Accepted-Evidence Set Membership Assignment
+Publication Status Sync publication.
+
+It answers only:
+
+```text
+May a bounded concrete accepted-evidence set membership assignment
+candidate path be evaluated after the clean-fixed publication-status sync
+boundary at 5edd974c7d3c40eaf154fb2ae60d69f8aa24f3e6 without creating a
+concrete assignment, assigning membership, creating accepted-evidence set
+membership, creating accepted evidence, or accepting any evidence item?
+```
+
+It opens only the bounded concrete accepted-evidence set membership
+assignment post-sync candidate boundary.
+
+For this document:
+
+```text
+post-sync == after the clean-fixed Phase-23 concrete accepted-evidence set
+membership assignment publication-status sync boundary at
+5edd974c7d3c40eaf154fb2ae60d69f8aa24f3e6
+```
+
+This is an exact-SHA governance input only.
+
+It is not a general temporal shortcut.
+
+It is not a concrete assignment.
+
+It is not membership assignment.
+
+It is not accepted-evidence set membership.
+
+It is not accepted evidence.
+
+It is not evidence item acceptance.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not convert CI PASS results, receipts, validator output, package
+review output, source review output, publication records,
+publication-status sync records, or clean-fixed claims into concrete
+assignment, membership assignment, accepted-evidence set membership,
+accepted evidence, evidence item acceptance, validator output
+acceptance, or receipt evidence acceptance.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, source acceptance, source merge, registry publication, trust
+assignment, capability issuance, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+It does not answer:
+
+```text
+How is a concrete assignment created?
+Which membership is assigned?
+Which evidence item is accepted?
+How is accepted-evidence set membership created?
+How is accepted evidence created?
+How is validator output accepted?
+How is receipt evidence accepted?
+How is runtime implementation procedure defined?
+How is source modified?
+How is code implemented or executed?
+How is a process started?
+How is runtime state created?
+How is a package installed, loaded, executed, deployed, or distributed?
+How is source accepted or merged?
+How is a capability issued?
+How is trust assigned?
+How is a registry entry published?
+How is kernel ABI or syscall surface expanded?
+How are workflow thresholds, baselines, or dependencies changed?
+```
+
+Those questions require later reviewed decision paths or records, if
+ever authorized.
+
+## Exact Subject
+
+This candidate draft is based on exact main SHA:
+
+```text
+5edd974c7d3c40eaf154fb2ae60d69f8aa24f3e6
+```
+
+That subject is the squash merge of PR #289:
+
+```text
+Phase-23 concrete accepted-evidence set membership assignment publication-status sync
+```
+
+PR #289 changed only:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md
+```
+
+PR #289 produced post-merge exact-main verification:
+
+| Evidence | Run / job | Result |
+|---|---|---|
+| `ci-freeze` | run `29655098287`, attempt 1, job `freeze / 88107884124` | PASS |
+| Dev Loop Validation | run `29655098326`, attempt 1, job `devloop / 88107884417` | PASS |
+| AykenOS Dev Loop CI | run `29655098320`, attempt 1 | PASS |
+| smoke | job `88107884229` | PASS |
+| contract | job `88107970040` | PASS |
+| full | job `88108162887` | PASS |
+| isolation | job `88108401362` | PASS |
+| performance | job `88108604620` | PASS |
+
+The Phase-23 Concrete Accepted-Evidence Set Membership Assignment
+Publication Status Sync remains bound to:
+
+```text
+5edd974c7d3c40eaf154fb2ae60d69f8aa24f3e6
+```
+
+That sync recorded only the bounded publication-status sync boundary as
+a governance sync boundary.
+
+That sync did not create a general publication status update.
+
+That sync did not modify prior records.
+
+That sync did not create a concrete assignment.
+
+That sync did not assign membership.
+
+That sync did not create accepted-evidence set membership.
+
+That sync did not create accepted evidence.
+
+That sync did not accept any evidence item.
+
+That sync did not accept validator output.
+
+That sync did not accept receipt evidence.
+
+This candidate consumes that exact subject as governance input only. It
+does not replace, broaden, reinterpret, or supersede the
+publication-status sync record, publication record, concrete assignment
+decision, or any earlier Phase-23 governance boundary.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped subject readings fail closed.
+
+## Core Rule
+
+```text
+post-sync == after the clean-fixed Phase-23 concrete accepted-evidence set membership assignment publication-status sync boundary at 5edd974c7d3c40eaf154fb2ae60d69f8aa24f3e6
+post-sync candidate == bounded concrete accepted-evidence set membership assignment post-sync candidate boundary only
+post-sync candidate != concrete accepted-evidence set membership assignment
+post-sync candidate != accepted-evidence set membership assignment
+post-sync candidate != accepted-evidence set membership
+post-sync candidate != accepted-evidence set
+post-sync candidate != accepted evidence
+post-sync candidate != evidence item acceptance
+post-sync candidate != validator output acceptance
+post-sync candidate != receipt evidence acceptance
+post-sync candidate != runtime implementation procedure
+post-sync candidate != source modification
+post-sync candidate != package loading
+post-sync candidate != package execution
+post-sync candidate != source acceptance
+post-sync candidate != source merge authority
+post-sync candidate != decision
+post-sync candidate != authority grant
+publication-status sync != concrete assignment unless separately reviewed
+publication-status sync != membership assignment unless separately reviewed
+publication-status sync != accepted-evidence set membership unless separately reviewed
+publication-status sync != accepted evidence unless separately reviewed
+publication-status sync != evidence item acceptance unless separately reviewed
+publication status update != concrete assignment unless separately reviewed
+publication record != concrete assignment unless separately reviewed
+publication record != membership assignment unless separately reviewed
+concrete assignment decision != concrete assignment unless separately reviewed
+concrete assignment record != concrete assignment unless separately reviewed
+concrete assignment != accepted-evidence set membership assignment unless separately reviewed
+accepted-evidence set membership assignment != accepted-evidence set membership unless separately reviewed
+accepted-evidence set membership != accepted evidence unless separately reviewed
+accepted evidence != evidence item acceptance unless separately reviewed
+accepted evidence != validator output unless separately reviewed
+accepted evidence != receipt evidence unless separately reviewed
+validator output != accepted evidence
+receipt evidence != accepted evidence
+receipt evidence != validator output
+CI PASS != post-sync candidate
+CI PASS != concrete accepted-evidence set membership assignment
+CI PASS != accepted-evidence set membership
+CI PASS != accepted evidence
+ci-freeze PASS != post-sync candidate
+ci-freeze PASS != concrete accepted-evidence set membership assignment
+ci-freeze PASS != accepted-evidence set membership
+ci-freeze PASS != accepted evidence
+Dev Loop PASS != post-sync candidate
+Dev Loop PASS != concrete accepted-evidence set membership assignment
+Dev Loop PASS != accepted-evidence set membership
+Dev Loop PASS != accepted evidence
+AykenOS Dev Loop CI PASS != post-sync candidate
+AykenOS Dev Loop CI PASS != concrete accepted-evidence set membership assignment
+AykenOS Dev Loop CI PASS != accepted-evidence set membership
+AykenOS Dev Loop CI PASS != accepted evidence
+post-merge exact-main verification != post-sync candidate
+post-merge exact-main verification != concrete accepted-evidence set membership assignment
+post-merge exact-main verification != accepted-evidence set membership
+post-merge exact-main verification != accepted evidence
+clean-fixed != post-sync candidate
+clean-fixed != concrete accepted-evidence set membership assignment
+clean-fixed != accepted-evidence set membership
+clean-fixed != accepted evidence
+CURRENT_PHASE=23 != post-sync candidate
+CURRENT_PHASE=23 != concrete accepted-evidence set membership assignment
+CURRENT_PHASE=23 != accepted-evidence set membership
+CURRENT_PHASE=23 != accepted evidence
+CURRENT_PHASE=23 != evidence item acceptance
+CURRENT_PHASE=23 != validator output acceptance
+CURRENT_PHASE=23 != receipt evidence acceptance
+CURRENT_PHASE=23 != runtime implementation procedure
+CURRENT_PHASE=23 != source modification
+CURRENT_PHASE=23 != execution authority
+CURRENT_PHASE=23 != package loading
+CURRENT_PHASE=23 != source merge authority
+CURRENT_PHASE=23 != kernel ABI expansion
+CURRENT_PHASE=23 != syscall expansion
+historical PASS != inherited evidence
+previous PR evidence != later PR evidence
+```
+
+The safe default remains no concrete assignment, no membership
+assignment, no accepted-evidence set membership, no accepted evidence, no
+evidence item acceptance, no validator output acceptance, no receipt
+evidence acceptance, no runtime behavior, no implementation procedure,
+no source modification, no code execution, no runtime state, and no
+package, capability, registry, trust, distribution, deployment, source
+acceptance, source merge, kernel ABI, syscall, workflow-threshold,
+baseline, dependency, or Ring0 authority unless a later reviewed
+Phase-23 decision or record grants a specific bounded authority with its
+own exact-SHA evidence.
+
+Unknown authority readings fail closed.
+
+## Post-Sync Candidate Boundary
+
+The Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate is accepted only as:
+
+```text
+bounded concrete accepted-evidence set membership assignment post-sync
+candidate boundary
+```
+
+This candidate exists only after the clean-fixed publication-status sync
+boundary at:
+
+```text
+5edd974c7d3c40eaf154fb2ae60d69f8aa24f3e6
+```
+
+This candidate may be used only to evaluate whether a later separate
+reviewed concrete assignment candidate, concrete assignment decision, or
+concrete assignment record path may be proposed.
+
+This candidate does not create a concrete assignment.
+
+This candidate does not assign accepted-evidence set membership.
+
+This candidate does not create accepted-evidence set membership.
+
+This candidate does not create an accepted-evidence set.
+
+This candidate does not create accepted evidence.
+
+This candidate does not accept any evidence item.
+
+This candidate does not accept validator output.
+
+This candidate does not accept receipt evidence.
+
+This candidate does not authorize package loading.
+
+This candidate does not authorize source acceptance or source merge.
+
+This candidate does not authorize runtime implementation procedure, code
+execution, process start, runtime state creation, capability issuance,
+registry publication, trust assignment, deployment, distribution, kernel
+ABI expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Any later concrete assignment, membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, or receipt evidence acceptance
+requires a separate reviewed decision path or record with its own exact
+subject, changed-file scope, non-authorization boundary, and post-merge
+exact-main verification.
+
+## Candidate Scope
+
+This candidate scope is limited to:
+
+1. Recording a governance-only post-sync candidate boundary after PR #289.
+2. Binding the post-sync candidate to the exact clean-fixed
+   publication-status sync subject.
+3. Preserving the distinction between post-sync candidate and concrete
+   assignment.
+4. Preserving the distinction between concrete assignment and
+   accepted-evidence set membership assignment.
+5. Preserving the distinction between accepted-evidence set membership
+   and accepted evidence.
+6. Preserving separation from evidence item acceptance, validator output
+   acceptance, and receipt evidence acceptance.
+7. Establishing post-merge exact-main verification expectations for this
+   candidate publication.
+
+Candidate scope is governance text only.
+
+Candidate scope is bounded post-sync candidate boundary only.
+
+Candidate scope is not concrete assignment.
+
+Candidate scope is not membership assignment.
+
+Candidate scope is not accepted-evidence set membership.
+
+Candidate scope is not accepted evidence.
+
+Candidate scope is not evidence item acceptance.
+
+Candidate scope is not validator output acceptance.
+
+Candidate scope is not receipt evidence acceptance.
+
+Candidate scope is not runtime implementation procedure.
+
+Candidate scope is not package loading authority.
+
+Candidate scope is not execution authority.
+
+Candidate scope is not source merge authority.
+
+## Current Phase Pointer Boundary
+
+The current phase pointer remains:
+
+```text
+CURRENT_PHASE=23
+```
+
+This candidate does not modify:
+
+```text
+docs/roadmap/CURRENT_PHASE
+```
+
+This candidate does not change the active phase pointer.
+
+`CURRENT_PHASE=23` does not authorize post-sync candidate status,
+concrete assignment, membership assignment, accepted-evidence set
+membership, accepted evidence, evidence item acceptance, validator output
+acceptance, receipt evidence acceptance, runtime implementation
+procedure, source modification, code implementation, code execution,
+process start, runtime state creation, package loading, package
+execution, capability issuance, registry publication, trust assignment,
+deployment, distribution, source acceptance, source merge, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+## Publication-Status Sync Input
+
+This candidate consumes the clean-fixed Phase-23 Concrete
+Accepted-Evidence Set Membership Assignment Publication Status Sync as
+its exact governance prerequisite.
+
+The publication-status sync remains bound to:
+
+```text
+5edd974c7d3c40eaf154fb2ae60d69f8aa24f3e6
+```
+
+The publication-status sync recorded only a bounded publication-status
+sync boundary as a governance sync boundary.
+
+The publication-status sync recorded that it did not create a general
+publication status update, did not modify prior records, did not create
+concrete assignment, did not assign membership, did not create
+accepted-evidence set membership, did not create accepted evidence, and
+did not accept any evidence item.
+
+This candidate accepts only the later bounded post-sync candidate
+boundary after that sync publication is clean-fixed.
+
+This candidate does not reinterpret the publication-status sync as
+concrete assignment, membership assignment, accepted-evidence set
+membership, accepted evidence, evidence item acceptance, validator output
+acceptance, receipt evidence acceptance, runtime implementation
+procedure, execution authority, package loading authority, source
+acceptance, source merge authority, capability issuance, registry
+publication, trust assignment, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold change, baseline
+change, dependency change, or Ring0 authority.
+
+Any publication-status sync conflict fails closed.
+
+## Relationship To Publication Record And Publication Status
+
+This candidate consumes the clean-fixed Phase-23 Concrete
+Accepted-Evidence Set Membership Assignment Publication Record and
+Publication Status Sync records as exact governance prerequisites only.
+
+The Phase-23 Concrete Accepted-Evidence Set Membership Assignment
+Publication Record remains bound to:
+
+```text
+a7a9d592d91037fbfddd62c861a19664fa8f20e8
+```
+
+The Phase-23 Concrete Accepted-Evidence Set Membership Assignment
+Publication Status Sync remains bound to:
+
+```text
+5edd974c7d3c40eaf154fb2ae60d69f8aa24f3e6
+```
+
+This candidate does not convert publication record status into concrete
+assignment.
+
+This candidate does not convert publication-status sync into concrete
+assignment.
+
+This candidate does not convert publication status into membership
+assignment.
+
+This candidate does not modify any prior publication record.
+
+This candidate does not update publication status outside this candidate
+record.
+
+Any publication record or publication-status conflict fails closed.
+
+## Relationship To Concrete Assignment Decision And Record
+
+This candidate consumes the clean-fixed Phase-23 concrete assignment
+candidate, decision-candidate, decision, record-candidate, record,
+publication-record-candidate, publication-record, publication-status
+sync-candidate, and publication-status sync records as exact governance
+prerequisites only.
+
+This candidate does not convert any of those records into concrete
+assignment.
+
+This candidate does not convert any decision boundary into assignment.
+
+This candidate does not convert any record boundary into assignment.
+
+This candidate does not make concrete assignment inevitable.
+
+This candidate does not identify an assignment target.
+
+This candidate does not identify accepted-evidence set membership.
+
+This candidate does not identify evidence item acceptance.
+
+Any concrete assignment decision or record conflict fails closed.
+
+## Relationship To Membership And Accepted Evidence
+
+Accepted-evidence set membership remains separate from concrete
+assignment unless a separate reviewed record explicitly grants that
+narrower authority.
+
+Accepted evidence remains separate from accepted-evidence set membership
+unless a separate reviewed record explicitly grants that narrower
+authority.
+
+Evidence item acceptance remains separate from accepted evidence unless
+a separate reviewed record explicitly grants that narrower authority.
+
+This candidate does not assign accepted-evidence set membership.
+
+This candidate does not create accepted-evidence set membership.
+
+This candidate does not define accepted-evidence set membership scope.
+
+This candidate does not create an accepted-evidence set.
+
+This candidate does not create accepted evidence.
+
+This candidate does not identify accepted evidence.
+
+This candidate does not accept any evidence item.
+
+This candidate does not define evidence item acceptance scope.
+
+This candidate does not make membership assignment inevitable.
+
+This candidate does not make accepted-evidence set membership inevitable.
+
+This candidate does not make accepted evidence inevitable.
+
+This candidate does not make evidence item acceptance inevitable.
+
+Any attempt to treat this candidate as membership assignment,
+accepted-evidence set membership, accepted evidence, or evidence item
+acceptance fails closed.
+
+## Relationship To Validator Output And Receipt Evidence
+
+This candidate consumes the clean-fixed Phase-23 Validator-Output
+Boundary Planning and Receipt-Evidence Boundary Planning records as exact
+governance prerequisites only.
+
+The Phase-23 Validator-Output Boundary Planning publication-status sync
+remains bound to:
+
+```text
+d225b2b5ffcd83fe12c70bf0150b60f8f288f329
+```
+
+The Phase-23 Receipt-Evidence Boundary Planning publication-status sync
+remains bound to:
+
+```text
+9153d858c8ca99b09beb2fa60c6c7bcc565445a9
+```
+
+This candidate does not convert validator output into accepted evidence.
+
+This candidate does not convert receipt evidence into accepted evidence.
+
+This candidate does not accept validator output.
+
+This candidate does not accept receipt evidence.
+
+This candidate does not grant accepted-evidence membership over validator
+output, receipt evidence, package review output, source review output,
+publication-status sync claims, or clean-fixed claims.
+
+Any validator-output or receipt-evidence boundary conflict fails closed.
+
+## Relationship To Phase-19 Runtime Authority
+
+This candidate remains subordinate to Phase-19 runtime authority records.
+
+This candidate must not broaden, replace, supersede, weaken, or
+reinterpret Phase-19 runtime authority records.
+
+This candidate must not use post-sync candidate status to infer runtime
+authority.
+
+This candidate must not use publication-status sync authority to infer
+runtime authority.
+
+This candidate must not use concrete assignment records to infer runtime
+authority.
+
+This candidate must not use accepted-evidence set membership to infer
+runtime authority.
+
+This candidate must not use accepted evidence to infer runtime authority.
+
+This candidate must not use validator-output planning to infer runtime
+authority.
+
+This candidate must not use receipt-evidence planning to infer runtime
+authority.
+
+This candidate must not use exact-SHA evidence expectations to infer
+runtime authority.
+
+This candidate must not use `CURRENT_PHASE=23` to infer runtime
+authority.
+
+Any Phase-23 post-sync candidate reading that conflicts with Phase-19
+runtime authority records fails closed.
+
+## Not Authorized By This Candidate
+
+This candidate does not authorize:
+
+1. Concrete accepted-evidence set membership assignment.
+2. Accepted-evidence set membership assignment.
+3. Accepted-evidence set membership.
+4. Accepted-evidence set creation.
+5. Accepted evidence.
+6. Evidence item acceptance.
+7. Validator output acceptance.
+8. Receipt evidence acceptance.
+9. Runtime implementation procedure.
+10. Source modification.
+11. Source acceptance.
+12. Source merge.
+13. Code implementation.
+14. Code execution.
+15. Process start.
+16. Runtime state creation.
+17. Package installation.
+18. Package loading.
+19. Package execution.
+20. Module loading.
+21. Workspace runtime or real mounts.
+22. Plugin loading or plugin instantiation.
+23. Capability token minting.
+24. Capability issuance.
+25. Registry publication.
+26. Trust assignment.
+27. Distribution execution.
+28. Deployment.
+29. Semantic CLI authority.
+30. AI Runtime authority.
+31. Agent authority.
+32. Syscall expansion.
+33. Kernel ABI expansion.
+34. Ring0 policy movement.
+35. Workflow-threshold changes.
+36. Baseline changes.
+37. Dependency changes.
+38. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this candidate is published, the publication may change only this
+file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md
+```
+
+The publication must not change:
+
+1. `docs/roadmap/CURRENT_PHASE`.
+2. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`.
+3. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md`.
+4. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`.
+5. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`.
+6. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+7. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`.
+8. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+9. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+10. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+11. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+12. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+13. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`.
+14. `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`.
+15. `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`.
+16. `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`.
+17. CI workflows.
+18. Baselines.
+19. Dependencies.
+20. Runtime source or kernel source.
+21. Syscalls or kernel ABI.
+22. Package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution paths.
+23. `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md`.
+
+Any changed-file expansion beyond this candidate requires separate
+review and fails this candidate scope.
+
+## Post-Merge Exact-Main Evidence Rule
+
+If this candidate is later published, the candidate publication subject
+must receive its own post-merge exact-main verification:
+
+1. `ci-freeze` PASS for the exact candidate publication SHA.
+2. Dev Loop Validation PASS for the exact candidate publication SHA.
+3. AykenOS Dev Loop CI PASS for the exact candidate publication SHA.
+4. smoke PASS.
+5. contract PASS.
+6. full PASS.
+7. isolation PASS.
+8. performance PASS.
+9. Exact changed-file list confirmation.
+10. No `docs/roadmap/CURRENT_PHASE` change.
+11. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`
+    change.
+12. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md`
+    change.
+13. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`
+    change.
+14. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`
+    change.
+15. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`
+    change.
+16. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`
+    change.
+17. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`
+    change.
+18. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`
+    change.
+19. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`
+    change.
+20. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`
+    change.
+21. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`
+    change.
+22. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md` change.
+23. No `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md` change.
+24. No `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md` change.
+25. No `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md` change.
+26. No CI workflow change.
+27. No baseline change.
+28. No dependency change.
+29. No runtime source or kernel source change.
+30. No syscall or kernel ABI change.
+31. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution change.
+
+Until that exact-main post-merge verification exists, this candidate
+must not be recorded as clean-fixed.
+
+Historical PASS results may be cited as context only.
+
+Failed attempts may be cited as transparent non-clean context only.
+
+They cannot be inherited as concrete assignment, membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime authority, package loading authority, package execution
+authority, source merge authority, capability authority, registry
+authority, trust authority, kernel ABI authority, syscall authority,
+workflow-threshold authority, baseline authority, dependency authority,
+or Ring0 authority.
+
+## Later Concrete Assignment Dependency
+
+This candidate is a prerequisite input for a possible later bounded
+concrete assignment candidate, concrete assignment decision, or concrete
+assignment record after the clean-fixed publication-status sync boundary.
+
+A later concrete assignment record, if ever proposed, must define:
+
+1. Exact concrete assignment record subject.
+2. Exact Phase-23 post-sync candidate prerequisite.
+3. Exact Phase-23 publication-status sync prerequisite.
+4. Exact changed-file boundary.
+5. Exact concrete assignment scope, if any.
+6. Exact accepted-evidence set membership proposed for assignment, if
+   any, without accepted-evidence set membership status unless separately
+   reviewed.
+7. Exact evidence item reference proposed for membership assignment, if
+   any, without evidence item acceptance unless separately reviewed.
+8. Exact accepted-evidence set membership denial or separately reviewed
+   accepted-evidence set membership scope.
+9. Exact evidence item acceptance denial or separate evidence item
+   acceptance scope.
+10. Exact accepted-evidence creation denial or separate accepted-evidence
+    scope.
+11. Exact validator-output acceptance denial or separate
+    validator-output acceptance scope.
+12. Exact receipt-evidence acceptance denial or separate receipt-evidence
+    acceptance scope.
+13. Exact runtime implementation procedure denial.
+14. Exact package loading and package execution denials.
+15. Exact source acceptance and source merge denials.
+16. Exact capability, registry, trust, deployment, distribution, kernel
+    ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+    denials.
+17. Exact post-merge verification requirements.
+
+Until such a later reviewed concrete assignment record is published, no
+concrete accepted-evidence set membership assignment exists from this
+candidate.
+
+Until such a later reviewed accepted-evidence set membership record is
+published, no accepted-evidence set membership exists from this
+candidate.
+
+Until such a later reviewed evidence-item acceptance record is published,
+no evidence item acceptance exists from this candidate.
+
+Until such a later reviewed accepted-evidence record is published, no
+accepted evidence exists from this candidate.
+
+Until such a later reviewed validator-output acceptance record is
+published, no validator output acceptance exists from this candidate.
+
+Until such a later reviewed receipt-evidence acceptance record is
+published, no receipt evidence acceptance exists from this candidate.
+
+## Excluded Local Draft
+
+This candidate does not consume:
+
+```text
+PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md
+```
+
+If that file exists locally as an untracked file, it remains:
+
+```text
+untracked
+PR-disjoint
+not decision input
+not post-sync candidate input
+not concrete assignment input
+not membership assignment input
+not accepted-evidence set membership
+not accepted evidence
+not evidence item acceptance
+not validator output
+not receipt evidence
+not source authority
+not package acceptance
+not runtime authority
+```
+
+It must not be staged, committed, or included in any Phase-23 concrete
+assignment post-sync candidate PR unless a separate reviewed scope
+explicitly authorizes that file.
+
+## Governance Boundary Invariants
+
+Every later RFC must preserve these Phase-23 post-sync candidate
+invariants:
+
+1. This candidate is bounded post-sync candidate boundary only.
+2. `post-sync` is bound only to the clean-fixed publication-status sync
+   subject `5edd974c7d3c40eaf154fb2ae60d69f8aa24f3e6`.
+3. This candidate is not concrete accepted-evidence set membership
+   assignment.
+4. This candidate is not accepted-evidence set membership assignment.
+5. This candidate is not accepted-evidence set membership.
+6. This candidate is not an accepted-evidence set.
+7. This candidate is not accepted evidence.
+8. This candidate is not evidence item acceptance.
+9. This candidate is not validator output acceptance.
+10. This candidate is not receipt evidence acceptance.
+11. This candidate is not runtime implementation procedure.
+12. This candidate is not source modification.
+13. This candidate is not code implementation.
+14. This candidate is not code execution.
+15. This candidate is not process start.
+16. This candidate is not runtime state creation.
+17. This candidate is not package installation.
+18. This candidate is not package loading.
+19. This candidate is not package execution.
+20. This candidate is not capability issuance.
+21. This candidate is not registry publication.
+22. This candidate is not trust assignment.
+23. This candidate is not deployment.
+24. This candidate is not distribution authority.
+25. This candidate is not source acceptance.
+26. This candidate is not source merge authority.
+27. This candidate does not modify `docs/roadmap/CURRENT_PHASE`.
+28. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`.
+29. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md`.
+30. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`.
+31. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`.
+32. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+33. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`.
+34. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+35. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+36. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+37. `CURRENT_PHASE=23` is not post-sync candidate authority.
+38. `CURRENT_PHASE=23` is not concrete assignment.
+39. `CURRENT_PHASE=23` is not accepted-evidence set membership.
+40. `CURRENT_PHASE=23` is not accepted evidence.
+41. `CURRENT_PHASE=23` is not evidence item acceptance.
+42. `CURRENT_PHASE=23` is not validator output acceptance.
+43. `CURRENT_PHASE=23` is not receipt evidence acceptance.
+44. `CURRENT_PHASE=23` is not runtime implementation procedure.
+45. `CURRENT_PHASE=23` is not source modification.
+46. `CURRENT_PHASE=23` is not execution authority.
+47. `CURRENT_PHASE=23` is not package loading.
+48. `CURRENT_PHASE=23` is not source merge authority.
+49. This candidate does not broaden Phase-19 runtime authority.
+50. This candidate does not reopen Phase-20.
+51. This candidate does not reopen Phase-21.
+52. This candidate does not reopen Phase-22.
+53. This candidate does not expand kernel ABI or syscalls.
+54. This candidate does not change workflow thresholds, baselines, or
+    dependencies.
+55. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-23 concrete accepted-evidence set membership
+assignment post-sync candidate
+**Architecture status:** Local draft post-sync candidate / pending
+separate reviewed publication
+**Authority notice:** This signature identifies the architectural
+authorship of this candidate. It grants no concrete accepted-evidence set
+membership assignment authority, accepted-evidence set membership
+assignment authority, accepted-evidence set membership authority,
+accepted-evidence set authority, accepted evidence status, evidence item
+acceptance authority, validator output acceptance authority, receipt
+evidence acceptance authority, runtime implementation procedure
+authority, source modification authority, code implementation authority,
+code execution authority, process start authority, general runtime
+authority, unbounded execution authority, runtime state authority,
+package installation authority, package loading authority, package
+execution authority, source merge authority, trust authority, registry
+authority, distribution authority, publication authority, capability
+issuance authority, deployment authority, module authority, plugin
+authority, Semantic CLI authority, AI Runtime authority, agent
+authority, kernel ABI authority, syscall authority, workflow-threshold
+authority, baseline authority, dependency authority, or Ring0 authority.
+
+## Conclusion
+
+This Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate is based on the clean-fixed Phase-23 Concrete
+Accepted-Evidence Set Membership Assignment Publication Status Sync
+publication subject:
+
+```text
+5edd974c7d3c40eaf154fb2ae60d69f8aa24f3e6
+```
+
+It defines only the bounded concrete accepted-evidence set membership
+assignment post-sync candidate boundary.
+
+For this document:
+
+```text
+post-sync == after the clean-fixed Phase-23 concrete accepted-evidence set
+membership assignment publication-status sync boundary at
+5edd974c7d3c40eaf154fb2ae60d69f8aa24f3e6
+```
+
+It does not create a concrete assignment.
+
+It does not assign membership.
+
+It does not create accepted-evidence set membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, capability issuance, registry publication, trust assignment,
+deployment, distribution, source acceptance, source merge, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Any later Phase-23 concrete-assignment, accepted-evidence-set-membership,
+accepted-evidence, evidence-item-acceptance, validator-output,
+receipt-evidence, package-review, source-review,
+runtime-implementation-procedure, or non-authorization boundary record
+requires its own exact-SHA evidence, changed-file scope,
+non-authorization boundary, and reviewed decision path.


### PR DESCRIPTION
This PR changes only PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md and defines only a governance-only post-sync candidate boundary after the clean-fixed publication-status sync boundary at 5edd974c7d3c40eaf154fb2ae60d69f8aa24f3e6. It does not create a concrete assignment, assign membership, create accepted-evidence set membership, create accepted evidence, accept any evidence item, accept validator output, accept receipt evidence, or authorize runtime/source/package/source-merge/capability/registry/trust/deployment/distribution/kernel ABI/syscall/workflow-threshold/baseline/dependency/Ring0 authority.