### PR TITLE
Phase-23 concrete accepted-evidence set membership assignment post-sync decision candidate

### DIFF
--- a/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md
+++ b/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md
@@ -1,0 +1,1087 @@
+# Phase-23 Concrete Accepted-Evidence Set Membership Assignment Post-Sync Decision Candidate
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY_CLEAN_RECOVERY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_FIRST_BOUNDED_IMPLEMENTATION.md`,
+`PHASE22_CLOSURE_DECISION.md`,
+`PHASE23_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE23_POINTER_TRANSITION_DECISION.md`,
+`docs/roadmap/CURRENT_PHASE`,
+`PHASE23_GOVERNANCE_OVERVIEW.md`,
+`PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`,
+`PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`,
+`PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`,
+and
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`.
+In case of conflict, those documents prevail unless this document is the
+narrower Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate for the exact governance-only post-sync
+decision-candidate boundary identified below.
+
+**Status:** PHASE-23 CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT
+POST-SYNC DECISION CANDIDATE / LOCAL DRAFT / GOVERNANCE-ONLY POST-SYNC
+DECISION CANDIDATE ONLY / BOUNDED POST-SYNC DECISION CANDIDATE BOUNDARY
+ONLY / NO POST-SYNC DECISION / NO CONCRETE ASSIGNMENT CANDIDATE / NO
+CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT / NO
+ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT / NO ACCEPTED-EVIDENCE SET
+MEMBERSHIP / NO ACCEPTED-EVIDENCE SET / NO ACCEPTED EVIDENCE / NO
+EVIDENCE ITEM ACCEPTANCE / NO VALIDATOR OUTPUT ACCEPTANCE / NO RECEIPT
+EVIDENCE ACCEPTANCE / NO RUNTIME IMPLEMENTATION PROCEDURE / NO SOURCE
+MODIFICATION / NO CODE IMPLEMENTATION / NO CODE EXECUTION / NO PROCESS
+START / NO RUNTIME STATE CREATION / NO PACKAGE INSTALLATION / NO PACKAGE
+LOADING / NO PACKAGE EXECUTION / NO DEPLOYMENT / NO CAPABILITY ISSUANCE /
+NO TRUST ASSIGNMENT / NO REGISTRY PUBLICATION / NO DISTRIBUTION
+AUTHORITY / NO SOURCE ACCEPTANCE / NO SOURCE MERGE AUTHORITY / NO KERNEL
+ABI EXPANSION / NO SYSCALL EXPANSION / NO WORKFLOW-THRESHOLD CHANGE / NO
+BASELINE CHANGE / NO DEPENDENCY CHANGE / NO RING0 AUTHORITY
+**Candidate date:** 2026-07-26
+**Candidate id:**
+`ayken.phase23.concrete_accepted_evidence_set_membership_assignment_post_sync_decision_candidate.v1`
+**Candidate drafting base main SHA:**
+`39d7fa841e731cfbef8368288e19b6d404aa699c`
+**Candidate publication subject:** pending separate reviewed publication
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate publication subject:**
+`39d7fa841e731cfbef8368288e19b6d404aa699c`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate PR:** PR #290
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate exact-main ci-freeze run:** `30173799661`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate exact-main ci-freeze attempt:** attempt 2
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate exact-main ci-freeze job:** `freeze / 89719970132`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate exact-main ci-freeze result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate exact-main ci-freeze non-clean context:** attempt 1
+failed in `sched-bridge-runtime` with marker timeout; attempt 1 is
+transparent non-clean context only and is not clean-fixed evidence
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate exact-main Dev Loop Validation run:** `30173799718`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate exact-main Dev Loop Validation attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate exact-main Dev Loop Validation job:**
+`devloop / 89719212780`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate exact-main Dev Loop Validation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate exact-main Dev Loop CI run:** `30173799684`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate exact-main Dev Loop CI attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate exact-main Dev Loop CI result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate exact-main smoke job:** `smoke / 89719212615`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate exact-main smoke result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate exact-main contract job:** `contract / 89719308920`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate exact-main contract result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate exact-main full job:** `full / 89719522427`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate exact-main full result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate exact-main isolation job:** `isolation / 89719726844`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate exact-main isolation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate exact-main performance job:**
+`performance / 89719933748`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate exact-main performance result:** PASS
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate publication subject:**
+`39d7fa841e731cfbef8368288e19b6d404aa699c`
+**Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync publication subject:**
+`5edd974c7d3c40eaf154fb2ae60d69f8aa24f3e6`
+**Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync candidate publication subject:**
+`0c25ace3ef87d830f31d86cb63246755b77cf6e0`
+**Phase-23 concrete accepted-evidence set membership assignment
+publication record publication subject:**
+`a7a9d592d91037fbfddd62c861a19664fa8f20e8`
+**Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate publication subject:**
+`485b8fafa89ab0df777365e3dd5d3f6ac698364b`
+**Phase-23 concrete accepted-evidence set membership assignment decision
+publication subject:** `a9533551e7fe0e278e0299b8a60e60632b4c5162`
+**Phase-23 concrete accepted-evidence set membership assignment decision
+candidate publication subject:** `7a1b5b0210cd045647596c8dbd7d23c1427d6f4f`
+**Phase-23 concrete accepted-evidence set membership assignment candidate
+publication subject:** `e9cb4866ce57240de34ef669b6822097473f9830`
+**Phase-23 concrete accepted-evidence set membership assignment record
+publication subject:** `1d2ec43580e3c919b995365bdb058b852f6b3450`
+**Current phase pointer:** `CURRENT_PHASE=23`
+**Candidate theme:** Governance-only post-sync decision-candidate
+boundary after the clean-fixed post-sync candidate boundary at
+`39d7fa841e731cfbef8368288e19b6d404aa699c`.
+**Authority boundary:** Post-sync decision candidate boundary only; not
+post-sync decision, not concrete assignment candidate, not concrete
+accepted-evidence set membership assignment, not accepted-evidence set
+membership assignment, not accepted-evidence set membership, not an
+accepted-evidence set, not accepted evidence, not evidence item
+acceptance, not validator output acceptance, not receipt evidence
+acceptance, not runtime implementation procedure, not source
+modification, not code implementation, not code execution, not process
+start, not runtime state creation, not general runtime authority, not
+unbounded execution authority, not package authority, not package
+installation, not package loading, not package execution, not source
+acceptance, not source merge authority, not source repository authority,
+not module loading, not workspace runtime, not plugin loading, not
+capability token minting, not capability issuance, not trust assignment,
+not trust issuer authority, not registry authority, not registry
+publication, not publication authority, not deployment authority, not
+distribution authority, not distribution execution, not Semantic CLI
+authority, not AI Runtime authority, not agent authority, not syscall
+expansion, not kernel ABI expansion, not workflow-threshold, baseline,
+dependency, or Ring0 authority.
+
+## Purpose
+
+This document records a Phase-23 governance-only concrete
+accepted-evidence set membership assignment post-sync decision candidate
+after the clean-fixed Phase-23 Concrete Accepted-Evidence Set Membership
+Assignment Post-Sync Candidate publication.
+
+It answers only:
+
+```text
+May a bounded post-sync decision candidate be evaluated after the
+clean-fixed post-sync candidate boundary at
+39d7fa841e731cfbef8368288e19b6d404aa699c without creating a post-sync
+decision, creating a concrete assignment candidate, creating a concrete
+assignment, assigning membership, creating accepted-evidence set
+membership, creating accepted evidence, or accepting any evidence item?
+```
+
+It opens only the bounded post-sync decision candidate boundary.
+
+For this document:
+
+```text
+post-sync == after the clean-fixed Phase-23 concrete accepted-evidence set
+membership assignment post-sync candidate boundary at
+39d7fa841e731cfbef8368288e19b6d404aa699c
+```
+
+This is an exact-SHA governance input only.
+
+It is not a general temporal shortcut.
+
+It is not a post-sync decision.
+
+It is not a concrete assignment candidate.
+
+It is not a concrete assignment.
+
+It is not membership assignment.
+
+It is not accepted-evidence set membership.
+
+It is not accepted evidence.
+
+It is not evidence item acceptance.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not convert CI PASS results, receipts, validator output, package
+review output, source review output, historical results, clean-fixed
+claims, or post-sync status into concrete assignment, membership
+assignment, accepted-evidence set membership, accepted evidence, or
+evidence item acceptance.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, source acceptance, source merge, registry publication, trust
+assignment, capability issuance, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+## Exact Subject
+
+This decision-candidate draft is based on exact main SHA:
+
+```text
+39d7fa841e731cfbef8368288e19b6d404aa699c
+```
+
+That subject is the squash merge of PR #290:
+
+```text
+Phase-23 concrete accepted-evidence set membership assignment post-sync candidate
+```
+
+PR #290 changed only:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md
+```
+
+PR #290 produced post-merge exact-main verification:
+
+| Evidence | Run / job | Result |
+|---|---|---|
+| `ci-freeze` | run `30173799661`, attempt 2, job `freeze / 89719970132` | PASS |
+| Dev Loop Validation | run `30173799718`, attempt 1, job `devloop / 89719212780` | PASS |
+| AykenOS Dev Loop CI | run `30173799684`, attempt 1 | PASS |
+| smoke | job `89719212615` | PASS |
+| contract | job `89719308920` | PASS |
+| full | job `89719522427` | PASS |
+| isolation | job `89719726844` | PASS |
+| performance | job `89719933748` | PASS |
+
+The PR #290 `ci-freeze` attempt 1 failure remains transparent non-clean
+context only. It is not clean-fixed evidence and grants no authority.
+
+The Phase-23 Concrete Accepted-Evidence Set Membership Assignment
+Post-Sync Candidate remains bound to:
+
+```text
+39d7fa841e731cfbef8368288e19b6d404aa699c
+```
+
+That candidate recorded that it was not a post-sync decision, not a
+concrete assignment candidate, not concrete assignment, not membership
+assignment, not accepted-evidence set membership, not accepted evidence,
+not evidence item acceptance, not validator output acceptance, not
+receipt evidence acceptance, and not an authority grant.
+
+This decision candidate consumes that exact subject as governance input
+only. It does not replace, broaden, reinterpret, or supersede the
+post-sync candidate or any earlier Phase-23 governance boundary.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped subject readings fail closed.
+
+## Core Rule
+
+```text
+post-sync decision candidate == bounded post-sync decision candidate boundary only
+post-sync decision candidate != post-sync decision
+post-sync decision candidate != concrete assignment candidate
+post-sync decision candidate != concrete assignment
+post-sync decision candidate != membership assignment
+post-sync decision candidate != accepted-evidence set membership
+post-sync decision candidate != accepted-evidence set
+post-sync decision candidate != accepted evidence
+post-sync decision candidate != evidence item acceptance
+post-sync decision candidate != validator output acceptance
+post-sync decision candidate != receipt evidence acceptance
+post-sync decision candidate != runtime implementation procedure
+post-sync decision candidate != source modification
+post-sync decision candidate != package loading
+post-sync decision candidate != package execution
+post-sync decision candidate != source acceptance
+post-sync decision candidate != source merge authority
+post-sync decision candidate != decision
+post-sync decision candidate != authority grant
+post-sync candidate != post-sync decision
+post-sync candidate != concrete assignment candidate
+post-sync candidate != concrete assignment unless separately reviewed
+post-sync candidate != membership assignment unless separately reviewed
+post-sync candidate != accepted evidence unless separately reviewed
+post-sync candidate != evidence item acceptance unless separately reviewed
+concrete assignment candidate != concrete assignment unless separately reviewed
+concrete assignment decision != concrete assignment unless separately reviewed
+concrete assignment record != concrete assignment unless separately reviewed
+concrete assignment != accepted-evidence set membership assignment unless separately reviewed
+accepted-evidence set membership != accepted evidence unless separately reviewed
+accepted evidence != evidence item acceptance unless separately reviewed
+accepted evidence != validator output unless separately reviewed
+accepted evidence != receipt evidence unless separately reviewed
+validator output != accepted evidence
+receipt evidence != accepted evidence
+CI PASS != post-sync decision candidate
+CI PASS != post-sync decision
+CI PASS != concrete assignment candidate
+CI PASS != concrete assignment
+CI PASS != accepted evidence
+ci-freeze PASS != post-sync decision candidate
+ci-freeze PASS != post-sync decision
+ci-freeze PASS != concrete assignment candidate
+ci-freeze PASS != concrete assignment
+ci-freeze PASS != accepted evidence
+Dev Loop PASS != post-sync decision candidate
+Dev Loop PASS != post-sync decision
+Dev Loop PASS != concrete assignment candidate
+Dev Loop PASS != concrete assignment
+Dev Loop PASS != accepted evidence
+AykenOS Dev Loop CI PASS != post-sync decision candidate
+AykenOS Dev Loop CI PASS != post-sync decision
+AykenOS Dev Loop CI PASS != concrete assignment candidate
+AykenOS Dev Loop CI PASS != concrete assignment
+AykenOS Dev Loop CI PASS != accepted evidence
+post-merge exact-main verification != post-sync decision candidate
+post-merge exact-main verification != post-sync decision
+post-merge exact-main verification != concrete assignment candidate
+post-merge exact-main verification != concrete assignment
+post-merge exact-main verification != accepted evidence
+clean-fixed != post-sync decision candidate
+clean-fixed != post-sync decision
+clean-fixed != concrete assignment candidate
+clean-fixed != concrete assignment
+clean-fixed != accepted evidence
+CURRENT_PHASE=23 != post-sync decision candidate
+CURRENT_PHASE=23 != post-sync decision
+CURRENT_PHASE=23 != concrete assignment candidate
+CURRENT_PHASE=23 != concrete assignment
+CURRENT_PHASE=23 != accepted evidence
+CURRENT_PHASE=23 != evidence item acceptance
+historical PASS != inherited evidence
+previous PR evidence != later PR evidence
+```
+
+The safe default remains no post-sync decision, no concrete assignment
+candidate, no concrete assignment, no membership assignment, no
+accepted-evidence set membership, no accepted evidence, no evidence item
+acceptance, no validator output acceptance, no receipt evidence
+acceptance, no runtime behavior, no implementation procedure, no source
+modification, no code execution, no runtime state, and no package,
+capability, registry, trust, distribution, deployment, source
+acceptance, source merge, kernel ABI, syscall, workflow-threshold,
+baseline, dependency, or Ring0 authority unless a later reviewed
+Phase-23 decision grants a specific bounded authority with its own
+exact-SHA evidence.
+
+Unknown authority readings fail closed.
+
+## Post-Sync Decision Candidate
+
+The Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate is accepted only as:
+
+```text
+bounded post-sync decision candidate boundary
+```
+
+This candidate may be used only to evaluate whether a later separate
+reviewed post-sync decision, concrete assignment candidate, concrete
+assignment decision, or concrete assignment record path may be proposed,
+without creating any of those later records or authorities.
+
+This candidate does not create a post-sync decision.
+
+This candidate does not create a concrete assignment candidate.
+
+This candidate does not create a concrete assignment.
+
+This candidate does not assign membership.
+
+This candidate does not create accepted-evidence set membership.
+
+This candidate does not create accepted evidence.
+
+This candidate does not accept any evidence item.
+
+This candidate does not accept validator output.
+
+This candidate does not accept receipt evidence.
+
+This candidate does not authorize package loading.
+
+This candidate does not authorize source acceptance or source merge.
+
+This candidate does not authorize runtime implementation procedure, code
+execution, process start, runtime state creation, capability issuance,
+registry publication, trust assignment, deployment, distribution, kernel
+ABI expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Any later post-sync decision, concrete assignment candidate, concrete
+assignment, membership assignment, accepted-evidence set membership,
+accepted evidence, evidence item acceptance, validator output
+acceptance, or receipt evidence acceptance requires a separate reviewed
+decision path with its own exact subject, changed-file scope,
+non-authorization boundary, and post-merge exact-main verification.
+
+## Candidate Scope
+
+This candidate scope is limited to:
+
+1. Recording a governance-only post-sync decision-candidate boundary
+   after PR #290.
+2. Binding this candidate to the exact clean-fixed post-sync candidate
+   publication subject.
+3. Preserving the distinction between post-sync decision candidate and
+   post-sync decision.
+4. Preserving the distinction between post-sync decision candidate and
+   concrete assignment candidate.
+5. Preserving the distinction between concrete assignment and
+   membership assignment.
+6. Preserving separation from accepted-evidence set membership,
+   accepted evidence, and evidence item acceptance.
+7. Preserving separation from validator output acceptance and receipt
+   evidence acceptance.
+8. Establishing post-merge exact-main verification expectations for this
+   post-sync decision-candidate record.
+
+Candidate scope is governance text only.
+
+Candidate scope is bounded post-sync decision candidate boundary only.
+
+Candidate scope is not post-sync decision.
+
+Candidate scope is not concrete assignment candidate.
+
+Candidate scope is not concrete assignment.
+
+Candidate scope is not membership assignment.
+
+Candidate scope is not accepted-evidence set membership.
+
+Candidate scope is not accepted evidence.
+
+Candidate scope is not evidence item acceptance.
+
+Candidate scope is not validator output acceptance.
+
+Candidate scope is not receipt evidence acceptance.
+
+Candidate scope is not runtime implementation procedure.
+
+Candidate scope is not package loading authority.
+
+Candidate scope is not execution authority.
+
+Candidate scope is not source merge authority.
+
+## Current Phase Pointer Boundary
+
+The current phase pointer remains:
+
+```text
+CURRENT_PHASE=23
+```
+
+This candidate does not modify:
+
+```text
+docs/roadmap/CURRENT_PHASE
+```
+
+This candidate does not change the active phase pointer.
+
+`CURRENT_PHASE=23` does not authorize post-sync decision-candidate
+status, post-sync decision, concrete assignment candidate, concrete
+assignment, membership assignment, accepted-evidence set membership,
+accepted evidence, evidence item acceptance, validator output
+acceptance, receipt evidence acceptance, runtime implementation
+procedure, source modification, code implementation, code execution,
+process start, runtime state creation, package loading, package
+execution, capability issuance, registry publication, trust assignment,
+deployment, distribution, source acceptance, source merge, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+## Post-Sync Candidate Input
+
+This decision candidate consumes the clean-fixed Phase-23 Concrete
+Accepted-Evidence Set Membership Assignment Post-Sync Candidate as its
+exact governance prerequisite.
+
+The post-sync candidate remains bound to:
+
+```text
+39d7fa841e731cfbef8368288e19b6d404aa699c
+```
+
+The post-sync candidate recorded that it was not a post-sync decision,
+not concrete assignment candidate, not concrete assignment, not
+membership assignment, not accepted-evidence set membership, not
+accepted evidence, not evidence item acceptance, not validator output
+acceptance, not receipt evidence acceptance, and not an authority grant.
+
+This decision candidate accepts only the later bounded post-sync
+decision-candidate boundary after that post-sync candidate publication is
+clean-fixed.
+
+This decision candidate does not reinterpret the post-sync candidate as
+post-sync decision, concrete assignment candidate, concrete assignment,
+membership assignment, accepted-evidence set membership, accepted
+evidence, evidence item acceptance, validator output acceptance, receipt
+evidence acceptance, runtime implementation procedure, execution
+authority, package loading authority, source acceptance, source merge
+authority, capability issuance, registry publication, trust assignment,
+deployment, distribution, kernel ABI expansion, syscall expansion,
+workflow-threshold change, baseline change, dependency change, or Ring0
+authority.
+
+Any post-sync candidate conflict fails closed.
+
+## Relationship To Concrete Assignment
+
+Concrete assignment remains separate from any candidate, decision,
+record, publication record, publication-status sync, post-sync candidate,
+or post-sync decision candidate unless a separate reviewed decision
+explicitly grants that narrower authority.
+
+This decision candidate does not create a concrete assignment candidate.
+
+This decision candidate does not create concrete assignment.
+
+This decision candidate does not assign membership.
+
+This decision candidate does not identify any accepted-evidence set
+membership assignment.
+
+This decision candidate does not make concrete assignment inevitable.
+
+This decision candidate does not make membership assignment inevitable.
+
+Any attempt to treat this decision candidate as concrete assignment or
+as concrete assignment candidate fails closed.
+
+## Relationship To Accepted-Evidence Set Membership And Accepted Evidence
+
+Accepted-evidence set membership remains separate from concrete
+assignment unless a separate reviewed decision explicitly grants that
+narrower authority.
+
+Accepted evidence remains separate from accepted-evidence set membership
+unless a separate reviewed decision explicitly grants that narrower
+authority.
+
+Evidence item acceptance remains separate from accepted evidence unless
+a separate reviewed decision explicitly grants that narrower authority.
+
+This decision candidate does not create accepted-evidence set
+membership.
+
+This decision candidate does not create accepted evidence.
+
+This decision candidate does not identify accepted evidence.
+
+This decision candidate does not accept any evidence item.
+
+This decision candidate does not define evidence item acceptance scope.
+
+This decision candidate does not make accepted-evidence set membership
+inevitable.
+
+This decision candidate does not make accepted evidence inevitable.
+
+This decision candidate does not make evidence item acceptance
+inevitable.
+
+Any attempt to treat this decision candidate as accepted-evidence set
+membership, accepted evidence, or evidence item acceptance fails closed.
+
+## Relationship To Validator Output And Receipt Evidence
+
+This decision candidate consumes prior validator-output and
+receipt-evidence governance records as exact governance prerequisites
+only.
+
+This decision candidate does not convert validator output into accepted
+evidence.
+
+This decision candidate does not convert receipt evidence into accepted
+evidence.
+
+This decision candidate does not accept validator output.
+
+This decision candidate does not accept receipt evidence.
+
+This decision candidate does not grant accepted-evidence membership over
+validator output, receipt evidence, package review output, source review
+output, historical PASS results, or clean-fixed claims.
+
+Any validator-output or receipt-evidence boundary conflict fails closed.
+
+## Relationship To Phase-19 Runtime Authority
+
+This decision candidate remains subordinate to Phase-19 runtime authority
+records.
+
+This decision candidate must not broaden, replace, supersede, weaken, or
+reinterpret Phase-19 runtime authority records.
+
+This decision candidate must not use post-sync decision-candidate status
+to infer runtime authority.
+
+This decision candidate must not use post-sync candidate status to infer
+runtime authority.
+
+This decision candidate must not use concrete assignment candidates,
+decisions, or records to infer runtime authority.
+
+This decision candidate must not use accepted evidence to infer runtime
+authority.
+
+This decision candidate must not use validator-output planning to infer
+runtime authority.
+
+This decision candidate must not use receipt-evidence planning to infer
+runtime authority.
+
+This decision candidate must not use exact-SHA evidence expectations to
+infer runtime authority.
+
+This decision candidate must not use `CURRENT_PHASE=23` to infer runtime
+authority.
+
+Any Phase-23 post-sync decision-candidate reading that conflicts with
+Phase-19 runtime authority records fails closed.
+
+## Not Authorized By This Candidate
+
+This candidate does not authorize:
+
+1. Post-sync decision.
+2. Concrete assignment candidate.
+3. Concrete accepted-evidence set membership assignment.
+4. Accepted-evidence set membership assignment.
+5. Accepted-evidence set membership.
+6. Accepted-evidence set creation.
+7. Accepted evidence.
+8. Evidence item acceptance.
+9. Validator output acceptance.
+10. Receipt evidence acceptance.
+11. Runtime implementation procedure.
+12. Source modification.
+13. Source acceptance.
+14. Source merge.
+15. Code implementation.
+16. Code execution.
+17. Process start.
+18. Runtime state creation.
+19. Package installation.
+20. Package loading.
+21. Package execution.
+22. Module loading.
+23. Workspace runtime or real mounts.
+24. Plugin loading or plugin instantiation.
+25. Capability token minting.
+26. Capability issuance.
+27. Registry publication.
+28. Trust assignment.
+29. Distribution execution.
+30. Deployment.
+31. Semantic CLI authority.
+32. AI Runtime authority.
+33. Agent authority.
+34. Syscall expansion.
+35. Kernel ABI expansion.
+36. Ring0 policy movement.
+37. Workflow-threshold changes.
+38. Baseline changes.
+39. Dependency changes.
+40. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this decision candidate is published, the publication may change only
+this file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md
+```
+
+The publication must not change:
+
+1. `docs/roadmap/CURRENT_PHASE`.
+2. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`.
+3. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`.
+4. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md`.
+5. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`.
+6. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`.
+7. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+8. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`.
+9. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+10. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+11. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+12. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+13. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+14. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`.
+15. `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`.
+16. `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`.
+17. `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`.
+18. CI workflows.
+19. Baselines.
+20. Dependencies.
+21. Runtime source or kernel source.
+22. Syscalls or kernel ABI.
+23. Package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution paths.
+24. `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md`.
+
+Any changed-file expansion beyond this decision candidate requires
+separate review and fails this candidate scope.
+
+## Post-Merge Exact-Main Evidence Rule
+
+If this decision candidate is later published, the candidate publication
+subject must receive its own post-merge exact-main verification:
+
+1. `ci-freeze` PASS for the exact candidate publication SHA.
+2. Dev Loop Validation PASS for the exact candidate publication SHA.
+3. AykenOS Dev Loop CI PASS for the exact candidate publication SHA.
+4. smoke PASS.
+5. contract PASS.
+6. full PASS.
+7. isolation PASS.
+8. performance PASS.
+9. Exact changed-file list confirmation.
+10. No `docs/roadmap/CURRENT_PHASE` change.
+11. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`
+    change.
+12. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`
+    change.
+13. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md`
+    change.
+14. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`
+    change.
+15. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`
+    change.
+16. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`
+    change.
+17. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`
+    change.
+18. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`
+    change.
+19. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`
+    change.
+20. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`
+    change.
+21. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`
+    change.
+22. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`
+    change.
+23. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md` change.
+24. No `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md` change.
+25. No `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md` change.
+26. No `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md` change.
+27. No CI workflow change.
+28. No baseline change.
+29. No dependency change.
+30. No runtime source or kernel source change.
+31. No syscall or kernel ABI change.
+32. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution change.
+
+Until that exact-main post-merge verification exists, this decision
+candidate must not be recorded as clean-fixed.
+
+Historical PASS results may be cited as context only.
+
+Failed attempts may be cited as transparent non-clean context only.
+
+They cannot be inherited as post-sync decision, concrete assignment
+candidate, concrete assignment, membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime authority, package loading authority, package execution
+authority, source merge authority, capability authority, registry
+authority, trust authority, kernel ABI authority, syscall authority,
+workflow-threshold authority, baseline authority, dependency authority,
+or Ring0 authority.
+
+## Later Post-Sync Decision Dependency
+
+This decision candidate is a prerequisite input for a possible later
+bounded post-sync decision, concrete assignment candidate, concrete
+assignment decision, or concrete assignment record after the clean-fixed
+post-sync candidate boundary.
+
+A later post-sync decision or concrete assignment record, if ever
+proposed, must define:
+
+1. Exact later decision or record subject.
+2. Exact Phase-23 post-sync decision candidate prerequisite.
+3. Exact Phase-23 post-sync candidate prerequisite.
+4. Exact Phase-23 publication-status sync prerequisite.
+5. Exact changed-file boundary.
+6. Exact concrete assignment candidate scope, if any.
+7. Exact concrete assignment scope, if any.
+8. Exact accepted-evidence set membership proposed for assignment, if
+   any, without accepted-evidence set membership status unless separately
+   reviewed.
+9. Exact evidence item reference proposed for membership assignment, if
+   any, without evidence item acceptance unless separately reviewed.
+10. Exact accepted-evidence set membership denial or separately reviewed
+    accepted-evidence set membership scope.
+11. Exact evidence item acceptance denial or separate evidence item
+    acceptance scope.
+12. Exact accepted-evidence creation denial or separate accepted-evidence
+    scope.
+13. Exact validator-output acceptance denial or separate
+    validator-output acceptance scope.
+14. Exact receipt-evidence acceptance denial or separate receipt-evidence
+    acceptance scope.
+15. Exact runtime implementation procedure denial.
+16. Exact package loading and package execution denials.
+17. Exact source acceptance and source merge denials.
+18. Exact capability, registry, trust, deployment, distribution, kernel
+    ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+    denials.
+19. Exact post-merge verification requirements.
+
+Until such a later reviewed post-sync decision is published, no
+post-sync decision exists from this candidate.
+
+Until such a later reviewed concrete assignment candidate is published,
+no concrete assignment candidate exists from this candidate.
+
+Until such a later reviewed concrete assignment record is published, no
+concrete accepted-evidence set membership assignment exists from this
+candidate.
+
+Until such a later reviewed accepted-evidence set membership record is
+published, no accepted-evidence set membership exists from this
+candidate.
+
+Until such a later reviewed evidence-item acceptance record is published,
+no evidence item acceptance exists from this candidate.
+
+Until such a later reviewed accepted-evidence record is published, no
+accepted evidence exists from this candidate.
+
+Until such a later reviewed validator-output acceptance record is
+published, no validator output acceptance exists from this candidate.
+
+Until such a later reviewed receipt-evidence acceptance record is
+published, no receipt evidence acceptance exists from this candidate.
+
+## Excluded Local Draft
+
+This decision candidate does not consume:
+
+```text
+PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md
+```
+
+If that file exists locally as an untracked file, it remains:
+
+```text
+untracked
+PR-disjoint
+not decision input
+not post-sync decision-candidate input
+not concrete assignment candidate input
+not concrete assignment input
+not membership assignment input
+not accepted-evidence set membership
+not accepted evidence
+not evidence item acceptance
+not validator output
+not receipt evidence
+not source authority
+not package acceptance
+not runtime authority
+```
+
+It must not be staged, committed, or included in any Phase-23 concrete
+assignment post-sync decision candidate PR unless a separate reviewed
+scope explicitly authorizes that file.
+
+## Governance Boundary Invariants
+
+Every later RFC must preserve these Phase-23 post-sync decision
+candidate invariants:
+
+1. This candidate is bounded post-sync decision candidate boundary only.
+2. `post-sync` is bound only to the clean-fixed post-sync candidate
+   subject `39d7fa841e731cfbef8368288e19b6d404aa699c`.
+3. This candidate is not post-sync decision.
+4. This candidate is not concrete assignment candidate.
+5. This candidate is not concrete accepted-evidence set membership
+   assignment.
+6. This candidate is not accepted-evidence set membership assignment.
+7. This candidate is not accepted-evidence set membership.
+8. This candidate is not accepted evidence.
+9. This candidate is not evidence item acceptance.
+10. This candidate is not validator output acceptance.
+11. This candidate is not receipt evidence acceptance.
+12. Post-sync decision candidate is not post-sync decision unless
+    separately reviewed.
+13. Post-sync decision candidate is not concrete assignment candidate
+    unless separately reviewed.
+14. Concrete assignment is not accepted-evidence set membership
+    assignment unless separately reviewed.
+15. Accepted-evidence set membership is not accepted evidence unless
+    separately reviewed.
+16. Accepted evidence is not evidence item acceptance unless separately
+    reviewed.
+17. This candidate is not runtime implementation procedure.
+18. This candidate is not source modification.
+19. This candidate is not code implementation.
+20. This candidate is not code execution.
+21. This candidate is not process start.
+22. This candidate is not runtime state creation.
+23. This candidate is not package installation.
+24. This candidate is not package loading.
+25. This candidate is not package execution.
+26. This candidate is not capability issuance.
+27. This candidate is not registry publication.
+28. This candidate is not trust assignment.
+29. This candidate is not deployment.
+30. This candidate is not distribution authority.
+31. This candidate is not source acceptance.
+32. This candidate is not source merge authority.
+33. This candidate does not modify `docs/roadmap/CURRENT_PHASE`.
+34. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`.
+35. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`.
+36. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`.
+37. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+38. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`.
+39. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+40. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+41. `CURRENT_PHASE=23` is not post-sync decision-candidate authority.
+42. `CURRENT_PHASE=23` is not post-sync decision.
+43. `CURRENT_PHASE=23` is not concrete assignment candidate.
+44. `CURRENT_PHASE=23` is not concrete assignment.
+45. `CURRENT_PHASE=23` is not accepted evidence.
+46. `CURRENT_PHASE=23` is not evidence item acceptance.
+47. This candidate does not broaden Phase-19 runtime authority.
+48. This candidate does not reopen Phase-20.
+49. This candidate does not reopen Phase-21.
+50. This candidate does not reopen Phase-22.
+51. This candidate does not expand kernel ABI or syscalls.
+52. This candidate does not change workflow thresholds, baselines, or
+    dependencies.
+53. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-23 concrete accepted-evidence set membership
+assignment post-sync decision candidate
+**Architecture status:** Local draft post-sync decision candidate /
+pending separate reviewed publication
+**Authority notice:** This signature identifies the architectural
+authorship of this decision candidate. It grants no post-sync decision
+authority, concrete assignment candidate authority, concrete assignment
+authority, accepted-evidence set membership assignment authority,
+accepted-evidence set membership authority, accepted-evidence set
+authority, accepted evidence status, evidence item acceptance authority,
+validator output acceptance authority, receipt evidence acceptance
+authority, runtime implementation procedure authority, source
+modification authority, code implementation authority, code execution
+authority, process start authority, general runtime authority, unbounded
+execution authority, runtime state authority, package installation
+authority, package loading authority, package execution authority,
+source merge authority, trust authority, registry authority,
+distribution authority, publication authority, capability issuance
+authority, deployment authority, module authority, plugin authority,
+Semantic CLI authority, AI Runtime authority, agent authority, kernel ABI
+authority, syscall authority, workflow-threshold authority, baseline
+authority, dependency authority, or Ring0 authority.
+
+## Conclusion
+
+This Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate is based on the clean-fixed Phase-23
+Concrete Accepted-Evidence Set Membership Assignment Post-Sync Candidate
+publication subject:
+
+```text
+39d7fa841e731cfbef8368288e19b6d404aa699c
+```
+
+It opens only the bounded post-sync decision candidate boundary.
+
+It does not create a post-sync decision.
+
+It does not create a concrete assignment candidate.
+
+It does not create a concrete assignment.
+
+It does not assign membership.
+
+It does not create accepted-evidence set membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, capability issuance, registry publication, trust assignment,
+deployment, distribution, source acceptance, source merge, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Any later Phase-23 post-sync decision, concrete-assignment,
+membership-assignment, accepted-evidence-set-membership,
+accepted-evidence, evidence-item-acceptance, validator-output,
+receipt-evidence, package-review, source-review,
+runtime-implementation-procedure, or non-authorization boundary record
+requires its own exact-SHA evidence, changed-file scope,
+non-authorization boundary, and reviewed decision path.


### PR DESCRIPTION
This PR changes only PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md and defines only a governance-only post-sync decision candidate boundary after the clean-fixed post-sync candidate boundary at 39d7fa841e731cfbef8368288e19b6d404aa699c. It does not create a post-sync decision, create a concrete assignment candidate, create a concrete assignment, assign membership, create accepted-evidence set membership, create accepted evidence, accept any evidence item, accept validator output, accept receipt evidence, or authorize runtime/source/package/source-merge/capability/registry/trust/deployment/distribution/kernel ABI/syscall/workflow-threshold/baseline/dependency/Ring0 authority.