### PR TITLE
Phase-23 concrete accepted-evidence set membership assignment post-sync decision

### DIFF
--- a/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md
+++ b/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md
@@ -1,0 +1,1061 @@
+# Phase-23 Concrete Accepted-Evidence Set Membership Assignment Post-Sync Decision
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY_CLEAN_RECOVERY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_FIRST_BOUNDED_IMPLEMENTATION.md`,
+`PHASE22_CLOSURE_DECISION.md`,
+`PHASE23_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE23_POINTER_TRANSITION_DECISION.md`,
+`docs/roadmap/CURRENT_PHASE`,
+`PHASE23_GOVERNANCE_OVERVIEW.md`,
+`PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`,
+`PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`,
+`PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`,
+and
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md`.
+In case of conflict, those documents prevail unless this document is the
+narrower Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision for the exact governance-only bounded post-sync
+decision boundary identified below.
+
+**Status:** PHASE-23 CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT
+POST-SYNC DECISION / LOCAL DRAFT / GOVERNANCE-ONLY POST-SYNC DECISION
+ONLY / BOUNDED POST-SYNC DECISION BOUNDARY ONLY / NO CONCRETE ASSIGNMENT
+CANDIDATE / NO CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT / NO
+ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT / NO ACCEPTED-EVIDENCE SET
+MEMBERSHIP / NO ACCEPTED-EVIDENCE SET / NO ACCEPTED EVIDENCE / NO
+EVIDENCE ITEM ACCEPTANCE / NO VALIDATOR OUTPUT ACCEPTANCE / NO RECEIPT
+EVIDENCE ACCEPTANCE / NO RUNTIME IMPLEMENTATION PROCEDURE / NO SOURCE
+MODIFICATION / NO CODE IMPLEMENTATION / NO CODE EXECUTION / NO PROCESS
+START / NO RUNTIME STATE CREATION / NO PACKAGE INSTALLATION / NO PACKAGE
+LOADING / NO PACKAGE EXECUTION / NO DEPLOYMENT / NO CAPABILITY ISSUANCE /
+NO TRUST ASSIGNMENT / NO REGISTRY PUBLICATION / NO DISTRIBUTION
+AUTHORITY / NO SOURCE ACCEPTANCE / NO SOURCE MERGE AUTHORITY / NO KERNEL
+ABI EXPANSION / NO SYSCALL EXPANSION / NO WORKFLOW-THRESHOLD CHANGE / NO
+BASELINE CHANGE / NO DEPENDENCY CHANGE / NO RING0 AUTHORITY
+**Decision date:** 2026-07-26
+**Decision id:**
+`ayken.phase23.concrete_accepted_evidence_set_membership_assignment_post_sync_decision.v1`
+**Decision drafting base main SHA:**
+`004a886426b30a55cc8176941ac1553004e31f76`
+**Decision publication subject:** pending separate reviewed publication
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate publication subject:**
+`004a886426b30a55cc8176941ac1553004e31f76`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate PR:** PR #291
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate exact-main ci-freeze run:** `30176011318`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate exact-main ci-freeze attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate exact-main ci-freeze job:**
+`freeze / 89724782919`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate exact-main ci-freeze result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate exact-main Dev Loop Validation run:**
+`30176011330`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate exact-main Dev Loop Validation attempt:**
+attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate exact-main Dev Loop Validation job:**
+`devloop / 89724782936`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate exact-main Dev Loop Validation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate exact-main Dev Loop CI run:** `30176011319`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate exact-main Dev Loop CI attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate exact-main Dev Loop CI result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate exact-main smoke job:** `smoke / 89724782894`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate exact-main smoke result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate exact-main contract job:**
+`contract / 89724861194`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate exact-main contract result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate exact-main full job:** `full / 89725033417`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate exact-main full result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate exact-main isolation job:**
+`isolation / 89725244069`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate exact-main isolation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate exact-main performance job:**
+`performance / 89725459981`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate exact-main performance result:** PASS
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate publication subject:**
+`004a886426b30a55cc8176941ac1553004e31f76`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate publication subject:**
+`39d7fa841e731cfbef8368288e19b6d404aa699c`
+**Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync publication subject:**
+`5edd974c7d3c40eaf154fb2ae60d69f8aa24f3e6`
+**Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync candidate publication subject:**
+`0c25ace3ef87d830f31d86cb63246755b77cf6e0`
+**Phase-23 concrete accepted-evidence set membership assignment
+publication record publication subject:**
+`a7a9d592d91037fbfddd62c861a19664fa8f20e8`
+**Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate publication subject:**
+`485b8fafa89ab0df777365e3dd5d3f6ac698364b`
+**Phase-23 concrete accepted-evidence set membership assignment decision
+publication subject:** `a9533551e7fe0e278e0299b8a60e60632b4c5162`
+**Phase-23 concrete accepted-evidence set membership assignment decision
+candidate publication subject:** `7a1b5b0210cd045647596c8dbd7d23c1427d6f4f`
+**Current phase pointer:** `CURRENT_PHASE=23`
+**Accepted Phase-23 post-sync decision boundary:** bounded post-sync
+decision boundary as a governance decision boundary only; concrete
+assignment candidate, concrete assignment, membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, and receipt evidence acceptance
+remain pending separate reviewed records if ever authorized.
+**Authority boundary:** Post-sync decision boundary only; bounded
+post-sync decision boundary only; not concrete assignment candidate, not
+concrete accepted-evidence set membership assignment, not
+accepted-evidence set membership assignment, not accepted-evidence set
+membership, not an accepted-evidence set, not accepted evidence, not
+evidence item acceptance, not validator output acceptance, not receipt
+evidence acceptance, not runtime implementation procedure, not source
+modification, not code implementation, not code execution, not process
+start, not runtime state creation, not general runtime authority, not
+unbounded execution authority, not package authority, not package
+installation, not package loading, not package execution, not source
+acceptance, not source merge authority, not source repository authority,
+not module loading, not workspace runtime, not plugin loading, not
+capability token minting, not capability issuance, not trust assignment,
+not trust issuer authority, not registry authority, not registry
+publication, not publication authority, not deployment authority, not
+distribution authority, not distribution execution, not Semantic CLI
+authority, not AI Runtime authority, not agent authority, not syscall
+expansion, not kernel ABI expansion, not workflow-threshold, baseline,
+dependency, or Ring0 authority.
+
+## Purpose
+
+This document records only a bounded post-sync decision boundary after
+the clean-fixed Phase-23 concrete accepted-evidence set membership
+assignment post-sync decision candidate at
+`004a886426b30a55cc8176941ac1553004e31f76`.
+
+It evaluates only:
+
+```text
+May a bounded post-sync decision boundary be recorded after the
+clean-fixed post-sync decision candidate at
+004a886426b30a55cc8176941ac1553004e31f76 without creating a concrete
+assignment candidate, creating a concrete assignment, assigning
+membership, creating accepted-evidence set membership, creating accepted
+evidence, or accepting any evidence item?
+```
+
+It accepts only the bounded post-sync decision boundary as a governance
+decision boundary.
+
+It does not create a concrete assignment candidate.
+
+It does not create a concrete assignment.
+
+It does not assign membership.
+
+It does not create accepted-evidence set membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize runtime implementation procedure,
+source modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, source acceptance, source merge, registry publication, trust
+assignment, capability issuance, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+It does not answer:
+
+```text
+Which concrete assignment candidate is created?
+How is concrete assignment created?
+How is membership assigned?
+Which accepted-evidence set membership exists?
+Which evidence is accepted?
+Which evidence item is accepted?
+How is validator output accepted?
+How is receipt evidence accepted?
+How is runtime implementation procedure defined?
+How is source modified?
+How is code implemented or executed?
+How is a process started?
+How is runtime state created?
+How is a package installed, loaded, executed, deployed, or distributed?
+How is source accepted or merged?
+How is a capability issued?
+How is trust assigned?
+How is a registry entry published?
+How is kernel ABI or syscall surface expanded?
+How are workflow thresholds, baselines, or dependencies changed?
+```
+
+Those questions require later reviewed decision paths, if ever
+authorized.
+
+## Exact Subject
+
+This decision draft is based on exact main SHA:
+
+```text
+004a886426b30a55cc8176941ac1553004e31f76
+```
+
+That subject is the squash merge of PR #291:
+
+```text
+Phase-23 concrete accepted-evidence set membership assignment post-sync decision candidate
+```
+
+PR #291 changed only:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md
+```
+
+PR #291 produced post-merge exact-main verification:
+
+| Evidence | Run / job | Result |
+|---|---|---|
+| `ci-freeze` | run `30176011318`, attempt 1, job `freeze / 89724782919` | PASS |
+| Dev Loop Validation | run `30176011330`, attempt 1, job `devloop / 89724782936` | PASS |
+| AykenOS Dev Loop CI | run `30176011319`, attempt 1 | PASS |
+| smoke | job `89724782894` | PASS |
+| contract | job `89724861194` | PASS |
+| full | job `89725033417` | PASS |
+| isolation | job `89725244069` | PASS |
+| performance | job `89725459981` | PASS |
+
+The Phase-23 Concrete Accepted-Evidence Set Membership Assignment
+Post-Sync Decision Candidate remains bound to:
+
+```text
+004a886426b30a55cc8176941ac1553004e31f76
+```
+
+That decision candidate recorded that it was not post-sync decision, not
+concrete assignment candidate, not concrete assignment, not membership
+assignment, not accepted-evidence set membership, not accepted evidence,
+not evidence item acceptance, not validator output acceptance, not
+receipt evidence acceptance, and not an authority grant.
+
+This decision consumes that exact subject as governance input only. It
+does not replace, broaden, reinterpret, or supersede the post-sync
+decision candidate or any earlier Phase-23 governance boundary.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped subject readings fail closed.
+
+## Core Rule
+
+```text
+post-sync decision == bounded post-sync decision boundary only
+post-sync decision != concrete assignment candidate
+post-sync decision != concrete assignment
+post-sync decision != membership assignment
+post-sync decision != accepted-evidence set membership
+post-sync decision != accepted-evidence set
+post-sync decision != accepted evidence
+post-sync decision != evidence item acceptance
+post-sync decision != validator output acceptance
+post-sync decision != receipt evidence acceptance
+post-sync decision != runtime implementation procedure
+post-sync decision != source modification
+post-sync decision != package loading
+post-sync decision != package execution
+post-sync decision != source acceptance
+post-sync decision != source merge authority
+post-sync decision candidate clean-fixed != post-sync decision
+post-sync decision candidate != post-sync decision unless separately reviewed
+post-sync decision candidate != concrete assignment candidate
+post-sync decision candidate != concrete assignment unless separately reviewed
+post-sync candidate != concrete assignment unless separately reviewed
+concrete assignment candidate != concrete assignment unless separately reviewed
+concrete assignment decision != concrete assignment unless separately reviewed
+concrete assignment record != concrete assignment unless separately reviewed
+concrete assignment != accepted-evidence set membership assignment unless separately reviewed
+accepted-evidence set membership != accepted evidence unless separately reviewed
+accepted evidence != evidence item acceptance unless separately reviewed
+accepted evidence != validator output unless separately reviewed
+accepted evidence != receipt evidence unless separately reviewed
+validator output != accepted evidence
+receipt evidence != accepted evidence
+CI PASS != post-sync decision
+CI PASS != concrete assignment candidate
+CI PASS != concrete assignment
+CI PASS != accepted evidence
+ci-freeze PASS != post-sync decision
+ci-freeze PASS != concrete assignment candidate
+ci-freeze PASS != concrete assignment
+ci-freeze PASS != accepted evidence
+Dev Loop PASS != post-sync decision
+Dev Loop PASS != concrete assignment candidate
+Dev Loop PASS != concrete assignment
+Dev Loop PASS != accepted evidence
+AykenOS Dev Loop CI PASS != post-sync decision
+AykenOS Dev Loop CI PASS != concrete assignment candidate
+AykenOS Dev Loop CI PASS != concrete assignment
+AykenOS Dev Loop CI PASS != accepted evidence
+post-merge exact-main verification != post-sync decision
+post-merge exact-main verification != concrete assignment candidate
+post-merge exact-main verification != concrete assignment
+post-merge exact-main verification != accepted evidence
+clean-fixed != post-sync decision
+clean-fixed != concrete assignment candidate
+clean-fixed != concrete assignment
+clean-fixed != accepted evidence
+CURRENT_PHASE=23 != post-sync decision
+CURRENT_PHASE=23 != concrete assignment candidate
+CURRENT_PHASE=23 != concrete assignment
+CURRENT_PHASE=23 != accepted evidence
+CURRENT_PHASE=23 != evidence item acceptance
+historical PASS != inherited evidence
+previous PR evidence != later PR evidence
+```
+
+The safe default remains no concrete assignment candidate, no concrete
+assignment, no membership assignment, no accepted-evidence set
+membership, no accepted evidence, no evidence item acceptance, no
+validator output acceptance, no receipt evidence acceptance, no runtime
+behavior, no implementation procedure, no source modification, no code
+execution, no runtime state, and no package, capability, registry, trust,
+distribution, deployment, source acceptance, source merge, kernel ABI,
+syscall, workflow-threshold, baseline, dependency, or Ring0 authority
+unless a later reviewed Phase-23 decision grants a specific bounded
+authority with its own exact-SHA evidence.
+
+Unknown authority readings fail closed.
+
+## Post-Sync Decision
+
+The Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision is accepted only as:
+
+```text
+bounded post-sync decision boundary
+```
+
+This decision may record the post-sync decision boundary after the
+clean-fixed post-sync decision candidate at:
+
+```text
+004a886426b30a55cc8176941ac1553004e31f76
+```
+
+It does not create a concrete assignment candidate.
+
+It does not create a concrete assignment.
+
+It does not assign membership.
+
+It does not create accepted-evidence set membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize package loading.
+
+It does not authorize source acceptance or source merge.
+
+It does not authorize runtime implementation procedure, code execution,
+process start, runtime state creation, capability issuance, registry
+publication, trust assignment, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Any later concrete assignment candidate, concrete assignment, membership
+assignment, accepted-evidence set membership, accepted evidence, evidence
+item acceptance, validator output acceptance, or receipt evidence
+acceptance requires a separate reviewed decision path with its own exact
+subject, changed-file scope, non-authorization boundary, and post-merge
+exact-main verification.
+
+## Decision Scope
+
+This decision scope is limited to:
+
+1. Recording a governance-only bounded post-sync decision boundary after
+   PR #291.
+2. Binding this decision to the exact clean-fixed post-sync decision
+   candidate publication subject.
+3. Preserving the distinction between post-sync decision and concrete
+   assignment candidate.
+4. Preserving the distinction between concrete assignment candidate and
+   concrete assignment.
+5. Preserving the distinction between concrete assignment and membership
+   assignment.
+6. Preserving separation from accepted-evidence set membership, accepted
+   evidence, and evidence item acceptance.
+7. Preserving separation from validator output acceptance and receipt
+   evidence acceptance.
+8. Establishing post-merge exact-main verification expectations for this
+   post-sync decision record.
+
+Decision scope is governance text only.
+
+Decision scope is bounded post-sync decision boundary only.
+
+Decision scope is not concrete assignment candidate.
+
+Decision scope is not concrete assignment.
+
+Decision scope is not membership assignment.
+
+Decision scope is not accepted-evidence set membership.
+
+Decision scope is not accepted evidence.
+
+Decision scope is not evidence item acceptance.
+
+Decision scope is not validator output acceptance.
+
+Decision scope is not receipt evidence acceptance.
+
+Decision scope is not runtime implementation procedure.
+
+Decision scope is not package loading authority.
+
+Decision scope is not execution authority.
+
+Decision scope is not source merge authority.
+
+## Current Phase Pointer Boundary
+
+The current phase pointer remains:
+
+```text
+CURRENT_PHASE=23
+```
+
+This decision does not modify:
+
+```text
+docs/roadmap/CURRENT_PHASE
+```
+
+This decision does not change the active phase pointer.
+
+`CURRENT_PHASE=23` does not authorize post-sync decision status,
+concrete assignment candidate, concrete assignment, membership
+assignment, accepted-evidence set membership, accepted evidence, evidence
+item acceptance, validator output acceptance, receipt evidence
+acceptance, runtime implementation procedure, source modification, code
+implementation, code execution, process start, runtime state creation,
+package loading, package execution, capability issuance, registry
+publication, trust assignment, deployment, distribution, source
+acceptance, source merge, kernel ABI expansion, syscall expansion,
+workflow-threshold changes, baseline changes, dependency changes, or
+Ring0 authority.
+
+## Post-Sync Decision Candidate Input
+
+This decision consumes the clean-fixed Phase-23 Concrete Accepted-Evidence
+Set Membership Assignment Post-Sync Decision Candidate as its exact
+governance prerequisite.
+
+The post-sync decision candidate remains bound to:
+
+```text
+004a886426b30a55cc8176941ac1553004e31f76
+```
+
+The post-sync decision candidate recorded that it was not post-sync
+decision, not concrete assignment candidate, not concrete assignment,
+not membership assignment, not accepted-evidence set membership, not
+accepted evidence, not evidence item acceptance, not validator output
+acceptance, not receipt evidence acceptance, and not an authority grant.
+
+This decision accepts only the later bounded post-sync decision boundary
+after that post-sync decision candidate publication is clean-fixed.
+
+This decision does not reinterpret the post-sync decision candidate as
+concrete assignment candidate, concrete assignment, membership
+assignment, accepted-evidence set membership, accepted evidence, evidence
+item acceptance, validator output acceptance, receipt evidence
+acceptance, runtime implementation procedure, execution authority,
+package loading authority, source acceptance, source merge authority,
+capability issuance, registry publication, trust assignment, deployment,
+distribution, kernel ABI expansion, syscall expansion, workflow-threshold
+change, baseline change, dependency change, or Ring0 authority.
+
+Any post-sync decision-candidate conflict fails closed.
+
+## Relationship To Concrete Assignment
+
+Concrete assignment remains separate from any candidate, decision,
+record, publication record, publication-status sync, post-sync candidate,
+post-sync decision candidate, or post-sync decision unless a separate
+reviewed decision explicitly grants that narrower authority.
+
+This decision does not create a concrete assignment candidate.
+
+This decision does not create concrete assignment.
+
+This decision does not assign membership.
+
+This decision does not identify any accepted-evidence set membership
+assignment.
+
+This decision does not make concrete assignment inevitable.
+
+This decision does not make membership assignment inevitable.
+
+Any attempt to treat this decision as concrete assignment or as concrete
+assignment candidate fails closed.
+
+## Relationship To Accepted-Evidence Set Membership And Accepted Evidence
+
+Accepted-evidence set membership remains separate from concrete
+assignment unless a separate reviewed decision explicitly grants that
+narrower authority.
+
+Accepted evidence remains separate from accepted-evidence set membership
+unless a separate reviewed decision explicitly grants that narrower
+authority.
+
+Evidence item acceptance remains separate from accepted evidence unless
+a separate reviewed decision explicitly grants that narrower authority.
+
+This decision does not create accepted-evidence set membership.
+
+This decision does not create accepted evidence.
+
+This decision does not identify accepted evidence.
+
+This decision does not accept any evidence item.
+
+This decision does not define evidence item acceptance scope.
+
+This decision does not make accepted-evidence set membership inevitable.
+
+This decision does not make accepted evidence inevitable.
+
+This decision does not make evidence item acceptance inevitable.
+
+Any attempt to treat this decision as accepted-evidence set membership,
+accepted evidence, or evidence item acceptance fails closed.
+
+## Relationship To Validator Output And Receipt Evidence
+
+This decision consumes prior validator-output and receipt-evidence
+governance records as exact governance prerequisites only.
+
+This decision does not convert validator output into accepted evidence.
+
+This decision does not convert receipt evidence into accepted evidence.
+
+This decision does not accept validator output.
+
+This decision does not accept receipt evidence.
+
+This decision does not grant accepted-evidence membership over validator
+output, receipt evidence, package review output, source review output,
+historical PASS results, or clean-fixed claims.
+
+Any validator-output or receipt-evidence boundary conflict fails closed.
+
+## Relationship To Phase-19 Runtime Authority
+
+This decision remains subordinate to Phase-19 runtime authority records.
+
+This decision must not broaden, replace, supersede, weaken, or
+reinterpret Phase-19 runtime authority records.
+
+This decision must not use post-sync decision status to infer runtime
+authority.
+
+This decision must not use post-sync decision-candidate status to infer
+runtime authority.
+
+This decision must not use concrete assignment candidates, decisions, or
+records to infer runtime authority.
+
+This decision must not use accepted evidence to infer runtime authority.
+
+This decision must not use validator-output planning to infer runtime
+authority.
+
+This decision must not use receipt-evidence planning to infer runtime
+authority.
+
+This decision must not use exact-SHA evidence expectations to infer
+runtime authority.
+
+This decision must not use `CURRENT_PHASE=23` to infer runtime authority.
+
+Any Phase-23 post-sync decision reading that conflicts with Phase-19
+runtime authority records fails closed.
+
+## Not Authorized By This Decision
+
+This decision does not authorize:
+
+1. Concrete assignment candidate.
+2. Concrete accepted-evidence set membership assignment.
+3. Accepted-evidence set membership assignment.
+4. Accepted-evidence set membership.
+5. Accepted-evidence set creation.
+6. Accepted evidence.
+7. Evidence item acceptance.
+8. Validator output acceptance.
+9. Receipt evidence acceptance.
+10. Runtime implementation procedure.
+11. Source modification.
+12. Source acceptance.
+13. Source merge.
+14. Code implementation.
+15. Code execution.
+16. Process start.
+17. Runtime state creation.
+18. Package installation.
+19. Package loading.
+20. Package execution.
+21. Module loading.
+22. Workspace runtime or real mounts.
+23. Plugin loading or plugin instantiation.
+24. Capability token minting.
+25. Capability issuance.
+26. Registry publication.
+27. Trust assignment.
+28. Distribution execution.
+29. Deployment.
+30. Semantic CLI authority.
+31. AI Runtime authority.
+32. Agent authority.
+33. Syscall expansion.
+34. Kernel ABI expansion.
+35. Ring0 policy movement.
+36. Workflow-threshold changes.
+37. Baseline changes.
+38. Dependency changes.
+39. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this decision is published, the publication may change only this file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md
+```
+
+The publication must not change:
+
+1. `docs/roadmap/CURRENT_PHASE`.
+2. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md`.
+3. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`.
+4. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`.
+5. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`.
+6. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+7. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`.
+8. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+9. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+10. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+11. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+12. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+13. `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`.
+14. `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`.
+15. `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`.
+16. `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`.
+17. CI workflows.
+18. Baselines.
+19. Dependencies.
+20. Runtime source or kernel source.
+21. Syscalls or kernel ABI.
+22. Package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution paths.
+23. `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md`.
+
+Any changed-file expansion beyond this decision requires separate review
+and fails this decision scope.
+
+## Post-Merge Exact-Main Evidence Rule
+
+If this decision is later published, the decision publication subject
+must receive its own post-merge exact-main verification:
+
+1. `ci-freeze` PASS for the exact decision publication SHA.
+2. Dev Loop Validation PASS for the exact decision publication SHA.
+3. AykenOS Dev Loop CI PASS for the exact decision publication SHA.
+4. smoke PASS.
+5. contract PASS.
+6. full PASS.
+7. isolation PASS.
+8. performance PASS.
+9. Exact changed-file list confirmation.
+10. No `docs/roadmap/CURRENT_PHASE` change.
+11. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md`
+    change.
+12. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`
+    change.
+13. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`
+    change.
+14. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`
+    change.
+15. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`
+    change.
+16. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`
+    change.
+17. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`
+    change.
+18. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`
+    change.
+19. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`
+    change.
+20. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`
+    change.
+21. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`
+    change.
+22. No `PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md` change.
+23. No `PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md` change.
+24. No `PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md` change.
+25. No `PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md` change.
+26. No CI workflow change.
+27. No baseline change.
+28. No dependency change.
+29. No runtime source or kernel source change.
+30. No syscall or kernel ABI change.
+31. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution change.
+
+Until that exact-main post-merge verification exists, this decision must
+not be recorded as clean-fixed.
+
+Historical PASS results may be cited as context only.
+
+Failed attempts may be cited as transparent non-clean context only.
+
+They cannot be inherited as concrete assignment candidate, concrete
+assignment, membership assignment, accepted-evidence set membership,
+accepted evidence, evidence item acceptance, validator output
+acceptance, receipt evidence acceptance, runtime authority, package
+loading authority, package execution authority, source merge authority,
+capability authority, registry authority, trust authority, kernel ABI
+authority, syscall authority, workflow-threshold authority, baseline
+authority, dependency authority, or Ring0 authority.
+
+## Later Concrete Assignment Candidate Dependency
+
+This decision is a prerequisite input for a possible later bounded
+concrete assignment candidate, concrete assignment decision, or concrete
+assignment record after the clean-fixed post-sync decision boundary.
+
+A later concrete assignment candidate, decision, or record, if ever
+proposed, must define:
+
+1. Exact later candidate, decision, or record subject.
+2. Exact Phase-23 post-sync decision prerequisite.
+3. Exact Phase-23 post-sync decision candidate prerequisite.
+4. Exact Phase-23 post-sync candidate prerequisite.
+5. Exact Phase-23 publication-status sync prerequisite.
+6. Exact changed-file boundary.
+7. Exact concrete assignment candidate scope, if any.
+8. Exact concrete assignment scope, if any.
+9. Exact accepted-evidence set membership proposed for assignment, if
+   any, without accepted-evidence set membership status unless separately
+   reviewed.
+10. Exact evidence item reference proposed for membership assignment, if
+    any, without evidence item acceptance unless separately reviewed.
+11. Exact accepted-evidence set membership denial or separately reviewed
+    accepted-evidence set membership scope.
+12. Exact evidence item acceptance denial or separate evidence item
+    acceptance scope.
+13. Exact accepted-evidence creation denial or separate accepted-evidence
+    scope.
+14. Exact validator-output acceptance denial or separate
+    validator-output acceptance scope.
+15. Exact receipt-evidence acceptance denial or separate receipt-evidence
+    acceptance scope.
+16. Exact runtime implementation procedure denial.
+17. Exact package loading and package execution denials.
+18. Exact source acceptance and source merge denials.
+19. Exact capability, registry, trust, deployment, distribution, kernel
+    ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+    denials.
+20. Exact post-merge verification requirements.
+
+Until such a later reviewed concrete assignment candidate is published,
+no concrete assignment candidate exists from this decision.
+
+Until such a later reviewed concrete assignment record is published, no
+concrete accepted-evidence set membership assignment exists from this
+decision.
+
+Until such a later reviewed accepted-evidence set membership record is
+published, no accepted-evidence set membership exists from this
+decision.
+
+Until such a later reviewed evidence-item acceptance record is published,
+no evidence item acceptance exists from this decision.
+
+Until such a later reviewed accepted-evidence record is published, no
+accepted evidence exists from this decision.
+
+Until such a later reviewed validator-output acceptance record is
+published, no validator output acceptance exists from this decision.
+
+Until such a later reviewed receipt-evidence acceptance record is
+published, no receipt evidence acceptance exists from this decision.
+
+## Excluded Local Draft
+
+This decision does not consume:
+
+```text
+PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md
+```
+
+If that file exists locally as an untracked file, it remains:
+
+```text
+untracked
+PR-disjoint
+not decision input
+not post-sync decision input
+not concrete assignment candidate input
+not concrete assignment input
+not membership assignment input
+not accepted-evidence set membership
+not accepted evidence
+not evidence item acceptance
+not validator output
+not receipt evidence
+not source authority
+not package acceptance
+not runtime authority
+```
+
+It must not be staged, committed, or included in any Phase-23 concrete
+assignment post-sync decision PR unless a separate reviewed scope
+explicitly authorizes that file.
+
+## Governance Boundary Invariants
+
+Every later RFC must preserve these Phase-23 post-sync decision
+invariants:
+
+1. This decision is bounded post-sync decision boundary only.
+2. `post-sync` is bound only to the clean-fixed post-sync decision
+   candidate subject `004a886426b30a55cc8176941ac1553004e31f76`.
+3. This decision is not concrete assignment candidate.
+4. This decision is not concrete accepted-evidence set membership
+   assignment.
+5. This decision is not accepted-evidence set membership assignment.
+6. This decision is not accepted-evidence set membership.
+7. This decision is not accepted evidence.
+8. This decision is not evidence item acceptance.
+9. This decision is not validator output acceptance.
+10. This decision is not receipt evidence acceptance.
+11. Post-sync decision is not concrete assignment candidate unless
+    separately reviewed.
+12. Concrete assignment candidate is not concrete assignment unless
+    separately reviewed.
+13. Concrete assignment is not accepted-evidence set membership
+    assignment unless separately reviewed.
+14. Accepted-evidence set membership is not accepted evidence unless
+    separately reviewed.
+15. Accepted evidence is not evidence item acceptance unless separately
+    reviewed.
+16. This decision is not runtime implementation procedure.
+17. This decision is not source modification.
+18. This decision is not code implementation.
+19. This decision is not code execution.
+20. This decision is not process start.
+21. This decision is not runtime state creation.
+22. This decision is not package installation.
+23. This decision is not package loading.
+24. This decision is not package execution.
+25. This decision is not capability issuance.
+26. This decision is not registry publication.
+27. This decision is not trust assignment.
+28. This decision is not deployment.
+29. This decision is not distribution authority.
+30. This decision is not source acceptance.
+31. This decision is not source merge authority.
+32. This decision does not modify `docs/roadmap/CURRENT_PHASE`.
+33. This decision does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md`.
+34. This decision does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`.
+35. This decision does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`.
+36. This decision does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`.
+37. This decision does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+38. This decision does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`.
+39. This decision does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+40. This decision does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+41. `CURRENT_PHASE=23` is not post-sync decision authority.
+42. `CURRENT_PHASE=23` is not concrete assignment candidate.
+43. `CURRENT_PHASE=23` is not concrete assignment.
+44. `CURRENT_PHASE=23` is not accepted evidence.
+45. `CURRENT_PHASE=23` is not evidence item acceptance.
+46. This decision does not broaden Phase-19 runtime authority.
+47. This decision does not reopen Phase-20.
+48. This decision does not reopen Phase-21.
+49. This decision does not reopen Phase-22.
+50. This decision does not expand kernel ABI or syscalls.
+51. This decision does not change workflow thresholds, baselines, or
+    dependencies.
+52. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-23 concrete accepted-evidence set membership
+assignment post-sync decision
+**Architecture status:** Local draft post-sync decision / pending
+separate reviewed publication
+**Authority notice:** This signature identifies the architectural
+authorship of this decision. If separately reviewed and published, this
+decision grants only the bounded post-sync decision boundary defined in
+this record. It grants no concrete
+assignment candidate authority, concrete assignment authority,
+accepted-evidence set membership assignment authority,
+accepted-evidence set membership authority, accepted-evidence set
+authority, accepted evidence status, evidence item acceptance authority,
+validator output acceptance authority, receipt evidence acceptance
+authority, runtime implementation procedure authority, source
+modification authority, code implementation authority, code execution
+authority, process start authority, general runtime authority, unbounded
+execution authority, runtime state authority, package installation
+authority, package loading authority, package execution authority,
+source merge authority, trust authority, registry authority,
+distribution authority, publication authority, capability issuance
+authority, deployment authority, module authority, plugin authority,
+Semantic CLI authority, AI Runtime authority, agent authority, kernel ABI
+authority, syscall authority, workflow-threshold authority, baseline
+authority, dependency authority, or Ring0 authority.
+
+## Conclusion
+
+This Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision is based on the clean-fixed Phase-23 Concrete
+Accepted-Evidence Set Membership Assignment Post-Sync Decision Candidate
+publication subject:
+
+```text
+004a886426b30a55cc8176941ac1553004e31f76
+```
+
+It accepts only the bounded post-sync decision boundary.
+
+It does not create a concrete assignment candidate.
+
+It does not create a concrete assignment.
+
+It does not assign membership.
+
+It does not create accepted-evidence set membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, capability issuance, registry publication, trust assignment,
+deployment, distribution, source acceptance, source merge, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Any later Phase-23 concrete-assignment-candidate, concrete-assignment,
+membership-assignment, accepted-evidence-set-membership,
+accepted-evidence, evidence-item-acceptance, validator-output,
+receipt-evidence, package-review, source-review,
+runtime-implementation-procedure, or non-authorization boundary record
+requires its own exact-SHA evidence, changed-file scope,
+non-authorization boundary, and reviewed decision path.


### PR DESCRIPTION
This PR changes only PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md and records only a governance-only bounded post-sync decision boundary after the clean-fixed post-sync decision candidate at 004a886426b30a55cc8176941ac1553004e31f76. It does not create a concrete assignment candidate, create a concrete assignment, assign membership, create accepted-evidence set membership, create accepted evidence, accept any evidence item, accept validator output, accept receipt evidence, or authorize runtime/source/package/source-merge/capability/registry/trust/deployment/distribution/kernel ABI/syscall/workflow-threshold/baseline/dependency/Ring0 authority.