### PR TITLE
Phase-23 concrete accepted-evidence set membership assignment post-sync concrete assignment decision

### DIFF
--- a/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md
+++ b/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md
@@ -1,0 +1,994 @@
+# Phase-23 Concrete Accepted-Evidence Set Membership Assignment Post-Sync Concrete Assignment Decision
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY_CLEAN_RECOVERY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_FIRST_BOUNDED_IMPLEMENTATION.md`,
+`PHASE22_CLOSURE_DECISION.md`,
+`PHASE23_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE23_POINTER_TRANSITION_DECISION.md`,
+`docs/roadmap/CURRENT_PHASE`,
+`PHASE23_GOVERNANCE_OVERVIEW.md`,
+`PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`,
+`PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`,
+`PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md`,
+and
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_CANDIDATE.md`.
+In case of conflict, those documents prevail unless this document is the
+narrower Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision for the exact governance-only
+post-sync concrete-assignment-decision boundary identified below.
+
+**Status:** PHASE-23 CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT
+POST-SYNC CONCRETE ASSIGNMENT DECISION / LOCAL DRAFT / GOVERNANCE-ONLY
+POST-SYNC CONCRETE ASSIGNMENT DECISION ONLY / BOUNDED POST-SYNC CONCRETE
+ASSIGNMENT DECISION BOUNDARY ONLY / NO CONCRETE ACCEPTED-EVIDENCE SET
+MEMBERSHIP ASSIGNMENT / NO ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT /
+NO ACCEPTED-EVIDENCE SET MEMBERSHIP / NO ACCEPTED-EVIDENCE SET / NO
+ACCEPTED EVIDENCE / NO EVIDENCE ITEM ACCEPTANCE / NO VALIDATOR OUTPUT
+ACCEPTANCE / NO RECEIPT EVIDENCE ACCEPTANCE / NO RUNTIME IMPLEMENTATION
+PROCEDURE / NO SOURCE MODIFICATION / NO CODE IMPLEMENTATION / NO CODE
+EXECUTION / NO PROCESS START / NO RUNTIME STATE CREATION / NO PACKAGE
+INSTALLATION / NO PACKAGE LOADING / NO PACKAGE EXECUTION / NO DEPLOYMENT /
+NO CAPABILITY ISSUANCE / NO TRUST ASSIGNMENT / NO REGISTRY PUBLICATION /
+NO DISTRIBUTION AUTHORITY / NO SOURCE ACCEPTANCE / NO SOURCE MERGE
+AUTHORITY / NO KERNEL ABI EXPANSION / NO SYSCALL EXPANSION / NO
+WORKFLOW-THRESHOLD CHANGE / NO BASELINE CHANGE / NO DEPENDENCY CHANGE /
+NO RING0 AUTHORITY
+**Decision date:** 2026-07-26
+**Decision id:**
+`ayken.phase23.concrete_accepted_evidence_set_membership_assignment_post_sync_concrete_assignment_decision.v1`
+**Decision drafting base main SHA:**
+`feb44834568a70bfe103f0fcbfaf37e2a8035619`
+**Decision publication subject:** pending separate reviewed publication
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate publication subject:**
+`feb44834568a70bfe103f0fcbfaf37e2a8035619`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate PR:** PR #293
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate exact-main ci-freeze run:**
+`30179805567`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate exact-main ci-freeze attempt:**
+attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate exact-main ci-freeze job:**
+`freeze / 89734370363`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate exact-main ci-freeze result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate exact-main Dev Loop Validation
+run:** `30179805626`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate exact-main Dev Loop Validation
+attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate exact-main Dev Loop Validation
+job:** `devloop / 89734370505`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate exact-main Dev Loop Validation
+result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate exact-main Dev Loop CI run:**
+`30179805559`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate exact-main Dev Loop CI attempt:**
+attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate exact-main Dev Loop CI result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate exact-main smoke job:**
+`smoke / 89734370410`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate exact-main smoke result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate exact-main contract job:**
+`contract / 89734464744`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate exact-main contract result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate exact-main full job:**
+`full / 89734626171`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate exact-main full result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate exact-main isolation job:**
+`isolation / 89734814802`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate exact-main isolation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate exact-main performance job:**
+`performance / 89734998371`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate exact-main performance result:** PASS
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate publication subject:**
+`feb44834568a70bfe103f0fcbfaf37e2a8035619`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision publication subject:**
+`cf7cf2ca6f59c9e8e03a13171f9b3efee889fdb0`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate publication subject:**
+`004a886426b30a55cc8176941ac1553004e31f76`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate publication subject:**
+`39d7fa841e731cfbef8368288e19b6d404aa699c`
+**Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync publication subject:**
+`5edd974c7d3c40eaf154fb2ae60d69f8aa24f3e6`
+**Phase-23 concrete accepted-evidence set membership assignment
+publication record publication subject:**
+`a7a9d592d91037fbfddd62c861a19664fa8f20e8`
+**Phase-23 concrete accepted-evidence set membership assignment decision
+publication subject:** `a9533551e7fe0e278e0299b8a60e60632b4c5162`
+**Phase-23 concrete accepted-evidence set membership assignment decision
+candidate publication subject:** `7a1b5b0210cd045647596c8dbd7d23c1427d6f4f`
+**Phase-23 concrete accepted-evidence set membership assignment candidate
+publication subject:** `e9cb4866ce57240de34ef669b6822097473f9830`
+**Phase-23 concrete accepted-evidence set membership assignment record
+publication subject:** `1d2ec43580e3c919b995365bdb058b852f6b3450`
+**Current phase pointer:** `CURRENT_PHASE=23`
+**Accepted Phase-23 post-sync concrete assignment decision boundary:**
+bounded post-sync concrete assignment decision boundary as a governance
+decision boundary only; concrete assignment, membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, and receipt evidence acceptance
+remain pending separate reviewed records if ever authorized.
+**Authority boundary:** Post-sync concrete assignment decision boundary
+only; bounded post-sync concrete assignment decision boundary only; not
+concrete accepted-evidence set membership assignment, not
+accepted-evidence set membership assignment, not accepted-evidence set
+membership, not an accepted-evidence set, not accepted evidence, not
+evidence item acceptance, not validator output acceptance, not receipt
+evidence acceptance, not runtime implementation procedure, not source
+modification, not code implementation, not code execution, not process
+start, not runtime state creation, not general runtime authority, not
+unbounded execution authority, not package authority, not package
+installation, not package loading, not package execution, not source
+acceptance, not source merge authority, not source repository authority,
+not module loading, not workspace runtime, not plugin loading, not
+capability token minting, not capability issuance, not trust assignment,
+not trust issuer authority, not registry authority, not registry
+publication, not publication authority, not deployment authority, not
+distribution authority, not distribution execution, not Semantic CLI
+authority, not AI Runtime authority, not agent authority, not syscall
+expansion, not kernel ABI expansion, not workflow-threshold, baseline,
+dependency, or Ring0 authority.
+
+## Purpose
+
+This document records only a bounded post-sync concrete assignment
+decision boundary after the clean-fixed Phase-23 concrete
+accepted-evidence set membership assignment post-sync concrete assignment
+candidate at:
+
+```text
+feb44834568a70bfe103f0fcbfaf37e2a8035619
+```
+
+It evaluates only:
+
+```text
+May a bounded post-sync concrete assignment decision boundary be recorded
+after the clean-fixed post-sync concrete assignment candidate at
+feb44834568a70bfe103f0fcbfaf37e2a8035619 without creating a concrete
+assignment, assigning membership, creating accepted-evidence set
+membership, creating accepted evidence, or accepting any evidence item?
+```
+
+It accepts only the bounded post-sync concrete assignment decision
+boundary as a governance decision boundary.
+
+It does not create a concrete assignment.
+
+It does not assign membership.
+
+It does not create accepted-evidence set membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, source acceptance, source merge, registry publication, trust
+assignment, capability issuance, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+It does not answer:
+
+```text
+Which concrete assignment is created?
+How is concrete assignment created?
+How is membership assigned?
+Which accepted-evidence set membership exists?
+Which evidence is accepted?
+Which evidence item is accepted?
+How is validator output accepted?
+How is receipt evidence accepted?
+How is runtime implementation procedure defined?
+How is source modified?
+How is code implemented or executed?
+How is a process started?
+How is runtime state created?
+How is a package installed, loaded, executed, deployed, or distributed?
+How is source accepted or merged?
+How is a capability issued?
+How is trust assigned?
+How is a registry entry published?
+How is kernel ABI or syscall surface expanded?
+How are workflow thresholds, baselines, or dependencies changed?
+```
+
+Those questions require later reviewed decision paths, if ever
+authorized.
+
+## Exact Subject
+
+This decision draft is based on exact main SHA:
+
+```text
+feb44834568a70bfe103f0fcbfaf37e2a8035619
+```
+
+That subject is the squash merge of PR #293:
+
+```text
+Phase-23 concrete accepted-evidence set membership assignment post-sync concrete assignment candidate
+```
+
+PR #293 changed only:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_CANDIDATE.md
+```
+
+PR #293 produced post-merge exact-main verification:
+
+| Evidence | Run / job | Result |
+|---|---|---|
+| `ci-freeze` | run `30179805567`, attempt 1, job `freeze / 89734370363` | PASS |
+| Dev Loop Validation | run `30179805626`, attempt 1, job `devloop / 89734370505` | PASS |
+| AykenOS Dev Loop CI | run `30179805559`, attempt 1 | PASS |
+| smoke | job `89734370410` | PASS |
+| contract | job `89734464744` | PASS |
+| full | job `89734626171` | PASS |
+| isolation | job `89734814802` | PASS |
+| performance | job `89734998371` | PASS |
+
+The Phase-23 Concrete Accepted-Evidence Set Membership Assignment
+Post-Sync Concrete Assignment Candidate remains bound to:
+
+```text
+feb44834568a70bfe103f0fcbfaf37e2a8035619
+```
+
+That candidate recorded that it opened only a bounded post-sync concrete
+assignment candidate boundary. It did not create concrete assignment,
+assign membership, create accepted-evidence set membership, create
+accepted evidence, accept evidence items, accept validator output,
+accept receipt evidence, or grant runtime, source, package,
+source-merge, capability, registry, trust, deployment, distribution,
+kernel ABI, syscall, workflow-threshold, baseline, dependency, or Ring0
+authority.
+
+This decision consumes that exact subject as governance input only. It
+does not replace, broaden, reinterpret, or supersede the post-sync
+concrete assignment candidate or any earlier Phase-23 governance
+boundary.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped subject readings fail closed.
+
+## Core Rule
+
+```text
+post-sync concrete assignment decision == bounded post-sync concrete assignment decision boundary only
+post-sync concrete assignment decision != concrete assignment
+post-sync concrete assignment decision != concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision != accepted-evidence set membership assignment
+post-sync concrete assignment decision != accepted-evidence set membership
+post-sync concrete assignment decision != accepted-evidence set
+post-sync concrete assignment decision != accepted evidence
+post-sync concrete assignment decision != evidence item acceptance
+post-sync concrete assignment decision != validator output acceptance
+post-sync concrete assignment decision != receipt evidence acceptance
+post-sync concrete assignment decision != runtime implementation procedure
+post-sync concrete assignment decision != source modification
+post-sync concrete assignment decision != package loading
+post-sync concrete assignment decision != package execution
+post-sync concrete assignment decision != source merge authority
+post-sync concrete assignment candidate clean-fixed != post-sync concrete assignment decision
+post-sync concrete assignment candidate != post-sync concrete assignment decision unless separately reviewed
+post-sync concrete assignment candidate != concrete assignment
+post-sync decision clean-fixed != concrete assignment
+post-sync decision != concrete assignment unless separately reviewed
+concrete assignment decision != concrete assignment unless separately reviewed
+concrete assignment != membership assignment unless separately reviewed
+membership assignment != accepted-evidence set membership unless separately reviewed
+accepted-evidence set membership != accepted evidence unless separately reviewed
+accepted evidence != evidence item acceptance unless separately reviewed
+accepted evidence != validator output unless separately reviewed
+accepted evidence != receipt evidence unless separately reviewed
+validator output != accepted evidence
+receipt evidence != accepted evidence
+receipt evidence != validator output
+CI PASS != post-sync concrete assignment decision
+CI PASS != concrete assignment
+CI PASS != accepted evidence
+ci-freeze PASS != post-sync concrete assignment decision
+ci-freeze PASS != concrete assignment
+Dev Loop PASS != post-sync concrete assignment decision
+AykenOS Dev Loop CI PASS != post-sync concrete assignment decision
+post-merge exact-main verification != post-sync concrete assignment decision
+post-merge exact-main verification != concrete assignment
+clean-fixed != post-sync concrete assignment decision
+clean-fixed != concrete assignment
+publication-status sync != concrete assignment
+CURRENT_PHASE=23 != post-sync concrete assignment decision
+CURRENT_PHASE=23 != concrete assignment
+CURRENT_PHASE=23 != membership assignment
+CURRENT_PHASE=23 != accepted-evidence set membership
+CURRENT_PHASE=23 != accepted evidence
+CURRENT_PHASE=23 != evidence item acceptance
+CURRENT_PHASE=23 != validator output acceptance
+CURRENT_PHASE=23 != receipt evidence acceptance
+CURRENT_PHASE=23 != runtime implementation procedure
+CURRENT_PHASE=23 != source modification
+CURRENT_PHASE=23 != execution authority
+CURRENT_PHASE=23 != package loading
+CURRENT_PHASE=23 != source merge authority
+CURRENT_PHASE=23 != kernel ABI expansion
+CURRENT_PHASE=23 != syscall expansion
+historical PASS != inherited evidence
+previous PR evidence != later PR evidence
+```
+
+The safe default remains no concrete assignment, no membership
+assignment, no accepted-evidence set membership, no accepted evidence, no
+evidence item acceptance, no validator output acceptance, no receipt
+evidence acceptance, no runtime behavior, no implementation procedure,
+no source modification, no code execution, no runtime state, and no
+package, capability, registry, trust, distribution, deployment, source
+acceptance, source merge, kernel ABI, syscall, workflow-threshold,
+baseline, dependency, or Ring0 authority unless a later reviewed
+Phase-23 decision grants a specific bounded authority with its own
+exact-SHA evidence.
+
+Unknown authority readings fail closed.
+
+## Post-Sync Concrete Assignment Decision
+
+The Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision is accepted only as:
+
+```text
+bounded post-sync concrete assignment decision boundary
+```
+
+This decision boundary may be used only to evaluate whether a later
+separate reviewed concrete assignment record, membership assignment
+record, accepted-evidence set membership record, or accepted-evidence
+record path may be proposed, without creating any of those later records,
+memberships, evidence statuses, or authorities.
+
+This decision does not create a concrete assignment.
+
+This decision does not assign accepted-evidence set membership.
+
+This decision does not create accepted-evidence set membership.
+
+This decision does not create accepted evidence.
+
+This decision does not accept any evidence item.
+
+This decision does not accept validator output.
+
+This decision does not accept receipt evidence.
+
+This decision does not authorize package loading.
+
+This decision does not authorize source acceptance or source merge.
+
+This decision does not authorize runtime implementation procedure, code
+execution, process start, runtime state creation, capability issuance,
+registry publication, trust assignment, deployment, distribution, kernel
+ABI expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Any later concrete assignment, membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, or receipt evidence acceptance
+requires a separate reviewed decision path with its own exact subject,
+changed-file scope, non-authorization boundary, and post-merge
+exact-main verification.
+
+## Decision Scope
+
+This decision scope is limited to:
+
+1. Accepting the Phase-23 post-sync concrete assignment decision boundary
+   only as a bounded governance decision boundary.
+2. Binding this decision to PR #293 as the clean-fixed post-sync concrete
+   assignment candidate input.
+3. Preserving the distinction between concrete assignment decision and
+   concrete assignment.
+4. Preserving the distinction between concrete assignment and membership
+   assignment.
+5. Preserving the distinction between membership assignment and
+   accepted-evidence set membership.
+6. Preserving the distinction between accepted-evidence set membership
+   and accepted evidence.
+7. Preserving separation from validator output acceptance and receipt
+   evidence acceptance.
+8. Establishing post-merge exact-main verification expectations for this
+   decision record.
+
+Decision scope is governance text only.
+
+Decision scope is bounded post-sync concrete assignment decision boundary
+only.
+
+Decision scope is not concrete assignment.
+
+Decision scope is not membership assignment.
+
+Decision scope is not accepted-evidence set membership.
+
+Decision scope is not accepted evidence.
+
+Decision scope is not evidence item acceptance.
+
+Decision scope is not validator output acceptance.
+
+Decision scope is not receipt evidence acceptance.
+
+Decision scope is not runtime implementation procedure.
+
+Decision scope is not package loading authority.
+
+Decision scope is not execution authority.
+
+Decision scope is not source merge authority.
+
+## Current Phase Pointer Boundary
+
+The current phase pointer remains:
+
+```text
+CURRENT_PHASE=23
+```
+
+This decision does not modify:
+
+```text
+docs/roadmap/CURRENT_PHASE
+```
+
+This decision does not change the active phase pointer.
+
+`CURRENT_PHASE=23` does not authorize concrete assignment, membership
+assignment, accepted-evidence set membership, accepted evidence,
+evidence item acceptance, validator output acceptance, receipt evidence
+acceptance, runtime implementation procedure, source modification, code
+implementation, code execution, process start, runtime state creation,
+package loading, package execution, capability issuance, registry
+publication, trust assignment, deployment, distribution, source
+acceptance, source merge, kernel ABI expansion, syscall expansion,
+workflow-threshold changes, baseline changes, dependency changes, or
+Ring0 authority.
+
+## Post-Sync Concrete Assignment Candidate Input
+
+This decision consumes the clean-fixed Phase-23 Concrete Accepted-Evidence
+Set Membership Assignment Post-Sync Concrete Assignment Candidate as its
+exact governance prerequisite.
+
+The post-sync concrete assignment candidate remains bound to:
+
+```text
+feb44834568a70bfe103f0fcbfaf37e2a8035619
+```
+
+The post-sync concrete assignment candidate recorded only a bounded
+post-sync concrete assignment candidate boundary.
+
+This decision does not reinterpret the post-sync concrete assignment
+candidate as concrete assignment, membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime implementation procedure, execution authority, package loading
+authority, source acceptance, source merge authority, capability
+issuance, registry publication, trust assignment, deployment,
+distribution, kernel ABI expansion, syscall expansion,
+workflow-threshold change, baseline change, dependency change, or Ring0
+authority.
+
+Any post-sync concrete assignment candidate conflict fails closed.
+
+## Relationship To Concrete Assignment And Membership
+
+This decision accepts only a bounded decision boundary for later
+post-sync concrete assignment evaluation.
+
+This decision does not create a concrete assignment.
+
+This decision does not assign accepted-evidence set membership.
+
+This decision does not create accepted-evidence set membership.
+
+This decision does not define assignment membership.
+
+This decision does not define accepted-evidence set membership.
+
+This decision does not make concrete assignment inevitable.
+
+This decision does not make membership assignment inevitable.
+
+This decision does not make accepted-evidence set membership inevitable.
+
+Any attempt to treat this decision as concrete assignment, membership
+assignment, or accepted-evidence set membership fails closed.
+
+## Relationship To Accepted Evidence And Evidence Item Acceptance
+
+Concrete assignment remains separate from accepted evidence unless a
+separate reviewed decision explicitly grants that narrower authority.
+
+This decision does not create accepted evidence.
+
+This decision does not identify accepted evidence.
+
+This decision does not accept any evidence item.
+
+This decision does not define accepted-evidence membership.
+
+This decision does not define accepted-evidence set membership.
+
+This decision does not make accepted evidence inevitable.
+
+Any attempt to treat this decision as accepted evidence or evidence item
+acceptance fails closed.
+
+## Relationship To Validator Output And Receipt Evidence
+
+This decision does not convert validator output into accepted evidence.
+
+This decision does not convert receipt evidence into accepted evidence.
+
+This decision does not accept validator output.
+
+This decision does not accept receipt evidence.
+
+This decision does not grant accepted-evidence membership over validator
+output, receipt evidence, package review output, source review output,
+historical PASS results, or clean-fixed claims.
+
+Any validator-output or receipt-evidence boundary conflict fails closed.
+
+## Relationship To Phase-19 Runtime Authority
+
+This decision remains subordinate to Phase-19 runtime authority records.
+
+This decision must not broaden, replace, supersede, weaken, or
+reinterpret Phase-19 runtime authority records.
+
+This decision must not use concrete assignment decision status to infer
+runtime authority.
+
+This decision must not use concrete assignment, membership assignment,
+accepted-evidence set membership, accepted-evidence authority, accepted
+evidence, validator-output planning, receipt-evidence planning, exact-SHA
+evidence expectations, or `CURRENT_PHASE=23` to infer runtime authority.
+
+Any Phase-23 post-sync concrete assignment decision reading that
+conflicts with Phase-19 runtime authority records fails closed.
+
+## Not Authorized By This Decision
+
+This decision does not authorize:
+
+1. Concrete accepted-evidence set membership assignment.
+2. Accepted-evidence set membership assignment.
+3. Accepted-evidence set membership.
+4. Accepted-evidence set creation.
+5. Accepted evidence.
+6. Evidence item acceptance.
+7. Validator output acceptance.
+8. Receipt evidence acceptance.
+9. Runtime implementation procedure.
+10. Source modification.
+11. Source acceptance.
+12. Source merge.
+13. Code implementation.
+14. Code execution.
+15. Process start.
+16. Runtime state creation.
+17. Package installation.
+18. Package loading.
+19. Package execution.
+20. Module loading.
+21. Workspace runtime or real mounts.
+22. Plugin loading or plugin instantiation.
+23. Capability token minting.
+24. Capability issuance.
+25. Registry publication.
+26. Trust assignment.
+27. Distribution execution.
+28. Deployment.
+29. Semantic CLI authority.
+30. AI Runtime authority.
+31. Agent authority.
+32. Syscall expansion.
+33. Kernel ABI expansion.
+34. Ring0 policy movement.
+35. Workflow-threshold changes.
+36. Baseline changes.
+37. Dependency changes.
+38. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this decision is published, the publication may change only this file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md
+```
+
+The publication must not change:
+
+1. `docs/roadmap/CURRENT_PHASE`.
+2. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_CANDIDATE.md`.
+3. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md`.
+4. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md`.
+5. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`.
+6. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`.
+7. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md`.
+8. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`.
+9. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`.
+10. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+11. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`.
+12. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+13. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+14. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+15. CI workflows.
+16. Baselines.
+17. Dependencies.
+18. Runtime source or kernel source.
+19. Syscalls or kernel ABI.
+20. Package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution paths.
+21. `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md`.
+
+Any changed-file expansion beyond this decision record requires separate
+review and fails this decision scope.
+
+## Post-Merge Exact-Main Evidence Rule
+
+If this decision is later published, the decision publication subject
+must receive its own post-merge exact-main verification:
+
+1. `ci-freeze` PASS for the exact decision publication SHA.
+2. Dev Loop Validation PASS for the exact decision publication SHA.
+3. AykenOS Dev Loop CI PASS for the exact decision publication SHA.
+4. smoke PASS.
+5. contract PASS.
+6. full PASS.
+7. isolation PASS.
+8. performance PASS.
+9. Exact changed-file list confirmation.
+10. No `docs/roadmap/CURRENT_PHASE` change.
+11. No `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_CANDIDATE.md`
+    change.
+12. No `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md`
+    change.
+13. No `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md`
+    change.
+14. No concrete assignment, membership assignment, accepted-evidence set
+    membership, accepted evidence, evidence item acceptance, validator
+    output acceptance, or receipt evidence acceptance.
+15. No CI workflow change.
+16. No baseline change.
+17. No dependency change.
+18. No runtime source or kernel source change.
+19. No syscall or kernel ABI change.
+20. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution change.
+
+Until that exact-main post-merge verification exists, this decision must
+not be recorded as clean-fixed.
+
+Historical PASS results may be cited as context only.
+
+Failed attempts may be cited as transparent non-clean context only.
+
+They cannot be inherited as concrete assignment, membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime authority, package loading authority, package execution
+authority, source merge authority, capability authority, registry
+authority, trust authority, kernel ABI authority, syscall authority,
+workflow-threshold authority, baseline authority, dependency authority,
+or Ring0 authority.
+
+## Later Concrete Assignment Record Dependency
+
+This decision is a prerequisite input for a possible later bounded
+post-sync concrete assignment record.
+
+A later concrete assignment record, if ever proposed, must define:
+
+1. Exact concrete assignment record subject.
+2. Exact Phase-23 post-sync concrete assignment decision prerequisite.
+3. Exact changed-file boundary.
+4. Exact evidence item reference proposed for concrete assignment, if
+   any, without evidence item acceptance unless separately reviewed.
+5. Exact accepted-evidence set membership proposed for assignment, if
+   any, without accepted-evidence set membership status unless separately
+   reviewed.
+6. Exact concrete assignment denial or separate concrete assignment
+   scope.
+7. Exact membership assignment denial or separate membership assignment
+   scope.
+8. Exact accepted-evidence set membership denial or separate membership
+   scope.
+9. Exact accepted-evidence denial or separate accepted-evidence scope.
+10. Exact validator-output acceptance denial or separate
+    validator-output acceptance scope.
+11. Exact receipt-evidence acceptance denial or separate receipt-evidence
+    acceptance scope.
+12. Exact runtime implementation procedure denial.
+13. Exact package loading and package execution denials.
+14. Exact source acceptance and source merge denials.
+15. Exact capability, registry, trust, deployment, distribution, kernel
+    ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+    denials.
+16. Exact post-merge verification requirements.
+
+Until such a later reviewed concrete assignment record is published, no
+concrete assignment exists from this decision.
+
+Until such a later reviewed membership assignment record is published, no
+membership assignment exists from this decision.
+
+Until such a later reviewed accepted-evidence set membership record is
+published, no accepted-evidence set membership exists from this decision.
+
+Until such a later reviewed accepted-evidence record is published, no
+accepted evidence exists from this decision.
+
+Until such a later reviewed evidence item acceptance record is published,
+no evidence item acceptance exists from this decision.
+
+Until such a later reviewed validator-output acceptance record is
+published, no validator output acceptance exists from this decision.
+
+Until such a later reviewed receipt-evidence acceptance record is
+published, no receipt evidence acceptance exists from this decision.
+
+## Excluded Local Draft
+
+This decision does not consume:
+
+```text
+PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md
+```
+
+If that file exists locally as an untracked file, it remains:
+
+```text
+untracked
+PR-disjoint
+not candidate input
+not decision input
+not evidence input
+not concrete assignment
+not membership assignment
+not accepted-evidence set membership
+not accepted evidence
+not evidence item acceptance
+not validator output
+not receipt evidence
+not source authority
+not package acceptance
+not runtime authority
+```
+
+It must not be staged, committed, or included in any Phase-23 post-sync
+concrete assignment decision PR unless a separate reviewed scope
+explicitly authorizes that file.
+
+## Governance Boundary Invariants
+
+Every later RFC must preserve these Phase-23 post-sync concrete
+assignment decision invariants:
+
+1. This decision is bounded post-sync concrete assignment decision
+   boundary only.
+2. This decision is not concrete assignment.
+3. This decision is not membership assignment.
+4. This decision is not accepted-evidence set membership.
+5. This decision is not an accepted-evidence set.
+6. This decision is not accepted evidence.
+7. This decision is not evidence item acceptance.
+8. This decision is not validator output acceptance.
+9. This decision is not receipt evidence acceptance.
+10. Concrete assignment decision is not concrete assignment unless
+    separately reviewed.
+11. Concrete assignment is not membership assignment unless separately
+    reviewed.
+12. Membership assignment is not accepted-evidence set membership unless
+    separately reviewed.
+13. Accepted-evidence set membership is not accepted evidence unless
+    separately reviewed.
+14. Accepted evidence is not evidence item acceptance unless separately
+    reviewed.
+15. This decision is not runtime implementation procedure.
+16. This decision is not source modification.
+17. This decision is not code implementation.
+18. This decision is not code execution.
+19. This decision is not process start.
+20. This decision is not runtime state creation.
+21. This decision is not package installation.
+22. This decision is not package loading.
+23. This decision is not package execution.
+24. This decision is not capability issuance.
+25. This decision is not registry publication.
+26. This decision is not trust assignment.
+27. This decision is not deployment.
+28. This decision is not distribution authority.
+29. This decision is not source acceptance.
+30. This decision is not source merge authority.
+31. This decision does not modify `docs/roadmap/CURRENT_PHASE`.
+32. This decision does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_CANDIDATE.md`.
+33. This decision does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md`.
+34. This decision does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md`.
+35. `CURRENT_PHASE=23` is not concrete assignment.
+36. `CURRENT_PHASE=23` is not membership assignment.
+37. `CURRENT_PHASE=23` is not accepted-evidence set membership.
+38. `CURRENT_PHASE=23` is not accepted evidence.
+39. `CURRENT_PHASE=23` is not evidence item acceptance.
+40. `CURRENT_PHASE=23` is not validator output acceptance.
+41. `CURRENT_PHASE=23` is not receipt evidence acceptance.
+42. `CURRENT_PHASE=23` is not runtime implementation procedure.
+43. `CURRENT_PHASE=23` is not source modification.
+44. `CURRENT_PHASE=23` is not execution authority.
+45. `CURRENT_PHASE=23` is not package loading.
+46. `CURRENT_PHASE=23` is not source merge authority.
+47. This decision does not broaden Phase-19 runtime authority.
+48. This decision does not reopen Phase-20.
+49. This decision does not reopen Phase-21.
+50. This decision does not reopen Phase-22.
+51. This decision does not expand kernel ABI or syscalls.
+52. This decision does not change workflow thresholds, baselines, or
+    dependencies.
+53. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-23 concrete accepted-evidence set membership
+assignment post-sync concrete assignment decision
+**Architecture status:** Local draft post-sync concrete assignment
+decision / pending separate reviewed publication
+**Authority notice:** If separately reviewed and published, this decision
+grants only the bounded post-sync concrete assignment decision boundary
+defined in this record. It grants no concrete assignment, membership
+assignment, accepted-evidence set membership, accepted evidence status,
+evidence item acceptance authority, validator output acceptance
+authority, receipt evidence acceptance authority, runtime implementation
+procedure authority, source modification authority, code implementation
+authority, code execution authority, process start authority, general
+runtime authority, unbounded execution authority, runtime state
+authority, package installation authority, package loading authority,
+package execution authority, source merge authority, trust authority,
+registry authority, distribution authority, publication authority,
+capability issuance authority, deployment authority, module authority,
+plugin authority, Semantic CLI authority, AI Runtime authority, agent
+authority, kernel ABI authority, syscall authority, workflow-threshold
+authority, baseline authority, dependency authority, or Ring0 authority.
+
+## Conclusion
+
+This Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision is based on the clean-fixed
+Phase-23 Concrete Accepted-Evidence Set Membership Assignment Post-Sync
+Concrete Assignment Candidate publication subject:
+
+```text
+feb44834568a70bfe103f0fcbfaf37e2a8035619
+```
+
+It accepts only the bounded post-sync concrete assignment decision
+boundary.
+
+It does not create a concrete assignment.
+
+It does not assign membership.
+
+It does not create accepted-evidence set membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize concrete assignment, membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime implementation procedure, source modification, code
+implementation, code execution, process start, runtime state creation,
+package installation, package loading, package execution, capability
+issuance, registry publication, trust assignment, deployment,
+distribution, source acceptance, source merge, kernel ABI expansion,
+syscall expansion, workflow-threshold changes, baseline changes,
+dependency changes, or Ring0 authority.
+
+Any later Phase-23 concrete assignment, membership assignment,
+accepted-evidence set membership, accepted-evidence, evidence-item,
+validator-output, receipt-evidence, package-review, source-review,
+runtime-implementation-procedure, or non-authorization boundary record
+requires its own exact-SHA evidence, changed-file scope,
+non-authorization boundary, and reviewed decision path.


### PR DESCRIPTION
This PR changes only PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md and records only a governance-only bounded post-sync concrete assignment decision boundary after the clean-fixed post-sync concrete assignment candidate boundary at feb44834568a70bfe103f0fcbfaf37e2a8035619. It does not create a concrete assignment, assign membership, create accepted-evidence set membership, create accepted evidence, accept any evidence item, accept validator output, accept receipt evidence, or authorize runtime/source/package/source-merge/capability/registry/trust/deployment/distribution/kernel ABI/syscall/workflow-threshold/baseline/dependency/Ring0 authority.