### PR TITLE
Phase-23 concrete accepted-evidence set membership assignment post-sync concrete assignment record

### DIFF
--- a/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_RECORD.md
+++ b/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_RECORD.md
@@ -1,0 +1,1040 @@
+# Phase-23 Concrete Accepted-Evidence Set Membership Assignment Post-Sync Concrete Assignment Record
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY_CLEAN_RECOVERY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_FIRST_BOUNDED_IMPLEMENTATION.md`,
+`PHASE22_CLOSURE_DECISION.md`,
+`PHASE23_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE23_POINTER_TRANSITION_DECISION.md`,
+`docs/roadmap/CURRENT_PHASE`,
+`PHASE23_GOVERNANCE_OVERVIEW.md`,
+`PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`,
+`PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`,
+`PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_CANDIDATE.md`,
+and
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md`.
+In case of conflict, those documents prevail unless this document is the
+narrower Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record for the exact governance-only
+post-sync concrete-assignment-record boundary identified below.
+
+**Status:** PHASE-23 CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT
+POST-SYNC CONCRETE ASSIGNMENT RECORD / LOCAL DRAFT / GOVERNANCE-ONLY
+POST-SYNC CONCRETE ASSIGNMENT RECORD ONLY / BOUNDED POST-SYNC CONCRETE
+ASSIGNMENT RECORD BOUNDARY ONLY / NO CONCRETE ACCEPTED-EVIDENCE SET
+MEMBERSHIP ASSIGNMENT / NO ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT /
+NO ACCEPTED-EVIDENCE SET MEMBERSHIP / NO ACCEPTED-EVIDENCE SET / NO
+ACCEPTED EVIDENCE / NO EVIDENCE ITEM ACCEPTANCE / NO VALIDATOR OUTPUT
+ACCEPTANCE / NO RECEIPT EVIDENCE ACCEPTANCE / NO RUNTIME IMPLEMENTATION
+PROCEDURE / NO SOURCE MODIFICATION / NO CODE IMPLEMENTATION / NO CODE
+EXECUTION / NO PROCESS START / NO RUNTIME STATE CREATION / NO PACKAGE
+INSTALLATION / NO PACKAGE LOADING / NO PACKAGE EXECUTION / NO DEPLOYMENT /
+NO CAPABILITY ISSUANCE / NO TRUST ASSIGNMENT / NO REGISTRY PUBLICATION /
+NO DISTRIBUTION AUTHORITY / NO SOURCE ACCEPTANCE / NO SOURCE MERGE
+AUTHORITY / NO KERNEL ABI EXPANSION / NO SYSCALL EXPANSION / NO
+WORKFLOW-THRESHOLD CHANGE / NO BASELINE CHANGE / NO DEPENDENCY CHANGE /
+NO RING0 AUTHORITY
+**Record date:** 2026-07-26
+**Record id:**
+`ayken.phase23.concrete_accepted_evidence_set_membership_assignment_post_sync_concrete_assignment_record.v1`
+**Record drafting base main SHA:**
+`c97fecb9eaee548f67e9d7c6b1a819b320ac5304`
+**Record publication subject:** pending separate reviewed publication
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision publication subject:**
+`c97fecb9eaee548f67e9d7c6b1a819b320ac5304`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision PR:** PR #294
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision exact-main ci-freeze run:**
+`30180737180`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision exact-main ci-freeze attempt:**
+attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision exact-main ci-freeze job:**
+`freeze / 89736696125`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision exact-main ci-freeze result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision exact-main Dev Loop Validation
+run:** `30180737175`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision exact-main Dev Loop Validation
+attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision exact-main Dev Loop Validation
+job:** `devloop / 89736696102`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision exact-main Dev Loop Validation
+result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision exact-main Dev Loop CI run:**
+`30180737179`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision exact-main Dev Loop CI attempt:**
+attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision exact-main Dev Loop CI result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision exact-main smoke job:**
+`smoke / 89736696117`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision exact-main smoke result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision exact-main contract job:**
+`contract / 89736774392`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision exact-main contract result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision exact-main full job:**
+`full / 89736919858`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision exact-main full result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision exact-main isolation job:**
+`isolation / 89737112114`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision exact-main isolation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision exact-main performance job:**
+`performance / 89737295499`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision exact-main performance result:** PASS
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision publication subject:**
+`c97fecb9eaee548f67e9d7c6b1a819b320ac5304`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate publication subject:**
+`feb44834568a70bfe103f0fcbfaf37e2a8035619`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision publication subject:**
+`cf7cf2ca6f59c9e8e03a13171f9b3efee889fdb0`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate publication subject:**
+`004a886426b30a55cc8176941ac1553004e31f76`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate publication subject:**
+`39d7fa841e731cfbef8368288e19b6d404aa699c`
+**Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync publication subject:**
+`5edd974c7d3c40eaf154fb2ae60d69f8aa24f3e6`
+**Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync candidate publication subject:**
+`0c25ace3ef87d830f31d86cb63246755b77cf6e0`
+**Phase-23 concrete accepted-evidence set membership assignment
+publication record publication subject:**
+`a7a9d592d91037fbfddd62c861a19664fa8f20e8`
+**Phase-23 concrete accepted-evidence set membership assignment
+publication record candidate publication subject:**
+`485b8fafa89ab0df777365e3dd5d3f6ac698364b`
+**Phase-23 concrete accepted-evidence set membership assignment decision
+publication subject:** `a9533551e7fe0e278e0299b8a60e60632b4c5162`
+**Phase-23 concrete accepted-evidence set membership assignment decision
+candidate publication subject:** `7a1b5b0210cd045647596c8dbd7d23c1427d6f4f`
+**Phase-23 concrete accepted-evidence set membership assignment candidate
+publication subject:** `e9cb4866ce57240de34ef669b6822097473f9830`
+**Phase-23 concrete accepted-evidence set membership assignment record
+publication subject:** `1d2ec43580e3c919b995365bdb058b852f6b3450`
+**Phase-23 concrete accepted-evidence set membership assignment record
+candidate publication subject:** `c20309a39c91d08dab1df3163a204ab80bc767a5`
+**Current phase pointer:** `CURRENT_PHASE=23`
+**Accepted Phase-23 post-sync concrete assignment record boundary:**
+bounded post-sync concrete assignment record boundary as a governance
+record boundary only; concrete assignment, membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, and receipt evidence acceptance
+remain pending separate reviewed records if ever authorized.
+**Authority boundary:** Post-sync concrete assignment record boundary
+only; bounded post-sync concrete assignment record boundary only; not
+concrete accepted-evidence set membership assignment, not
+accepted-evidence set membership assignment, not accepted-evidence set
+membership, not an accepted-evidence set, not accepted evidence, not
+evidence item acceptance, not validator output acceptance, not receipt
+evidence acceptance, not runtime implementation procedure, not source
+modification, not code implementation, not code execution, not process
+start, not runtime state creation, not general runtime authority, not
+unbounded execution authority, not package authority, not package
+installation, not package loading, not package execution, not source
+acceptance, not source merge authority, not source repository authority,
+not module loading, not workspace runtime, not plugin loading, not
+capability token minting, not capability issuance, not trust assignment,
+not trust issuer authority, not registry authority, not registry
+publication, not publication authority, not deployment authority, not
+distribution authority, not distribution execution, not Semantic CLI
+authority, not AI Runtime authority, not agent authority, not syscall
+expansion, not kernel ABI expansion, not workflow-threshold, baseline,
+dependency, or Ring0 authority.
+
+## Purpose
+
+This document records only a bounded post-sync concrete assignment record
+boundary after the clean-fixed Phase-23 concrete accepted-evidence set
+membership assignment post-sync concrete assignment decision at:
+
+```text
+c97fecb9eaee548f67e9d7c6b1a819b320ac5304
+```
+
+It evaluates only:
+
+```text
+May a bounded post-sync concrete assignment record boundary be recorded
+after the clean-fixed post-sync concrete assignment decision at
+c97fecb9eaee548f67e9d7c6b1a819b320ac5304 without creating a concrete
+assignment, assigning membership, creating accepted-evidence set
+membership, creating accepted evidence, or accepting any evidence item?
+```
+
+It accepts only the bounded post-sync concrete assignment record boundary
+as a governance record boundary.
+
+It does not create a concrete assignment.
+
+It does not assign membership.
+
+It does not create accepted-evidence set membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not convert CI PASS results, receipts, validator output, package
+review output, source review output, historical results, clean-fixed
+claims, post-sync concrete-assignment-decision claims,
+concrete-assignment-record claims, or record-boundary claims into
+concrete assignment, membership assignment, accepted-evidence set
+membership, accepted evidence, evidence item acceptance, validator output
+acceptance, or receipt evidence acceptance.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, source acceptance, source merge, registry publication, trust
+assignment, capability issuance, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+It does not answer:
+
+```text
+Which concrete assignment is created?
+How is concrete assignment created?
+Which membership is assigned?
+Which accepted-evidence set membership exists?
+Which evidence is accepted?
+Which evidence item is accepted?
+How is validator output accepted?
+How is receipt evidence accepted?
+How is runtime implementation procedure defined?
+How is source modified?
+How is code implemented or executed?
+How is a process started?
+How is runtime state created?
+How is a package installed, loaded, executed, deployed, or distributed?
+How is source accepted or merged?
+How is a capability issued?
+How is trust assigned?
+How is a registry entry published?
+How is kernel ABI or syscall surface expanded?
+How are workflow thresholds, baselines, or dependencies changed?
+```
+
+Those questions require later reviewed decision or record paths, if ever
+authorized.
+
+## Exact Subject
+
+This record draft is based on exact main SHA:
+
+```text
+c97fecb9eaee548f67e9d7c6b1a819b320ac5304
+```
+
+That subject is the squash merge of PR #294:
+
+```text
+Phase-23 concrete accepted-evidence set membership assignment post-sync concrete assignment decision
+```
+
+PR #294 changed only:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md
+```
+
+PR #294 produced post-merge exact-main verification:
+
+| Evidence | Run / job | Result |
+|---|---|---|
+| `ci-freeze` | run `30180737180`, attempt 1, job `freeze / 89736696125` | PASS |
+| Dev Loop Validation | run `30180737175`, attempt 1, job `devloop / 89736696102` | PASS |
+| AykenOS Dev Loop CI | run `30180737179`, attempt 1 | PASS |
+| smoke | job `89736696117` | PASS |
+| contract | job `89736774392` | PASS |
+| full | job `89736919858` | PASS |
+| isolation | job `89737112114` | PASS |
+| performance | job `89737295499` | PASS |
+
+The Phase-23 Concrete Accepted-Evidence Set Membership Assignment
+Post-Sync Concrete Assignment Decision remains bound to:
+
+```text
+c97fecb9eaee548f67e9d7c6b1a819b320ac5304
+```
+
+That decision recorded that it opened only a bounded post-sync concrete
+assignment decision boundary. It did not create concrete assignment,
+assign membership, create accepted-evidence set membership, create
+accepted evidence, accept evidence items, accept validator output,
+accept receipt evidence, or grant runtime, source, package,
+source-merge, capability, registry, trust, deployment, distribution,
+kernel ABI, syscall, workflow-threshold, baseline, dependency, or Ring0
+authority.
+
+This record consumes that exact subject as governance input only. It
+does not replace, broaden, reinterpret, or supersede the post-sync
+concrete assignment decision or any earlier Phase-23 governance
+boundary.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped subject readings fail closed.
+
+## Core Rule
+
+```text
+post-sync concrete assignment record == bounded post-sync concrete assignment record boundary only
+post-sync concrete assignment record != concrete assignment unless separately reviewed
+post-sync concrete assignment record != concrete accepted-evidence set membership assignment
+post-sync concrete assignment record != accepted-evidence set membership assignment
+post-sync concrete assignment record != membership assignment
+post-sync concrete assignment record != accepted-evidence set membership
+post-sync concrete assignment record != accepted-evidence set
+post-sync concrete assignment record != accepted evidence
+post-sync concrete assignment record != evidence item acceptance
+post-sync concrete assignment record != validator output acceptance
+post-sync concrete assignment record != receipt evidence acceptance
+post-sync concrete assignment record != runtime implementation procedure
+post-sync concrete assignment record != source modification
+post-sync concrete assignment record != package loading
+post-sync concrete assignment record != package execution
+post-sync concrete assignment record != source merge authority
+bounded post-sync concrete assignment record boundary != concrete assignment
+bounded post-sync concrete assignment record boundary != membership assignment
+bounded post-sync concrete assignment record boundary != accepted-evidence set membership
+bounded post-sync concrete assignment record boundary != accepted evidence
+bounded post-sync concrete assignment record boundary != evidence item acceptance
+post-sync concrete assignment decision clean-fixed != post-sync concrete assignment record
+post-sync concrete assignment decision != post-sync concrete assignment record unless separately reviewed
+post-sync concrete assignment decision != concrete assignment
+post-sync concrete assignment decision != membership assignment
+post-sync concrete assignment decision != accepted evidence
+post-sync concrete assignment candidate clean-fixed != concrete assignment
+post-sync decision clean-fixed != concrete assignment
+concrete assignment decision != concrete assignment unless separately reviewed
+concrete assignment record publication != concrete assignment
+concrete assignment record boundary != concrete assignment
+concrete assignment != membership assignment unless separately reviewed
+membership assignment != accepted-evidence set membership unless separately reviewed
+accepted-evidence set membership != accepted evidence unless separately reviewed
+accepted evidence != evidence item acceptance unless separately reviewed
+accepted evidence != validator output unless separately reviewed
+accepted evidence != receipt evidence unless separately reviewed
+validator output != accepted evidence
+receipt evidence != accepted evidence
+receipt evidence != validator output
+CI PASS != post-sync concrete assignment record
+CI PASS != concrete assignment
+CI PASS != membership assignment
+CI PASS != accepted-evidence set membership
+CI PASS != accepted evidence
+ci-freeze PASS != post-sync concrete assignment record
+ci-freeze PASS != concrete assignment
+ci-freeze PASS != accepted evidence
+Dev Loop PASS != post-sync concrete assignment record
+Dev Loop PASS != concrete assignment
+AykenOS Dev Loop CI PASS != post-sync concrete assignment record
+AykenOS Dev Loop CI PASS != concrete assignment
+post-merge exact-main verification != post-sync concrete assignment record
+post-merge exact-main verification != concrete assignment
+clean-fixed != post-sync concrete assignment record
+clean-fixed != concrete assignment
+publication-status sync != post-sync concrete assignment record
+publication-status sync != concrete assignment
+CURRENT_PHASE=23 != post-sync concrete assignment record
+CURRENT_PHASE=23 != concrete assignment
+CURRENT_PHASE=23 != membership assignment
+CURRENT_PHASE=23 != accepted-evidence set membership
+CURRENT_PHASE=23 != accepted evidence
+CURRENT_PHASE=23 != evidence item acceptance
+CURRENT_PHASE=23 != validator output acceptance
+CURRENT_PHASE=23 != receipt evidence acceptance
+CURRENT_PHASE=23 != runtime implementation procedure
+CURRENT_PHASE=23 != source modification
+CURRENT_PHASE=23 != execution authority
+CURRENT_PHASE=23 != package loading
+CURRENT_PHASE=23 != source merge authority
+CURRENT_PHASE=23 != kernel ABI expansion
+CURRENT_PHASE=23 != syscall expansion
+historical PASS != inherited evidence
+previous PR evidence != later PR evidence
+```
+
+The safe default remains no concrete assignment, no membership
+assignment, no accepted-evidence set membership, no accepted evidence, no
+evidence item acceptance, no validator output acceptance, no receipt
+evidence acceptance, no runtime behavior, no implementation procedure,
+no source modification, no code execution, no runtime state, and no
+package, capability, registry, trust, distribution, deployment, source
+acceptance, source merge, kernel ABI, syscall, workflow-threshold,
+baseline, dependency, or Ring0 authority unless a later reviewed
+Phase-23 decision or record grants a specific bounded authority with its
+own exact-SHA evidence.
+
+Unknown authority readings fail closed.
+
+## Post-Sync Concrete Assignment Record
+
+The Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record is accepted only as:
+
+```text
+bounded post-sync concrete assignment record boundary
+```
+
+This record boundary may be used only to evaluate whether a later
+separate reviewed concrete assignment, membership assignment,
+accepted-evidence set membership, accepted-evidence, evidence item
+acceptance, validator-output acceptance, or receipt-evidence acceptance
+path may be proposed, without creating any of those later assignments,
+memberships, evidence statuses, records, or authorities.
+
+This record does not create a concrete assignment.
+
+This record does not assign accepted-evidence set membership.
+
+This record does not create accepted-evidence set membership.
+
+This record does not create accepted evidence.
+
+This record does not accept any evidence item.
+
+This record does not accept validator output.
+
+This record does not accept receipt evidence.
+
+This record does not authorize package loading.
+
+This record does not authorize source acceptance or source merge.
+
+This record does not authorize runtime implementation procedure, code
+execution, process start, runtime state creation, capability issuance,
+registry publication, trust assignment, deployment, distribution, kernel
+ABI expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Any later concrete assignment, membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, or receipt evidence acceptance
+requires a separate reviewed decision or record path with its own exact
+subject, changed-file scope, non-authorization boundary, and post-merge
+exact-main verification.
+
+## Record Scope
+
+This record scope is limited to:
+
+1. Accepting the Phase-23 post-sync concrete assignment record boundary
+   only as a bounded governance record boundary.
+2. Binding this record to PR #294 as the clean-fixed post-sync concrete
+   assignment decision input.
+3. Preserving the distinction between concrete assignment record boundary
+   and concrete assignment.
+4. Preserving the distinction between concrete assignment and membership
+   assignment.
+5. Preserving the distinction between membership assignment and
+   accepted-evidence set membership.
+6. Preserving the distinction between accepted-evidence set membership
+   and accepted evidence.
+7. Preserving the distinction between accepted evidence and evidence
+   item acceptance.
+8. Preserving separation from validator output acceptance and receipt
+   evidence acceptance.
+9. Establishing post-merge exact-main verification expectations for this
+   record.
+
+Record scope is governance text only.
+
+Record scope is bounded post-sync concrete assignment record boundary
+only.
+
+Record scope is not concrete assignment.
+
+Record scope is not membership assignment.
+
+Record scope is not accepted-evidence set membership.
+
+Record scope is not accepted evidence.
+
+Record scope is not evidence item acceptance.
+
+Record scope is not validator output acceptance.
+
+Record scope is not receipt evidence acceptance.
+
+Record scope is not runtime implementation procedure.
+
+Record scope is not package loading authority.
+
+Record scope is not execution authority.
+
+Record scope is not source merge authority.
+
+## Current Phase Pointer Boundary
+
+The current phase pointer remains:
+
+```text
+CURRENT_PHASE=23
+```
+
+This record does not modify:
+
+```text
+docs/roadmap/CURRENT_PHASE
+```
+
+This record does not change the active phase pointer.
+
+`CURRENT_PHASE=23` does not authorize concrete assignment, membership
+assignment, accepted-evidence set membership, accepted evidence,
+evidence item acceptance, validator output acceptance, receipt evidence
+acceptance, runtime implementation procedure, source modification, code
+implementation, code execution, process start, runtime state creation,
+package loading, package execution, capability issuance, registry
+publication, trust assignment, deployment, distribution, source
+acceptance, source merge, kernel ABI expansion, syscall expansion,
+workflow-threshold changes, baseline changes, dependency changes, or
+Ring0 authority.
+
+## Post-Sync Concrete Assignment Decision Input
+
+This record consumes the clean-fixed Phase-23 Concrete Accepted-Evidence
+Set Membership Assignment Post-Sync Concrete Assignment Decision as its
+exact governance prerequisite.
+
+The post-sync concrete assignment decision remains bound to:
+
+```text
+c97fecb9eaee548f67e9d7c6b1a819b320ac5304
+```
+
+The post-sync concrete assignment decision recorded only a bounded
+post-sync concrete assignment decision boundary.
+
+This record does not reinterpret the post-sync concrete assignment
+decision as concrete assignment, membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime implementation procedure, execution authority, package loading
+authority, source acceptance, source merge authority, capability
+issuance, registry publication, trust assignment, deployment,
+distribution, kernel ABI expansion, syscall expansion,
+workflow-threshold change, baseline change, dependency change, or Ring0
+authority.
+
+Any post-sync concrete assignment decision conflict fails closed.
+
+## Relationship To Concrete Assignment And Membership
+
+This record accepts only a bounded governance record boundary for later
+post-sync concrete assignment evaluation.
+
+This record does not create a concrete assignment.
+
+This record does not assign accepted-evidence set membership.
+
+This record does not create accepted-evidence set membership.
+
+This record does not define assignment membership.
+
+This record does not define accepted-evidence set membership.
+
+This record does not make concrete assignment inevitable.
+
+This record does not make membership assignment inevitable.
+
+This record does not make accepted-evidence set membership inevitable.
+
+Any attempt to treat this record as concrete assignment, membership
+assignment, or accepted-evidence set membership fails closed.
+
+## Relationship To Accepted Evidence And Evidence Item Acceptance
+
+Concrete assignment remains separate from accepted evidence unless a
+separate reviewed decision or record explicitly grants that narrower
+authority.
+
+This record does not create accepted evidence.
+
+This record does not identify accepted evidence.
+
+This record does not accept any evidence item.
+
+This record does not define accepted-evidence membership.
+
+This record does not define accepted-evidence set membership.
+
+This record does not make accepted evidence inevitable.
+
+Any attempt to treat this record as accepted evidence or evidence item
+acceptance fails closed.
+
+## Relationship To Validator Output And Receipt Evidence
+
+This record does not convert validator output into accepted evidence.
+
+This record does not convert receipt evidence into accepted evidence.
+
+This record does not accept validator output.
+
+This record does not accept receipt evidence.
+
+This record does not grant accepted-evidence membership over validator
+output, receipt evidence, package review output, source review output,
+historical PASS results, or clean-fixed claims.
+
+Any validator-output or receipt-evidence boundary conflict fails closed.
+
+## Relationship To Phase-19 Runtime Authority
+
+This record remains subordinate to Phase-19 runtime authority records.
+
+This record must not broaden, replace, supersede, weaken, or reinterpret
+Phase-19 runtime authority records.
+
+This record must not use concrete assignment record status to infer
+runtime authority.
+
+This record must not use concrete assignment, membership assignment,
+accepted-evidence set membership, accepted-evidence authority, accepted
+evidence, validator-output planning, receipt-evidence planning,
+exact-SHA evidence expectations, or `CURRENT_PHASE=23` to infer runtime
+authority.
+
+Any Phase-23 post-sync concrete assignment record reading that conflicts
+with Phase-19 runtime authority records fails closed.
+
+## Not Authorized By This Record
+
+This record does not authorize:
+
+1. Concrete accepted-evidence set membership assignment.
+2. Accepted-evidence set membership assignment.
+3. Membership assignment.
+4. Accepted-evidence set membership.
+5. Accepted-evidence set creation.
+6. Accepted evidence.
+7. Evidence item acceptance.
+8. Validator output acceptance.
+9. Receipt evidence acceptance.
+10. Runtime implementation procedure.
+11. Source modification.
+12. Source acceptance.
+13. Source merge.
+14. Code implementation.
+15. Code execution.
+16. Process start.
+17. Runtime state creation.
+18. Package installation.
+19. Package loading.
+20. Package execution.
+21. Module loading.
+22. Workspace runtime or real mounts.
+23. Plugin loading or plugin instantiation.
+24. Capability token minting.
+25. Capability issuance.
+26. Registry publication.
+27. Trust assignment.
+28. Distribution execution.
+29. Deployment.
+30. Semantic CLI authority.
+31. AI Runtime authority.
+32. Agent authority.
+33. Syscall expansion.
+34. Kernel ABI expansion.
+35. Ring0 policy movement.
+36. Workflow-threshold changes.
+37. Baseline changes.
+38. Dependency changes.
+39. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this record is published, the publication may change only this file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_RECORD.md
+```
+
+The publication must not change:
+
+1. `docs/roadmap/CURRENT_PHASE`.
+2. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md`.
+3. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_CANDIDATE.md`.
+4. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md`.
+5. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md`.
+6. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`.
+7. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`.
+8. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md`.
+9. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`.
+10. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`.
+11. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+12. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`.
+13. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+14. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+15. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+16. CI workflows.
+17. Baselines.
+18. Dependencies.
+19. Runtime source or kernel source.
+20. Syscalls or kernel ABI.
+21. Package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution paths.
+22. `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md`.
+
+Any changed-file expansion beyond this record requires separate review
+and fails this record scope.
+
+## Post-Merge Exact-Main Evidence Rule
+
+If this record is later published, the record publication subject must
+receive its own post-merge exact-main verification:
+
+1. `ci-freeze` PASS for the exact record publication SHA.
+2. Dev Loop Validation PASS for the exact record publication SHA.
+3. AykenOS Dev Loop CI PASS for the exact record publication SHA.
+4. smoke PASS.
+5. contract PASS.
+6. full PASS.
+7. isolation PASS.
+8. performance PASS.
+9. Exact changed-file list confirmation.
+10. No `docs/roadmap/CURRENT_PHASE` change.
+11. No `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md`
+    change.
+12. No `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_CANDIDATE.md`
+    change.
+13. No `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md`
+    change.
+14. No concrete assignment, membership assignment, accepted-evidence set
+    membership, accepted evidence, evidence item acceptance, validator
+    output acceptance, or receipt evidence acceptance.
+15. No CI workflow change.
+16. No baseline change.
+17. No dependency change.
+18. No runtime source or kernel source change.
+19. No syscall or kernel ABI change.
+20. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution change.
+
+Until that exact-main post-merge verification exists, this record must
+not be recorded as clean-fixed.
+
+Historical PASS results may be cited as context only.
+
+Failed attempts may be cited as transparent non-clean context only.
+
+They cannot be inherited as concrete assignment, membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime authority, package loading authority, package execution
+authority, source merge authority, capability authority, registry
+authority, trust authority, kernel ABI authority, syscall authority,
+workflow-threshold authority, baseline authority, dependency authority,
+or Ring0 authority.
+
+## Later Concrete Assignment Dependency
+
+This record is a prerequisite input for a possible later bounded
+post-sync concrete assignment path.
+
+A later concrete assignment decision or record, if ever proposed, must
+define:
+
+1. Exact concrete assignment subject.
+2. Exact Phase-23 post-sync concrete assignment record prerequisite.
+3. Exact changed-file boundary.
+4. Exact evidence item reference proposed for concrete assignment, if
+   any, without evidence item acceptance unless separately reviewed.
+5. Exact accepted-evidence set membership proposed for assignment, if
+   any, without accepted-evidence set membership status unless separately
+   reviewed.
+6. Exact concrete assignment grant, denial, or separate concrete
+   assignment scope.
+7. Exact membership assignment denial or separate membership assignment
+   scope.
+8. Exact accepted-evidence set membership denial or separate membership
+   scope.
+9. Exact accepted-evidence denial or separate accepted-evidence scope.
+10. Exact evidence item acceptance denial or separate evidence item
+    acceptance scope.
+11. Exact validator-output acceptance denial or separate
+    validator-output acceptance scope.
+12. Exact receipt-evidence acceptance denial or separate receipt-evidence
+    acceptance scope.
+13. Exact runtime implementation procedure denial.
+14. Exact package loading and package execution denials.
+15. Exact source acceptance and source merge denials.
+16. Exact capability, registry, trust, deployment, distribution, kernel
+    ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+    denials.
+17. Exact post-merge verification requirements.
+
+Until such a later reviewed concrete assignment record is published, no
+concrete assignment exists from this record.
+
+Until such a later reviewed membership assignment record is published, no
+membership assignment exists from this record.
+
+Until such a later reviewed accepted-evidence set membership record is
+published, no accepted-evidence set membership exists from this record.
+
+Until such a later reviewed accepted-evidence record is published, no
+accepted evidence exists from this record.
+
+Until such a later reviewed evidence item acceptance record is published,
+no evidence item acceptance exists from this record.
+
+Until such a later reviewed validator-output acceptance record is
+published, no validator output acceptance exists from this record.
+
+Until such a later reviewed receipt-evidence acceptance record is
+published, no receipt evidence acceptance exists from this record.
+
+## Excluded Local Draft
+
+This record does not consume:
+
+```text
+PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md
+```
+
+If that file exists locally as an untracked file, it remains:
+
+```text
+untracked
+PR-disjoint
+not candidate input
+not decision input
+not record input
+not evidence input
+not concrete assignment
+not membership assignment
+not accepted-evidence set membership
+not accepted evidence
+not evidence item acceptance
+not validator output
+not receipt evidence
+not source authority
+not package acceptance
+not runtime authority
+```
+
+It must not be staged, committed, or included in any Phase-23 post-sync
+concrete assignment record PR unless a separate reviewed scope explicitly
+authorizes that file.
+
+## Governance Boundary Invariants
+
+Every later RFC must preserve these Phase-23 post-sync concrete
+assignment record invariants:
+
+1. This record is bounded post-sync concrete assignment record boundary
+   only.
+2. This record is not concrete assignment.
+3. This record is not membership assignment.
+4. This record is not accepted-evidence set membership.
+5. This record is not an accepted-evidence set.
+6. This record is not accepted evidence.
+7. This record is not evidence item acceptance.
+8. This record is not validator output acceptance.
+9. This record is not receipt evidence acceptance.
+10. Concrete assignment record is not concrete assignment unless
+    separately reviewed.
+11. Concrete assignment is not membership assignment unless separately
+    reviewed.
+12. Membership assignment is not accepted-evidence set membership unless
+    separately reviewed.
+13. Accepted-evidence set membership is not accepted evidence unless
+    separately reviewed.
+14. Accepted evidence is not evidence item acceptance unless separately
+    reviewed.
+15. This record is not runtime implementation procedure.
+16. This record is not source modification.
+17. This record is not code implementation.
+18. This record is not code execution.
+19. This record is not process start.
+20. This record is not runtime state creation.
+21. This record is not package installation.
+22. This record is not package loading.
+23. This record is not package execution.
+24. This record is not capability issuance.
+25. This record is not registry publication.
+26. This record is not trust assignment.
+27. This record is not deployment.
+28. This record is not distribution authority.
+29. This record is not source acceptance.
+30. This record is not source merge authority.
+31. This record does not modify `docs/roadmap/CURRENT_PHASE`.
+32. This record does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md`.
+33. This record does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_CANDIDATE.md`.
+34. This record does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md`.
+35. `CURRENT_PHASE=23` is not concrete assignment.
+36. `CURRENT_PHASE=23` is not membership assignment.
+37. `CURRENT_PHASE=23` is not accepted-evidence set membership.
+38. `CURRENT_PHASE=23` is not accepted evidence.
+39. `CURRENT_PHASE=23` is not evidence item acceptance.
+40. `CURRENT_PHASE=23` is not validator output acceptance.
+41. `CURRENT_PHASE=23` is not receipt evidence acceptance.
+42. `CURRENT_PHASE=23` is not runtime implementation procedure.
+43. `CURRENT_PHASE=23` is not source modification.
+44. `CURRENT_PHASE=23` is not execution authority.
+45. `CURRENT_PHASE=23` is not package loading.
+46. `CURRENT_PHASE=23` is not source merge authority.
+47. This record does not broaden Phase-19 runtime authority.
+48. This record does not reopen Phase-20.
+49. This record does not reopen Phase-21.
+50. This record does not reopen Phase-22.
+51. This record does not expand kernel ABI or syscalls.
+52. This record does not change workflow thresholds, baselines, or
+    dependencies.
+53. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-23 concrete accepted-evidence set membership
+assignment post-sync concrete assignment record
+**Architecture status:** Local draft post-sync concrete assignment record
+/ pending separate reviewed publication
+**Authority notice:** If separately reviewed and published, this record
+grants only the bounded post-sync concrete assignment record boundary
+defined in this record. It grants no concrete assignment, membership
+assignment, accepted-evidence set membership, accepted evidence status,
+evidence item acceptance authority, validator output acceptance
+authority, receipt evidence acceptance authority, runtime implementation
+procedure authority, source modification authority, code implementation
+authority, code execution authority, process start authority, general
+runtime authority, unbounded execution authority, runtime state
+authority, package installation authority, package loading authority,
+package execution authority, source merge authority, trust authority,
+registry authority, distribution authority, publication authority,
+capability issuance authority, deployment authority, module authority,
+plugin authority, Semantic CLI authority, AI Runtime authority, agent
+authority, kernel ABI authority, syscall authority, workflow-threshold
+authority, baseline authority, dependency authority, or Ring0 authority.
+
+## Conclusion
+
+This Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record is based on the clean-fixed Phase-23
+Concrete Accepted-Evidence Set Membership Assignment Post-Sync Concrete
+Assignment Decision publication subject:
+
+```text
+c97fecb9eaee548f67e9d7c6b1a819b320ac5304
+```
+
+It accepts only the bounded post-sync concrete assignment record
+boundary.
+
+It does not create a concrete assignment.
+
+It does not assign membership.
+
+It does not create accepted-evidence set membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize concrete assignment, membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime implementation procedure, source modification, code
+implementation, code execution, process start, runtime state creation,
+package installation, package loading, package execution, capability
+issuance, registry publication, trust assignment, deployment,
+distribution, source acceptance, source merge, kernel ABI expansion,
+syscall expansion, workflow-threshold changes, baseline changes,
+dependency changes, or Ring0 authority.
+
+Any later Phase-23 concrete assignment, membership assignment,
+accepted-evidence set membership, accepted-evidence, evidence-item,
+validator-output, receipt-evidence, package-review, source-review,
+runtime-implementation-procedure, or non-authorization boundary record
+requires its own exact-SHA evidence, changed-file scope,
+non-authorization boundary, and reviewed decision path.


### PR DESCRIPTION
This PR changes only PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_RECORD.md and records only a governance-only bounded post-sync concrete assignment record boundary after the clean-fixed post-sync concrete assignment decision boundary at c97fecb9eaee548f67e9d7c6b1a819b320ac5304. It does not create a concrete assignment, assign membership, create accepted-evidence set membership, create accepted evidence, accept any evidence item, accept validator output, accept receipt evidence, or authorize runtime/source/package/source-merge/capability/registry/trust/deployment/distribution/kernel ABI/syscall/workflow-threshold/baseline/dependency/Ring0 authority.