### PR TITLE
Phase-23 concrete accepted-evidence set membership assignment post-sync concrete assignment

### DIFF
--- a/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT.md
+++ b/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT.md
@@ -1,0 +1,991 @@
+# Phase-23 Concrete Accepted-Evidence Set Membership Assignment Post-Sync Concrete Assignment
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY_CLEAN_RECOVERY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_FIRST_BOUNDED_IMPLEMENTATION.md`,
+`PHASE22_CLOSURE_DECISION.md`,
+`PHASE23_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE23_POINTER_TRANSITION_DECISION.md`,
+`docs/roadmap/CURRENT_PHASE`,
+`PHASE23_GOVERNANCE_OVERVIEW.md`,
+`PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`,
+`PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`,
+`PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md`,
+and
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_RECORD.md`.
+In case of conflict, those documents prevail unless this document is the
+narrower Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment boundary for the exact governance-only
+bounded post-sync concrete-assignment boundary identified below.
+
+**Status:** PHASE-23 CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT
+POST-SYNC CONCRETE ASSIGNMENT / LOCAL DRAFT / GOVERNANCE-ONLY POST-SYNC
+CONCRETE ASSIGNMENT BOUNDARY ONLY / BOUNDED POST-SYNC CONCRETE
+ASSIGNMENT BOUNDARY ONLY / NO ACCEPTED-EVIDENCE SET MEMBERSHIP
+ASSIGNMENT / NO MEMBERSHIP ASSIGNMENT / NO ACCEPTED-EVIDENCE SET
+MEMBERSHIP / NO ACCEPTED-EVIDENCE SET / NO ACCEPTED EVIDENCE / NO
+EVIDENCE ITEM ACCEPTANCE / NO VALIDATOR OUTPUT ACCEPTANCE / NO RECEIPT
+EVIDENCE ACCEPTANCE / NO RUNTIME IMPLEMENTATION PROCEDURE / NO SOURCE
+MODIFICATION / NO CODE IMPLEMENTATION / NO CODE EXECUTION / NO PROCESS
+START / NO RUNTIME STATE CREATION / NO PACKAGE INSTALLATION / NO PACKAGE
+LOADING / NO PACKAGE EXECUTION / NO DEPLOYMENT / NO CAPABILITY ISSUANCE /
+NO TRUST ASSIGNMENT / NO REGISTRY PUBLICATION / NO DISTRIBUTION
+AUTHORITY / NO SOURCE ACCEPTANCE / NO SOURCE MERGE AUTHORITY / NO KERNEL
+ABI EXPANSION / NO SYSCALL EXPANSION / NO WORKFLOW-THRESHOLD CHANGE / NO
+BASELINE CHANGE / NO DEPENDENCY CHANGE / NO RING0 AUTHORITY
+**Boundary date:** 2026-07-27
+**Boundary id:**
+`ayken.phase23.concrete_accepted_evidence_set_membership_assignment_post_sync_concrete_assignment.v1`
+**Boundary drafting base main SHA:**
+`af894b8c0b49bc84d4671b98ce25a10e9467a1dc`
+**Boundary publication subject:** pending separate reviewed publication
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record publication subject:**
+`af894b8c0b49bc84d4671b98ce25a10e9467a1dc`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record PR:** PR #295
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record exact-main ci-freeze run:**
+`30200743133`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record exact-main ci-freeze clean attempt:**
+attempt 2
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record exact-main ci-freeze clean job:**
+`freeze / 89790608574`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record exact-main ci-freeze clean result:**
+PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record exact-main ci-freeze non-clean
+attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record exact-main ci-freeze non-clean job:**
+`freeze / 89790131553`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record exact-main ci-freeze non-clean
+result:** alias-proof failure / transparent non-clean context only / not
+clean-fixed evidence
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record exact-main Dev Loop Validation
+run:** `30200743101`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record exact-main Dev Loop Validation
+attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record exact-main Dev Loop Validation
+job:** `devloop / 89790131510`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record exact-main Dev Loop Validation
+result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record exact-main Dev Loop CI run:**
+`30200743134`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record exact-main Dev Loop CI attempt:**
+attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record exact-main Dev Loop CI result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record exact-main smoke job:**
+`smoke / 89790131518`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record exact-main smoke result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record exact-main contract job:**
+`contract / 89790225850`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record exact-main contract result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record exact-main full job:**
+`full / 89790394074`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record exact-main full result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record exact-main isolation job:**
+`isolation / 89790627641`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record exact-main isolation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record exact-main performance job:**
+`performance / 89790838599`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record exact-main performance result:** PASS
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record publication subject:**
+`af894b8c0b49bc84d4671b98ce25a10e9467a1dc`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision publication subject:**
+`c97fecb9eaee548f67e9d7c6b1a819b320ac5304`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate publication subject:**
+`feb44834568a70bfe103f0fcbfaf37e2a8035619`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision publication subject:**
+`cf7cf2ca6f59c9e8e03a13171f9b3efee889fdb0`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate publication subject:**
+`004a886426b30a55cc8176941ac1553004e31f76`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate publication subject:**
+`39d7fa841e731cfbef8368288e19b6d404aa699c`
+**Phase-23 concrete accepted-evidence set membership assignment
+publication-status sync publication subject:**
+`5edd974c7d3c40eaf154fb2ae60d69f8aa24f3e6`
+**Current phase pointer:** `CURRENT_PHASE=23`
+**Accepted Phase-23 post-sync concrete assignment boundary:** bounded
+post-sync concrete assignment boundary as a governance boundary only;
+membership assignment, accepted-evidence set membership, accepted
+evidence, evidence item acceptance, validator output acceptance, and
+receipt evidence acceptance remain pending separate reviewed records if
+ever authorized.
+**Authority boundary:** Post-sync concrete assignment boundary only;
+bounded post-sync concrete assignment boundary only; not
+accepted-evidence set membership assignment, not membership assignment,
+not accepted-evidence set membership, not an accepted-evidence set, not
+accepted evidence, not evidence item acceptance, not validator output
+acceptance, not receipt evidence acceptance, not runtime implementation
+procedure, not source modification, not code implementation, not code
+execution, not process start, not runtime state creation, not general
+runtime authority, not unbounded execution authority, not package
+authority, not package installation, not package loading, not package
+execution, not source acceptance, not source merge authority, not source
+repository authority, not module loading, not workspace runtime, not
+plugin loading, not capability token minting, not capability issuance,
+not trust assignment, not trust issuer authority, not registry
+authority, not registry publication, not publication authority, not
+deployment authority, not distribution authority, not distribution
+execution, not Semantic CLI authority, not AI Runtime authority, not
+agent authority, not syscall expansion, not kernel ABI expansion, not
+workflow-threshold, baseline, dependency, or Ring0 authority.
+
+## Purpose
+
+This document records only a bounded post-sync concrete assignment
+boundary after the clean-fixed Phase-23 concrete accepted-evidence set
+membership assignment post-sync concrete assignment record at:
+
+```text
+af894b8c0b49bc84d4671b98ce25a10e9467a1dc
+```
+
+It evaluates only:
+
+```text
+May a bounded post-sync concrete assignment boundary be recorded after
+the clean-fixed post-sync concrete assignment record at
+af894b8c0b49bc84d4671b98ce25a10e9467a1dc without assigning membership,
+creating accepted-evidence set membership, creating accepted evidence, or
+accepting any evidence item?
+```
+
+It accepts only the bounded post-sync concrete assignment boundary as a
+governance boundary.
+
+This boundary is not membership assignment.
+
+This boundary does not assign membership.
+
+This boundary does not create accepted-evidence set membership.
+
+This boundary does not create accepted evidence.
+
+This boundary does not accept any evidence item.
+
+This boundary does not accept validator output.
+
+This boundary does not accept receipt evidence.
+
+It does not convert CI PASS results, receipts, validator output, package
+review output, source review output, historical results, clean-fixed
+claims, post-sync concrete-assignment-record claims, or concrete
+assignment boundary claims into membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, or receipt evidence acceptance.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, source acceptance, source merge, registry publication, trust
+assignment, capability issuance, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+It does not answer:
+
+```text
+Which membership is assigned?
+Which accepted-evidence set membership exists?
+Which evidence is accepted?
+Which evidence item is accepted?
+How is validator output accepted?
+How is receipt evidence accepted?
+How is runtime implementation procedure defined?
+How is source modified?
+How is code implemented or executed?
+How is a process started?
+How is runtime state created?
+How is a package installed, loaded, executed, deployed, or distributed?
+How is source accepted or merged?
+How is a capability issued?
+How is trust assigned?
+How is a registry entry published?
+How is kernel ABI or syscall surface expanded?
+How are workflow thresholds, baselines, or dependencies changed?
+```
+
+Those questions require later reviewed decision or record paths, if ever
+authorized.
+
+## Exact Subject
+
+This boundary draft is based on exact main SHA:
+
+```text
+af894b8c0b49bc84d4671b98ce25a10e9467a1dc
+```
+
+That subject is the squash merge of PR #295:
+
+```text
+Phase-23 concrete accepted-evidence set membership assignment post-sync concrete assignment record
+```
+
+PR #295 changed only:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_RECORD.md
+```
+
+PR #295 produced post-merge exact-main verification:
+
+| Evidence | Run / job | Result |
+|---|---|---|
+| `ci-freeze` | run `30200743133`, attempt 2, job `freeze / 89790608574` | PASS |
+| Dev Loop Validation | run `30200743101`, attempt 1, job `devloop / 89790131510` | PASS |
+| AykenOS Dev Loop CI | run `30200743134`, attempt 1 | PASS |
+| smoke | job `89790131518` | PASS |
+| contract | job `89790225850` | PASS |
+| full | job `89790394074` | PASS |
+| isolation | job `89790627641` | PASS |
+| performance | job `89790838599` | PASS |
+
+PR #295 also produced transparent non-clean context:
+
+| Evidence | Run / job | Result |
+|---|---|---|
+| `ci-freeze` | run `30200743133`, attempt 1, job `freeze / 89790131553` | alias-proof failure / non-clean context only |
+
+The non-clean attempt is not clean-fixed evidence.
+
+The Phase-23 Concrete Accepted-Evidence Set Membership Assignment
+Post-Sync Concrete Assignment Record remains bound to:
+
+```text
+af894b8c0b49bc84d4671b98ce25a10e9467a1dc
+```
+
+That record opened only a bounded post-sync concrete assignment record
+boundary. It did not assign membership, create accepted-evidence set
+membership, create accepted evidence, accept evidence items, accept
+validator output, accept receipt evidence, or grant runtime, source,
+package, source-merge, capability, registry, trust, deployment,
+distribution, kernel ABI, syscall, workflow-threshold, baseline,
+dependency, or Ring0 authority.
+
+This boundary consumes that exact subject as governance input only. It
+does not replace, broaden, reinterpret, or supersede the post-sync
+concrete assignment record or any earlier Phase-23 governance boundary.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped subject readings fail closed.
+
+## Core Rule
+
+```text
+post-sync concrete assignment == bounded post-sync concrete assignment boundary only
+post-sync concrete assignment boundary != membership assignment
+post-sync concrete assignment boundary != accepted-evidence set membership
+post-sync concrete assignment boundary != accepted evidence
+post-sync concrete assignment boundary != evidence item acceptance
+post-sync concrete assignment boundary != validator output acceptance
+post-sync concrete assignment boundary != receipt evidence acceptance
+post-sync concrete assignment boundary != runtime implementation procedure
+post-sync concrete assignment boundary != source modification
+post-sync concrete assignment boundary != package loading
+post-sync concrete assignment boundary != package execution
+post-sync concrete assignment boundary != source merge authority
+concrete assignment boundary != membership assignment
+concrete assignment boundary != accepted-evidence set membership
+concrete assignment boundary != accepted evidence
+concrete assignment boundary != evidence item acceptance
+concrete assignment record clean-fixed != post-sync concrete assignment
+post-sync concrete assignment record != post-sync concrete assignment unless separately reviewed
+post-sync concrete assignment record boundary != concrete assignment boundary unless separately reviewed
+post-sync concrete assignment decision clean-fixed != post-sync concrete assignment
+post-sync concrete assignment candidate clean-fixed != post-sync concrete assignment
+post-sync decision clean-fixed != post-sync concrete assignment
+membership assignment != accepted-evidence set membership unless separately reviewed
+accepted-evidence set membership != accepted evidence unless separately reviewed
+accepted evidence != evidence item acceptance unless separately reviewed
+accepted evidence != validator output unless separately reviewed
+accepted evidence != receipt evidence unless separately reviewed
+validator output != accepted evidence
+receipt evidence != accepted evidence
+receipt evidence != validator output
+CI PASS != post-sync concrete assignment
+CI PASS != membership assignment
+CI PASS != accepted-evidence set membership
+CI PASS != accepted evidence
+ci-freeze PASS != post-sync concrete assignment
+ci-freeze PASS != accepted evidence
+Dev Loop PASS != post-sync concrete assignment
+AykenOS Dev Loop CI PASS != post-sync concrete assignment
+post-merge exact-main verification != post-sync concrete assignment
+clean-fixed != post-sync concrete assignment
+publication-status sync != post-sync concrete assignment
+CURRENT_PHASE=23 != post-sync concrete assignment
+CURRENT_PHASE=23 != membership assignment
+CURRENT_PHASE=23 != accepted-evidence set membership
+CURRENT_PHASE=23 != accepted evidence
+CURRENT_PHASE=23 != evidence item acceptance
+CURRENT_PHASE=23 != validator output acceptance
+CURRENT_PHASE=23 != receipt evidence acceptance
+CURRENT_PHASE=23 != runtime implementation procedure
+CURRENT_PHASE=23 != source modification
+CURRENT_PHASE=23 != execution authority
+CURRENT_PHASE=23 != package loading
+CURRENT_PHASE=23 != source merge authority
+CURRENT_PHASE=23 != kernel ABI expansion
+CURRENT_PHASE=23 != syscall expansion
+historical PASS != inherited evidence
+previous PR evidence != later PR evidence
+```
+
+The safe default remains no membership assignment, no accepted-evidence
+set membership, no accepted evidence, no evidence item acceptance, no
+validator output acceptance, no receipt evidence acceptance, no runtime
+behavior, no implementation procedure, no source modification, no code
+execution, no runtime state, and no package, capability, registry, trust,
+distribution, deployment, source acceptance, source merge, kernel ABI,
+syscall, workflow-threshold, baseline, dependency, or Ring0 authority
+unless a later reviewed Phase-23 decision or record grants a specific
+bounded authority with its own exact-SHA evidence.
+
+Unknown authority readings fail closed.
+
+## Post-Sync Concrete Assignment Boundary
+
+The Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment is accepted only as:
+
+```text
+bounded post-sync concrete assignment boundary
+```
+
+This boundary may be used only to evaluate whether a later separate
+reviewed membership assignment, accepted-evidence set membership,
+accepted-evidence, evidence item acceptance, validator-output
+acceptance, or receipt-evidence acceptance path may be proposed, without
+creating any of those later assignments, memberships, evidence statuses,
+records, or authorities.
+
+This boundary does not assign accepted-evidence set membership.
+
+This boundary does not create accepted-evidence set membership.
+
+This boundary does not create accepted evidence.
+
+This boundary does not accept any evidence item.
+
+This boundary does not accept validator output.
+
+This boundary does not accept receipt evidence.
+
+This boundary does not authorize package loading.
+
+This boundary does not authorize source acceptance or source merge.
+
+This boundary does not authorize runtime implementation procedure, code
+execution, process start, runtime state creation, capability issuance,
+registry publication, trust assignment, deployment, distribution, kernel
+ABI expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Any later membership assignment, accepted-evidence set membership,
+accepted evidence, evidence item acceptance, validator output
+acceptance, or receipt evidence acceptance requires a separate reviewed
+decision or record path with its own exact subject, changed-file scope,
+non-authorization boundary, and post-merge exact-main verification.
+
+## Boundary Scope
+
+This boundary scope is limited to:
+
+1. Accepting the Phase-23 post-sync concrete assignment boundary only as
+   a bounded governance boundary.
+2. Binding this boundary to PR #295 as the clean-fixed post-sync
+   concrete assignment record input.
+3. Preserving the distinction between concrete assignment boundary and
+   membership assignment.
+4. Preserving the distinction between membership assignment and
+   accepted-evidence set membership.
+5. Preserving the distinction between accepted-evidence set membership
+   and accepted evidence.
+6. Preserving the distinction between accepted evidence and evidence
+   item acceptance.
+7. Preserving separation from validator output acceptance and receipt
+   evidence acceptance.
+8. Preserving transparent non-clean context separation for the PR #295
+   ci-freeze attempt 1 alias-proof failure.
+9. Establishing post-merge exact-main verification expectations for
+   this boundary.
+
+Boundary scope is governance text only.
+
+Boundary scope is bounded post-sync concrete assignment boundary only.
+
+Boundary scope is not membership assignment.
+
+Boundary scope is not accepted-evidence set membership.
+
+Boundary scope is not accepted evidence.
+
+Boundary scope is not evidence item acceptance.
+
+Boundary scope is not validator output acceptance.
+
+Boundary scope is not receipt evidence acceptance.
+
+Boundary scope is not runtime implementation procedure.
+
+Boundary scope is not package loading authority.
+
+Boundary scope is not execution authority.
+
+Boundary scope is not source merge authority.
+
+## Current Phase Pointer Boundary
+
+The current phase pointer remains:
+
+```text
+CURRENT_PHASE=23
+```
+
+This boundary does not modify:
+
+```text
+docs/roadmap/CURRENT_PHASE
+```
+
+This boundary does not change the active phase pointer.
+
+`CURRENT_PHASE=23` does not authorize post-sync concrete assignment,
+membership assignment, accepted-evidence set membership, accepted
+evidence, evidence item acceptance, validator output acceptance, receipt
+evidence acceptance, runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package loading, package execution, capability
+issuance, registry publication, trust assignment, deployment,
+distribution, source acceptance, source merge, kernel ABI expansion,
+syscall expansion, workflow-threshold changes, baseline changes,
+dependency changes, or Ring0 authority.
+
+## Post-Sync Concrete Assignment Record Input
+
+This boundary consumes the clean-fixed Phase-23 Concrete
+Accepted-Evidence Set Membership Assignment Post-Sync Concrete
+Assignment Record as its exact governance prerequisite.
+
+The post-sync concrete assignment record remains bound to:
+
+```text
+af894b8c0b49bc84d4671b98ce25a10e9467a1dc
+```
+
+The post-sync concrete assignment record recorded only a bounded
+post-sync concrete assignment record boundary.
+
+This boundary does not reinterpret the post-sync concrete assignment
+record as membership assignment, accepted-evidence set membership,
+accepted evidence, evidence item acceptance, validator output
+acceptance, receipt evidence acceptance, runtime implementation
+procedure, execution authority, package loading authority, source
+acceptance, source merge authority, capability issuance, registry
+publication, trust assignment, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold change, baseline
+change, dependency change, or Ring0 authority.
+
+Any post-sync concrete assignment record conflict fails closed.
+
+## Relationship To Membership
+
+This boundary accepts only a bounded governance boundary for post-sync
+concrete assignment evaluation.
+
+This boundary does not assign accepted-evidence set membership.
+
+This boundary does not create accepted-evidence set membership.
+
+This boundary does not define assignment membership.
+
+This boundary does not define accepted-evidence set membership.
+
+This boundary does not make membership assignment inevitable.
+
+This boundary does not make accepted-evidence set membership inevitable.
+
+Any attempt to treat this boundary as membership assignment or
+accepted-evidence set membership fails closed.
+
+## Relationship To Accepted Evidence And Evidence Item Acceptance
+
+Post-sync concrete assignment remains separate from accepted evidence
+unless a separate reviewed decision or record explicitly grants that
+narrower authority.
+
+This boundary does not create accepted evidence.
+
+This boundary does not identify accepted evidence.
+
+This boundary does not accept any evidence item.
+
+This boundary does not define accepted-evidence membership.
+
+This boundary does not define accepted-evidence set membership.
+
+This boundary does not make accepted evidence inevitable.
+
+Any attempt to treat this boundary as accepted evidence or evidence item
+acceptance fails closed.
+
+## Relationship To Validator Output And Receipt Evidence
+
+This boundary does not convert validator output into accepted evidence.
+
+This boundary does not convert receipt evidence into accepted evidence.
+
+This boundary does not accept validator output.
+
+This boundary does not accept receipt evidence.
+
+This boundary does not grant accepted-evidence membership over validator
+output, receipt evidence, package review output, source review output,
+historical PASS results, clean-fixed claims, or non-clean attempt
+claims.
+
+Any validator-output or receipt-evidence boundary conflict fails closed.
+
+## Relationship To Phase-19 Runtime Authority
+
+This boundary remains subordinate to Phase-19 runtime authority records.
+
+This boundary must not broaden, replace, supersede, weaken, or
+reinterpret Phase-19 runtime authority records.
+
+This boundary must not use post-sync concrete assignment boundary status
+to infer runtime authority.
+
+This boundary must not use membership assignment, accepted-evidence set
+membership, accepted-evidence authority, accepted evidence,
+validator-output planning, receipt-evidence planning, exact-SHA evidence
+expectations, or `CURRENT_PHASE=23` to infer runtime authority.
+
+Any Phase-23 post-sync concrete assignment reading that conflicts with
+Phase-19 runtime authority records fails closed.
+
+## Not Authorized By This Boundary
+
+This boundary does not authorize:
+
+1. Accepted-evidence set membership assignment.
+2. Membership assignment.
+3. Accepted-evidence set membership.
+4. Accepted-evidence set creation.
+5. Accepted evidence.
+6. Evidence item acceptance.
+7. Validator output acceptance.
+8. Receipt evidence acceptance.
+9. Runtime implementation procedure.
+10. Source modification.
+11. Source acceptance.
+12. Source merge.
+13. Code implementation.
+14. Code execution.
+15. Process start.
+16. Runtime state creation.
+17. Package installation.
+18. Package loading.
+19. Package execution.
+20. Module loading.
+21. Workspace runtime or real mounts.
+22. Plugin loading or plugin instantiation.
+23. Capability token minting.
+24. Capability issuance.
+25. Registry publication.
+26. Trust assignment.
+27. Distribution execution.
+28. Deployment.
+29. Semantic CLI authority.
+30. AI Runtime authority.
+31. Agent authority.
+32. Syscall expansion.
+33. Kernel ABI expansion.
+34. Ring0 policy movement.
+35. Workflow-threshold changes.
+36. Baseline changes.
+37. Dependency changes.
+38. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this boundary is published, the publication may change only this file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT.md
+```
+
+The publication must not change:
+
+1. `docs/roadmap/CURRENT_PHASE`.
+2. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_RECORD.md`.
+3. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md`.
+4. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_CANDIDATE.md`.
+5. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md`.
+6. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md`.
+7. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`.
+8. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`.
+9. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md`.
+10. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`.
+11. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`.
+12. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+13. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`.
+14. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+15. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+16. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`.
+17. CI workflows.
+18. Baselines.
+19. Dependencies.
+20. Runtime source or kernel source.
+21. Syscalls or kernel ABI.
+22. Package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution paths.
+23. `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md`.
+
+Any changed-file expansion beyond this boundary requires separate review
+and fails this boundary scope.
+
+## Post-Merge Exact-Main Evidence Rule
+
+If this boundary is later published, the boundary publication subject
+must receive its own post-merge exact-main verification:
+
+1. `ci-freeze` PASS for the exact boundary publication SHA.
+2. Dev Loop Validation PASS for the exact boundary publication SHA.
+3. AykenOS Dev Loop CI PASS for the exact boundary publication SHA.
+4. smoke PASS.
+5. contract PASS.
+6. full PASS.
+7. isolation PASS.
+8. performance PASS.
+9. Exact changed-file list confirmation.
+10. No `docs/roadmap/CURRENT_PHASE` change.
+11. No `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_RECORD.md`
+    change.
+12. No `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md`
+    change.
+13. No membership assignment, accepted-evidence set membership, accepted
+    evidence, evidence item acceptance, validator output acceptance, or
+    receipt evidence acceptance.
+14. No CI workflow change.
+15. No baseline change.
+16. No dependency change.
+17. No runtime source or kernel source change.
+18. No syscall or kernel ABI change.
+19. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution change.
+
+Until that exact-main post-merge verification exists, this boundary must
+not be recorded as clean-fixed.
+
+Historical PASS results may be cited as context only.
+
+Failed attempts may be cited as transparent non-clean context only.
+
+They cannot be inherited as membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime authority, package loading authority, package execution
+authority, source merge authority, capability authority, registry
+authority, trust authority, kernel ABI authority, syscall authority,
+workflow-threshold authority, baseline authority, dependency authority,
+or Ring0 authority.
+
+## Later Membership Assignment Dependency
+
+This boundary is a prerequisite input for a possible later bounded
+membership assignment path.
+
+A later membership assignment decision or record, if ever proposed, must
+define:
+
+1. Exact membership assignment subject.
+2. Exact Phase-23 post-sync concrete assignment prerequisite.
+3. Exact changed-file boundary.
+4. Exact evidence item reference proposed for membership assignment, if
+   any, without evidence item acceptance unless separately reviewed.
+5. Exact accepted-evidence set membership proposed for assignment, if
+   any, without accepted-evidence set membership status unless separately
+   reviewed.
+6. Exact membership assignment grant, denial, or separate membership
+   assignment scope.
+7. Exact accepted-evidence set membership denial or separate membership
+   scope.
+8. Exact accepted-evidence denial or separate accepted-evidence scope.
+9. Exact evidence item acceptance denial or separate evidence item
+   acceptance scope.
+10. Exact validator-output acceptance denial or separate
+    validator-output acceptance scope.
+11. Exact receipt-evidence acceptance denial or separate receipt-evidence
+    acceptance scope.
+12. Exact runtime implementation procedure denial.
+13. Exact package loading and package execution denials.
+14. Exact source acceptance and source merge denials.
+15. Exact capability, registry, trust, deployment, distribution, kernel
+    ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+    denials.
+16. Exact post-merge verification requirements.
+
+Until such a later reviewed membership assignment record is published,
+no membership assignment exists from this boundary.
+
+Until such a later reviewed accepted-evidence set membership record is
+published, no accepted-evidence set membership exists from this
+boundary.
+
+Until such a later reviewed accepted-evidence record is published, no
+accepted evidence exists from this boundary.
+
+Until such a later reviewed evidence item acceptance record is published,
+no evidence item acceptance exists from this boundary.
+
+Until such a later reviewed validator-output acceptance record is
+published, no validator output acceptance exists from this boundary.
+
+Until such a later reviewed receipt-evidence acceptance record is
+published, no receipt evidence acceptance exists from this boundary.
+
+## Excluded Local Draft
+
+This boundary does not consume:
+
+```text
+PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md
+```
+
+If that file exists locally as an untracked file, it remains:
+
+```text
+untracked
+PR-disjoint
+not candidate input
+not decision input
+not record input
+not evidence input
+not membership assignment
+not accepted-evidence set membership
+not accepted evidence
+not evidence item acceptance
+not validator output
+not receipt evidence
+not source authority
+not package acceptance
+not runtime authority
+```
+
+It must not be staged, committed, or included in any Phase-23 post-sync
+concrete assignment PR unless a separate reviewed scope explicitly
+authorizes that file.
+
+## Governance Boundary Invariants
+
+Every later RFC must preserve these Phase-23 post-sync concrete
+assignment invariants:
+
+1. This boundary is bounded post-sync concrete assignment boundary only.
+2. This boundary is not membership assignment.
+3. This boundary is not accepted-evidence set membership.
+4. This boundary is not an accepted-evidence set.
+5. This boundary is not accepted evidence.
+6. This boundary is not evidence item acceptance.
+7. This boundary is not validator output acceptance.
+8. This boundary is not receipt evidence acceptance.
+9. Concrete assignment boundary is not membership assignment.
+10. Membership assignment is not accepted-evidence set membership unless
+    separately reviewed.
+11. Accepted-evidence set membership is not accepted evidence unless
+    separately reviewed.
+12. Accepted evidence is not evidence item acceptance unless separately
+    reviewed.
+13. This boundary is not runtime implementation procedure.
+14. This boundary is not source modification.
+15. This boundary is not code implementation.
+16. This boundary is not code execution.
+17. This boundary is not process start.
+18. This boundary is not runtime state creation.
+19. This boundary is not package installation.
+20. This boundary is not package loading.
+21. This boundary is not package execution.
+22. This boundary is not capability issuance.
+23. This boundary is not registry publication.
+24. This boundary is not trust assignment.
+25. This boundary is not deployment.
+26. This boundary is not distribution authority.
+27. This boundary is not source acceptance.
+28. This boundary is not source merge authority.
+29. This boundary does not modify `docs/roadmap/CURRENT_PHASE`.
+30. This boundary does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_RECORD.md`.
+31. This boundary does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md`.
+32. This boundary does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_CANDIDATE.md`.
+33. `CURRENT_PHASE=23` is not post-sync concrete assignment.
+34. `CURRENT_PHASE=23` is not membership assignment.
+35. `CURRENT_PHASE=23` is not accepted-evidence set membership.
+36. `CURRENT_PHASE=23` is not accepted evidence.
+37. `CURRENT_PHASE=23` is not evidence item acceptance.
+38. `CURRENT_PHASE=23` is not validator output acceptance.
+39. `CURRENT_PHASE=23` is not receipt evidence acceptance.
+40. `CURRENT_PHASE=23` is not runtime implementation procedure.
+41. `CURRENT_PHASE=23` is not source modification.
+42. `CURRENT_PHASE=23` is not execution authority.
+43. `CURRENT_PHASE=23` is not package loading.
+44. `CURRENT_PHASE=23` is not source merge authority.
+45. This boundary does not broaden Phase-19 runtime authority.
+46. This boundary does not reopen Phase-20.
+47. This boundary does not reopen Phase-21.
+48. This boundary does not reopen Phase-22.
+49. This boundary does not expand kernel ABI or syscalls.
+50. This boundary does not change workflow thresholds, baselines, or
+    dependencies.
+51. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-23 concrete accepted-evidence set membership
+assignment post-sync concrete assignment boundary
+**Architecture status:** Local draft post-sync concrete assignment
+boundary / pending separate reviewed publication
+**Authority notice:** If separately reviewed and published, this
+boundary grants only the bounded post-sync concrete assignment boundary
+defined in this record. It grants no membership assignment,
+accepted-evidence set membership, accepted evidence status, evidence
+item acceptance authority, validator output acceptance authority,
+receipt evidence acceptance authority, runtime implementation procedure
+authority, source modification authority, code implementation authority,
+code execution authority, process start authority, general runtime
+authority, unbounded execution authority, runtime state authority,
+package installation authority, package loading authority, package
+execution authority, source merge authority, trust authority, registry
+authority, distribution authority, publication authority, capability
+issuance authority, deployment authority, module authority, plugin
+authority, Semantic CLI authority, AI Runtime authority, agent authority,
+kernel ABI authority, syscall authority, workflow-threshold authority,
+baseline authority, dependency authority, or Ring0 authority.
+
+## Conclusion
+
+This Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment boundary is based on the clean-fixed
+Phase-23 Concrete Accepted-Evidence Set Membership Assignment Post-Sync
+Concrete Assignment Record publication subject:
+
+```text
+af894b8c0b49bc84d4671b98ce25a10e9467a1dc
+```
+
+It accepts only the bounded post-sync concrete assignment boundary.
+
+It does not assign membership.
+
+It does not create accepted-evidence set membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize membership assignment, accepted-evidence set
+membership, accepted evidence, evidence item acceptance, validator
+output acceptance, receipt evidence acceptance, runtime implementation
+procedure, source modification, code implementation, code execution,
+process start, runtime state creation, package installation, package
+loading, package execution, capability issuance, registry publication,
+trust assignment, deployment, distribution, source acceptance, source
+merge, kernel ABI expansion, syscall expansion, workflow-threshold
+changes, baseline changes, dependency changes, or Ring0 authority.
+
+Any later Phase-23 membership-assignment, accepted-evidence set
+membership, accepted-evidence, evidence-item, validator-output,
+receipt-evidence, package-review, source-review,
+runtime-implementation-procedure, or non-authorization boundary record
+requires its own exact-SHA evidence, changed-file scope,
+non-authorization boundary, and reviewed decision path.


### PR DESCRIPTION
This PR changes only PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT.md and records only a governance-only bounded post-sync concrete assignment boundary after the clean-fixed post-sync concrete assignment record boundary at af894b8c0b49bc84d4671b98ce25a10e9467a1dc. It does not assign membership, create accepted-evidence set membership, create accepted evidence, accept any evidence item, accept validator output, accept receipt evidence, or authorize runtime/source/package/source-merge/capability/registry/trust/deployment/distribution/kernel ABI/syscall/workflow-threshold/baseline/dependency/Ring0 authority.