### PR TITLE
Phase-23 concrete accepted-evidence set membership assignment post-sync membership assignment candidate

### DIFF
--- a/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md
+++ b/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md
@@ -1,0 +1,967 @@
+# Phase-23 Concrete Accepted-Evidence Set Membership Assignment Post-Sync Membership Assignment Candidate
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY_CLEAN_RECOVERY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_FIRST_BOUNDED_IMPLEMENTATION.md`,
+`PHASE22_CLOSURE_DECISION.md`,
+`PHASE23_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE23_POINTER_TRANSITION_DECISION.md`,
+`docs/roadmap/CURRENT_PHASE`,
+`PHASE23_GOVERNANCE_OVERVIEW.md`,
+`PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`,
+`PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`,
+`PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_RECORD.md`,
+and
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT.md`.
+In case of conflict, those documents prevail unless this document is the
+narrower Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment candidate for the exact governance-only
+bounded post-sync membership-assignment-candidate boundary identified
+below.
+
+**Status:** PHASE-23 CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT
+POST-SYNC MEMBERSHIP ASSIGNMENT CANDIDATE / LOCAL DRAFT /
+GOVERNANCE-ONLY POST-SYNC MEMBERSHIP ASSIGNMENT CANDIDATE ONLY / BOUNDED
+POST-SYNC MEMBERSHIP ASSIGNMENT CANDIDATE BOUNDARY ONLY / NO MEMBERSHIP
+ASSIGNMENT / NO ACCEPTED-EVIDENCE SET MEMBERSHIP / NO ACCEPTED-EVIDENCE
+SET / NO ACCEPTED EVIDENCE / NO EVIDENCE ITEM ACCEPTANCE / NO VALIDATOR
+OUTPUT ACCEPTANCE / NO RECEIPT EVIDENCE ACCEPTANCE / NO RUNTIME
+IMPLEMENTATION PROCEDURE / NO SOURCE MODIFICATION / NO CODE
+IMPLEMENTATION / NO CODE EXECUTION / NO PROCESS START / NO RUNTIME STATE
+CREATION / NO PACKAGE INSTALLATION / NO PACKAGE LOADING / NO PACKAGE
+EXECUTION / NO DEPLOYMENT / NO CAPABILITY ISSUANCE / NO TRUST
+ASSIGNMENT / NO REGISTRY PUBLICATION / NO DISTRIBUTION AUTHORITY / NO
+SOURCE ACCEPTANCE / NO SOURCE MERGE AUTHORITY / NO KERNEL ABI EXPANSION /
+NO SYSCALL EXPANSION / NO WORKFLOW-THRESHOLD CHANGE / NO BASELINE CHANGE
+/ NO DEPENDENCY CHANGE / NO RING0 AUTHORITY
+**Candidate date:** 2026-07-27
+**Candidate id:**
+`ayken.phase23.concrete_accepted_evidence_set_membership_assignment_post_sync_membership_assignment_candidate.v1`
+**Candidate drafting base main SHA:**
+`3af79c98e8af6d19cead148ccb276cf0d19cdf36`
+**Candidate publication subject:** pending separate reviewed publication
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment publication subject:**
+`3af79c98e8af6d19cead148ccb276cf0d19cdf36`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment PR:** PR #296
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment exact-main ci-freeze run:** `30223245346`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment exact-main ci-freeze attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment exact-main ci-freeze job:**
+`freeze / 89849209655`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment exact-main ci-freeze result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment exact-main Dev Loop Validation run:**
+`30223245365`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment exact-main Dev Loop Validation attempt:**
+attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment exact-main Dev Loop Validation job:**
+`devloop / 89849209424`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment exact-main Dev Loop Validation result:**
+PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment exact-main Dev Loop CI run:** `30223245337`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment exact-main Dev Loop CI attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment exact-main Dev Loop CI result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment exact-main smoke job:** `smoke / 89849209553`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment exact-main smoke result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment exact-main contract job:**
+`contract / 89849295560`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment exact-main contract result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment exact-main full job:** `full / 89849506815`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment exact-main full result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment exact-main isolation job:**
+`isolation / 89849770643`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment exact-main isolation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment exact-main performance job:**
+`performance / 89849961623`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment exact-main performance result:** PASS
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment publication subject:**
+`3af79c98e8af6d19cead148ccb276cf0d19cdf36`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record publication subject:**
+`af894b8c0b49bc84d4671b98ce25a10e9467a1dc`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision publication subject:**
+`c97fecb9eaee548f67e9d7c6b1a819b320ac5304`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate publication subject:**
+`feb44834568a70bfe103f0fcbfaf37e2a8035619`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision publication subject:**
+`cf7cf2ca6f59c9e8e03a13171f9b3efee889fdb0`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate publication subject:**
+`004a886426b30a55cc8176941ac1553004e31f76`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate publication subject:**
+`39d7fa841e731cfbef8368288e19b6d404aa699c`
+**Current phase pointer:** `CURRENT_PHASE=23`
+**Candidate theme:** Governance-only bounded post-sync membership
+assignment candidate boundary after the clean-fixed post-sync concrete
+assignment boundary at
+`3af79c98e8af6d19cead148ccb276cf0d19cdf36`.
+**Authority boundary:** Post-sync membership assignment candidate
+boundary only; not membership assignment, not accepted-evidence set
+membership, not an accepted-evidence set, not accepted evidence, not
+evidence item acceptance, not validator output acceptance, not receipt
+evidence acceptance, not runtime implementation procedure, not source
+modification, not code implementation, not code execution, not process
+start, not runtime state creation, not general runtime authority, not
+unbounded execution authority, not package authority, not package
+installation, not package loading, not package execution, not source
+acceptance, not source merge authority, not source repository authority,
+not module loading, not workspace runtime, not plugin loading, not
+capability token minting, not capability issuance, not trust assignment,
+not trust issuer authority, not registry authority, not registry
+publication, not publication authority, not deployment authority, not
+distribution authority, not distribution execution, not Semantic CLI
+authority, not AI Runtime authority, not agent authority, not syscall
+expansion, not kernel ABI expansion, not workflow-threshold, baseline,
+dependency, or Ring0 authority.
+
+## Purpose
+
+This document opens only a bounded post-sync membership assignment
+candidate boundary after the clean-fixed Phase-23 concrete
+accepted-evidence set membership assignment post-sync concrete
+assignment boundary at:
+
+```text
+3af79c98e8af6d19cead148ccb276cf0d19cdf36
+```
+
+It evaluates only:
+
+```text
+May a bounded post-sync membership assignment candidate boundary be
+opened after the clean-fixed post-sync concrete assignment boundary at
+3af79c98e8af6d19cead148ccb276cf0d19cdf36 without creating a membership
+assignment, creating accepted-evidence set membership, creating accepted
+evidence, or accepting any evidence item?
+```
+
+It opens only the bounded post-sync membership assignment candidate
+boundary as a governance candidate boundary.
+
+This candidate is not membership assignment.
+
+This candidate does not create membership assignment.
+
+This candidate does not create accepted-evidence set membership.
+
+This candidate does not create accepted evidence.
+
+This candidate does not accept any evidence item.
+
+This candidate does not accept validator output.
+
+This candidate does not accept receipt evidence.
+
+It does not convert CI PASS results, receipts, validator output, package
+review output, source review output, historical results, clean-fixed
+claims, post-sync concrete-assignment claims, or membership-assignment
+candidate claims into membership assignment, accepted-evidence set
+membership, accepted evidence, evidence item acceptance, validator output
+acceptance, or receipt evidence acceptance.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, source acceptance, source merge, registry publication, trust
+assignment, capability issuance, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+It does not answer:
+
+```text
+Which membership is assigned?
+Which accepted-evidence set membership exists?
+Which evidence is accepted?
+Which evidence item is accepted?
+How is validator output accepted?
+How is receipt evidence accepted?
+How is runtime implementation procedure defined?
+How is source modified?
+How is code implemented or executed?
+How is a process started?
+How is runtime state created?
+How is a package installed, loaded, executed, deployed, or distributed?
+How is source accepted or merged?
+How is a capability issued?
+How is trust assigned?
+How is a registry entry published?
+How is kernel ABI or syscall surface expanded?
+How are workflow thresholds, baselines, or dependencies changed?
+```
+
+Those questions require later reviewed decision or record paths, if ever
+authorized.
+
+## Exact Subject
+
+This candidate draft is based on exact main SHA:
+
+```text
+3af79c98e8af6d19cead148ccb276cf0d19cdf36
+```
+
+That subject is the squash merge of PR #296:
+
+```text
+Phase-23 concrete accepted-evidence set membership assignment post-sync concrete assignment
+```
+
+PR #296 changed only:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT.md
+```
+
+PR #296 produced post-merge exact-main verification:
+
+| Evidence | Run / job | Result |
+|---|---|---|
+| `ci-freeze` | run `30223245346`, attempt 1, job `freeze / 89849209655` | PASS |
+| Dev Loop Validation | run `30223245365`, attempt 1, job `devloop / 89849209424` | PASS |
+| AykenOS Dev Loop CI | run `30223245337`, attempt 1 | PASS |
+| smoke | job `89849209553` | PASS |
+| contract | job `89849295560` | PASS |
+| full | job `89849506815` | PASS |
+| isolation | job `89849770643` | PASS |
+| performance | job `89849961623` | PASS |
+
+The Phase-23 Concrete Accepted-Evidence Set Membership Assignment
+Post-Sync Concrete Assignment boundary remains bound to:
+
+```text
+3af79c98e8af6d19cead148ccb276cf0d19cdf36
+```
+
+That boundary opened only a bounded post-sync concrete assignment
+boundary. It did not create membership assignment, create
+accepted-evidence set membership, create accepted evidence, accept
+evidence items, accept validator output, accept receipt evidence, or
+grant runtime, source, package, source-merge, capability, registry,
+trust, deployment, distribution, kernel ABI, syscall, workflow-threshold,
+baseline, dependency, or Ring0 authority.
+
+This candidate consumes that exact subject as governance input only. It
+does not replace, broaden, reinterpret, or supersede the post-sync
+concrete assignment boundary or any earlier Phase-23 governance
+boundary.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped subject readings fail closed.
+
+## Core Rule
+
+```text
+post-sync membership assignment candidate == bounded post-sync membership assignment candidate boundary only
+post-sync membership assignment candidate != membership assignment
+post-sync membership assignment candidate != accepted-evidence set membership
+post-sync membership assignment candidate != accepted-evidence set
+post-sync membership assignment candidate != accepted evidence
+post-sync membership assignment candidate != evidence item acceptance
+post-sync membership assignment candidate != validator output acceptance
+post-sync membership assignment candidate != receipt evidence acceptance
+post-sync membership assignment candidate != runtime implementation procedure
+post-sync membership assignment candidate != source modification
+post-sync membership assignment candidate != package loading
+post-sync membership assignment candidate != package execution
+post-sync membership assignment candidate != source merge authority
+post-sync concrete assignment clean-fixed != post-sync membership assignment candidate
+post-sync concrete assignment != membership assignment candidate unless separately reviewed
+post-sync concrete assignment boundary != membership assignment
+membership assignment candidate != membership assignment unless separately reviewed
+membership assignment != accepted-evidence set membership unless separately reviewed
+accepted-evidence set membership != accepted evidence unless separately reviewed
+accepted evidence != evidence item acceptance unless separately reviewed
+accepted evidence != validator output unless separately reviewed
+accepted evidence != receipt evidence unless separately reviewed
+validator output != accepted evidence
+receipt evidence != accepted evidence
+receipt evidence != validator output
+CI PASS != post-sync membership assignment candidate
+CI PASS != membership assignment
+CI PASS != accepted-evidence set membership
+CI PASS != accepted evidence
+ci-freeze PASS != post-sync membership assignment candidate
+ci-freeze PASS != membership assignment
+Dev Loop PASS != post-sync membership assignment candidate
+AykenOS Dev Loop CI PASS != post-sync membership assignment candidate
+post-merge exact-main verification != post-sync membership assignment candidate
+post-merge exact-main verification != membership assignment
+clean-fixed != post-sync membership assignment candidate
+clean-fixed != membership assignment
+publication-status sync != membership assignment
+CURRENT_PHASE=23 != post-sync membership assignment candidate
+CURRENT_PHASE=23 != membership assignment
+CURRENT_PHASE=23 != accepted-evidence set membership
+CURRENT_PHASE=23 != accepted evidence
+CURRENT_PHASE=23 != evidence item acceptance
+CURRENT_PHASE=23 != validator output acceptance
+CURRENT_PHASE=23 != receipt evidence acceptance
+CURRENT_PHASE=23 != runtime implementation procedure
+CURRENT_PHASE=23 != source modification
+CURRENT_PHASE=23 != execution authority
+CURRENT_PHASE=23 != package loading
+CURRENT_PHASE=23 != source merge authority
+CURRENT_PHASE=23 != kernel ABI expansion
+CURRENT_PHASE=23 != syscall expansion
+historical PASS != inherited evidence
+previous PR evidence != later PR evidence
+```
+
+The safe default remains no membership assignment, no accepted-evidence
+set membership, no accepted evidence, no evidence item acceptance, no
+validator output acceptance, no receipt evidence acceptance, no runtime
+behavior, no implementation procedure, no source modification, no code
+execution, no runtime state, and no package, capability, registry, trust,
+distribution, deployment, source acceptance, source merge, kernel ABI,
+syscall, workflow-threshold, baseline, dependency, or Ring0 authority
+unless a later reviewed Phase-23 decision or record grants a specific
+bounded authority with its own exact-SHA evidence.
+
+Unknown authority readings fail closed.
+
+## Post-Sync Membership Assignment Candidate Boundary
+
+The Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment candidate is opened only as:
+
+```text
+bounded post-sync membership assignment candidate boundary
+```
+
+This candidate boundary may be used only to evaluate whether a later
+separate reviewed membership assignment decision or membership
+assignment record path may be proposed, without creating membership
+assignment, accepted-evidence set membership, accepted evidence,
+evidence item acceptance, validator output acceptance, receipt evidence
+acceptance, or related authority.
+
+This candidate does not create membership assignment.
+
+This candidate does not assign accepted-evidence set membership.
+
+This candidate does not create accepted-evidence set membership.
+
+This candidate does not create accepted evidence.
+
+This candidate does not accept any evidence item.
+
+This candidate does not accept validator output.
+
+This candidate does not accept receipt evidence.
+
+This candidate does not authorize package loading.
+
+This candidate does not authorize source acceptance or source merge.
+
+This candidate does not authorize runtime implementation procedure, code
+execution, process start, runtime state creation, capability issuance,
+registry publication, trust assignment, deployment, distribution, kernel
+ABI expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Any later membership assignment, accepted-evidence set membership,
+accepted evidence, evidence item acceptance, validator output
+acceptance, or receipt evidence acceptance requires a separate reviewed
+decision or record path with its own exact subject, changed-file scope,
+non-authorization boundary, and post-merge exact-main verification.
+
+## Candidate Scope
+
+This candidate scope is limited to:
+
+1. Opening the Phase-23 post-sync membership assignment candidate
+   boundary only as a bounded governance candidate boundary.
+2. Binding this candidate to PR #296 as the clean-fixed post-sync
+   concrete assignment boundary input.
+3. Preserving the distinction between membership assignment candidate
+   and membership assignment.
+4. Preserving the distinction between membership assignment and
+   accepted-evidence set membership.
+5. Preserving the distinction between accepted-evidence set membership
+   and accepted evidence.
+6. Preserving the distinction between accepted evidence and evidence
+   item acceptance.
+7. Preserving separation from validator output acceptance and receipt
+   evidence acceptance.
+8. Establishing post-merge exact-main verification expectations for this
+   candidate record.
+
+Candidate scope is governance text only.
+
+Candidate scope is bounded post-sync membership assignment candidate
+boundary only.
+
+Candidate scope is not membership assignment.
+
+Candidate scope is not accepted-evidence set membership.
+
+Candidate scope is not accepted evidence.
+
+Candidate scope is not evidence item acceptance.
+
+Candidate scope is not validator output acceptance.
+
+Candidate scope is not receipt evidence acceptance.
+
+Candidate scope is not runtime implementation procedure.
+
+Candidate scope is not package loading authority.
+
+Candidate scope is not execution authority.
+
+Candidate scope is not source merge authority.
+
+## Current Phase Pointer Boundary
+
+The current phase pointer remains:
+
+```text
+CURRENT_PHASE=23
+```
+
+This candidate does not modify:
+
+```text
+docs/roadmap/CURRENT_PHASE
+```
+
+This candidate does not change the active phase pointer.
+
+`CURRENT_PHASE=23` does not authorize membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime implementation procedure, source modification, code
+implementation, code execution, process start, runtime state creation,
+package loading, package execution, capability issuance, registry
+publication, trust assignment, deployment, distribution, source
+acceptance, source merge, kernel ABI expansion, syscall expansion,
+workflow-threshold changes, baseline changes, dependency changes, or
+Ring0 authority.
+
+## Post-Sync Concrete Assignment Boundary Input
+
+This candidate consumes the clean-fixed Phase-23 Concrete
+Accepted-Evidence Set Membership Assignment Post-Sync Concrete
+Assignment boundary as its exact governance prerequisite.
+
+The post-sync concrete assignment boundary remains bound to:
+
+```text
+3af79c98e8af6d19cead148ccb276cf0d19cdf36
+```
+
+The post-sync concrete assignment boundary recorded only a bounded
+post-sync concrete assignment boundary.
+
+This candidate does not reinterpret the post-sync concrete assignment
+boundary as membership assignment, accepted-evidence set membership,
+accepted evidence, evidence item acceptance, validator output
+acceptance, receipt evidence acceptance, runtime implementation
+procedure, execution authority, package loading authority, source
+acceptance, source merge authority, capability issuance, registry
+publication, trust assignment, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold change, baseline
+change, dependency change, or Ring0 authority.
+
+Any post-sync concrete assignment boundary conflict fails closed.
+
+## Relationship To Membership Assignment And Membership
+
+This candidate opens only a bounded governance candidate boundary for
+post-sync membership assignment evaluation.
+
+This candidate does not create membership assignment.
+
+This candidate does not assign accepted-evidence set membership.
+
+This candidate does not create accepted-evidence set membership.
+
+This candidate does not define assignment membership.
+
+This candidate does not define accepted-evidence set membership.
+
+This candidate does not make membership assignment inevitable.
+
+This candidate does not make accepted-evidence set membership
+inevitable.
+
+Any attempt to treat this candidate as membership assignment or
+accepted-evidence set membership fails closed.
+
+## Relationship To Accepted Evidence And Evidence Item Acceptance
+
+Membership assignment remains separate from accepted-evidence set
+membership unless a separate reviewed decision or record explicitly
+grants that narrower authority.
+
+Accepted-evidence set membership remains separate from accepted evidence
+unless a separate reviewed decision or record explicitly grants that
+narrower authority.
+
+This candidate does not create accepted evidence.
+
+This candidate does not identify accepted evidence.
+
+This candidate does not accept any evidence item.
+
+This candidate does not define accepted-evidence membership.
+
+This candidate does not define accepted-evidence set membership.
+
+This candidate does not make accepted evidence inevitable.
+
+Any attempt to treat this candidate as accepted evidence or evidence item
+acceptance fails closed.
+
+## Relationship To Validator Output And Receipt Evidence
+
+This candidate does not convert validator output into accepted evidence.
+
+This candidate does not convert receipt evidence into accepted evidence.
+
+This candidate does not accept validator output.
+
+This candidate does not accept receipt evidence.
+
+This candidate does not grant accepted-evidence membership over
+validator output, receipt evidence, package review output, source review
+output, historical PASS results, or clean-fixed claims.
+
+Any validator-output or receipt-evidence boundary conflict fails closed.
+
+## Relationship To Phase-19 Runtime Authority
+
+This candidate remains subordinate to Phase-19 runtime authority records.
+
+This candidate must not broaden, replace, supersede, weaken, or
+reinterpret Phase-19 runtime authority records.
+
+This candidate must not use post-sync membership assignment candidate
+status to infer runtime authority.
+
+This candidate must not use membership assignment, accepted-evidence set
+membership, accepted-evidence authority, accepted evidence,
+validator-output planning, receipt-evidence planning, exact-SHA evidence
+expectations, or `CURRENT_PHASE=23` to infer runtime authority.
+
+Any Phase-23 post-sync membership assignment candidate reading that
+conflicts with Phase-19 runtime authority records fails closed.
+
+## Not Authorized By This Candidate
+
+This candidate does not authorize:
+
+1. Membership assignment.
+2. Accepted-evidence set membership.
+3. Accepted-evidence set creation.
+4. Accepted evidence.
+5. Evidence item acceptance.
+6. Validator output acceptance.
+7. Receipt evidence acceptance.
+8. Runtime implementation procedure.
+9. Source modification.
+10. Source acceptance.
+11. Source merge.
+12. Code implementation.
+13. Code execution.
+14. Process start.
+15. Runtime state creation.
+16. Package installation.
+17. Package loading.
+18. Package execution.
+19. Module loading.
+20. Workspace runtime or real mounts.
+21. Plugin loading or plugin instantiation.
+22. Capability token minting.
+23. Capability issuance.
+24. Registry publication.
+25. Trust assignment.
+26. Distribution execution.
+27. Deployment.
+28. Semantic CLI authority.
+29. AI Runtime authority.
+30. Agent authority.
+31. Syscall expansion.
+32. Kernel ABI expansion.
+33. Ring0 policy movement.
+34. Workflow-threshold changes.
+35. Baseline changes.
+36. Dependency changes.
+37. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this candidate is published, the publication may change only this
+file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md
+```
+
+The publication must not change:
+
+1. `docs/roadmap/CURRENT_PHASE`.
+2. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT.md`.
+3. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_RECORD.md`.
+4. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md`.
+5. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_CANDIDATE.md`.
+6. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md`.
+7. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md`.
+8. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`.
+9. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`.
+10. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md`.
+11. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`.
+12. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`.
+13. CI workflows.
+14. Baselines.
+15. Dependencies.
+16. Runtime source or kernel source.
+17. Syscalls or kernel ABI.
+18. Package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution paths.
+19. `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md`.
+
+Any changed-file expansion beyond this candidate requires separate
+review and fails this candidate scope.
+
+## Post-Merge Exact-Main Evidence Rule
+
+If this candidate is later published, the candidate publication subject
+must receive its own post-merge exact-main verification:
+
+1. `ci-freeze` PASS for the exact candidate publication SHA.
+2. Dev Loop Validation PASS for the exact candidate publication SHA.
+3. AykenOS Dev Loop CI PASS for the exact candidate publication SHA.
+4. smoke PASS.
+5. contract PASS.
+6. full PASS.
+7. isolation PASS.
+8. performance PASS.
+9. Exact changed-file list confirmation.
+10. No `docs/roadmap/CURRENT_PHASE` change.
+11. No `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT.md`
+    change.
+12. No membership assignment, accepted-evidence set membership, accepted
+    evidence, evidence item acceptance, validator output acceptance, or
+    receipt evidence acceptance.
+13. No CI workflow change.
+14. No baseline change.
+15. No dependency change.
+16. No runtime source or kernel source change.
+17. No syscall or kernel ABI change.
+18. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution change.
+
+Until that exact-main post-merge verification exists, this candidate
+must not be recorded as clean-fixed.
+
+Historical PASS results may be cited as context only.
+
+Failed attempts may be cited as transparent non-clean context only.
+
+They cannot be inherited as membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime authority, package loading authority, package execution
+authority, source merge authority, capability authority, registry
+authority, trust authority, kernel ABI authority, syscall authority,
+workflow-threshold authority, baseline authority, dependency authority,
+or Ring0 authority.
+
+## Later Membership Assignment Dependency
+
+This candidate is a prerequisite input for a possible later bounded
+membership assignment decision or record path.
+
+A later membership assignment decision or record, if ever proposed, must
+define:
+
+1. Exact membership assignment subject.
+2. Exact Phase-23 post-sync membership assignment candidate
+   prerequisite.
+3. Exact changed-file boundary.
+4. Exact evidence item reference proposed for membership assignment, if
+   any, without evidence item acceptance unless separately reviewed.
+5. Exact accepted-evidence set membership proposed for assignment, if
+   any, without accepted-evidence set membership status unless separately
+   reviewed.
+6. Exact membership assignment grant, denial, or separate membership
+   assignment scope.
+7. Exact accepted-evidence set membership denial or separate membership
+   scope.
+8. Exact accepted-evidence denial or separate accepted-evidence scope.
+9. Exact evidence item acceptance denial or separate evidence item
+   acceptance scope.
+10. Exact validator-output acceptance denial or separate
+    validator-output acceptance scope.
+11. Exact receipt-evidence acceptance denial or separate receipt-evidence
+    acceptance scope.
+12. Exact runtime implementation procedure denial.
+13. Exact package loading and package execution denials.
+14. Exact source acceptance and source merge denials.
+15. Exact capability, registry, trust, deployment, distribution, kernel
+    ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+    denials.
+16. Exact post-merge verification requirements.
+
+Until such a later reviewed membership assignment record is published,
+no membership assignment exists from this candidate.
+
+Until such a later reviewed accepted-evidence set membership record is
+published, no accepted-evidence set membership exists from this
+candidate.
+
+Until such a later reviewed accepted-evidence record is published, no
+accepted evidence exists from this candidate.
+
+Until such a later reviewed evidence item acceptance record is published,
+no evidence item acceptance exists from this candidate.
+
+Until such a later reviewed validator-output acceptance record is
+published, no validator output acceptance exists from this candidate.
+
+Until such a later reviewed receipt-evidence acceptance record is
+published, no receipt evidence acceptance exists from this candidate.
+
+## Excluded Local Draft
+
+This candidate does not consume:
+
+```text
+PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md
+```
+
+If that file exists locally as an untracked file, it remains:
+
+```text
+untracked
+PR-disjoint
+not candidate input
+not decision input
+not evidence input
+not membership assignment
+not accepted-evidence set membership
+not accepted evidence
+not evidence item acceptance
+not validator output
+not receipt evidence
+not source authority
+not package acceptance
+not runtime authority
+```
+
+It must not be staged, committed, or included in any Phase-23 post-sync
+membership assignment candidate PR unless a separate reviewed scope
+explicitly authorizes that file.
+
+## Governance Boundary Invariants
+
+Every later RFC must preserve these Phase-23 post-sync membership
+assignment candidate invariants:
+
+1. This candidate is bounded post-sync membership assignment candidate
+   boundary only.
+2. This candidate is not membership assignment.
+3. This candidate is not accepted-evidence set membership.
+4. This candidate is not an accepted-evidence set.
+5. This candidate is not accepted evidence.
+6. This candidate is not evidence item acceptance.
+7. This candidate is not validator output acceptance.
+8. This candidate is not receipt evidence acceptance.
+9. Membership assignment candidate is not membership assignment unless
+   separately reviewed.
+10. Membership assignment is not accepted-evidence set membership unless
+    separately reviewed.
+11. Accepted-evidence set membership is not accepted evidence unless
+    separately reviewed.
+12. Accepted evidence is not evidence item acceptance unless separately
+    reviewed.
+13. This candidate is not runtime implementation procedure.
+14. This candidate is not source modification.
+15. This candidate is not code implementation.
+16. This candidate is not code execution.
+17. This candidate is not process start.
+18. This candidate is not runtime state creation.
+19. This candidate is not package installation.
+20. This candidate is not package loading.
+21. This candidate is not package execution.
+22. This candidate is not capability issuance.
+23. This candidate is not registry publication.
+24. This candidate is not trust assignment.
+25. This candidate is not deployment.
+26. This candidate is not distribution authority.
+27. This candidate is not source acceptance.
+28. This candidate is not source merge authority.
+29. This candidate does not modify `docs/roadmap/CURRENT_PHASE`.
+30. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT.md`.
+31. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_RECORD.md`.
+32. This candidate does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md`.
+33. `CURRENT_PHASE=23` is not post-sync membership assignment candidate.
+34. `CURRENT_PHASE=23` is not membership assignment.
+35. `CURRENT_PHASE=23` is not accepted-evidence set membership.
+36. `CURRENT_PHASE=23` is not accepted evidence.
+37. `CURRENT_PHASE=23` is not evidence item acceptance.
+38. `CURRENT_PHASE=23` is not validator output acceptance.
+39. `CURRENT_PHASE=23` is not receipt evidence acceptance.
+40. `CURRENT_PHASE=23` is not runtime implementation procedure.
+41. `CURRENT_PHASE=23` is not source modification.
+42. `CURRENT_PHASE=23` is not execution authority.
+43. `CURRENT_PHASE=23` is not package loading.
+44. `CURRENT_PHASE=23` is not source merge authority.
+45. This candidate does not broaden Phase-19 runtime authority.
+46. This candidate does not reopen Phase-20.
+47. This candidate does not reopen Phase-21.
+48. This candidate does not reopen Phase-22.
+49. This candidate does not expand kernel ABI or syscalls.
+50. This candidate does not change workflow thresholds, baselines, or
+    dependencies.
+51. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-23 concrete accepted-evidence set membership
+assignment post-sync membership assignment candidate
+**Architecture status:** Local draft post-sync membership assignment
+candidate / pending separate reviewed publication
+**Authority notice:** This signature identifies the architectural
+authorship of this candidate. It grants no membership assignment,
+accepted-evidence set membership, accepted evidence status, evidence
+item acceptance authority, validator output acceptance authority,
+receipt evidence acceptance authority, runtime implementation procedure
+authority, source modification authority, code implementation authority,
+code execution authority, process start authority, general runtime
+authority, unbounded execution authority, runtime state authority,
+package installation authority, package loading authority, package
+execution authority, source merge authority, trust authority, registry
+authority, distribution authority, publication authority, capability
+issuance authority, deployment authority, module authority, plugin
+authority, Semantic CLI authority, AI Runtime authority, agent authority,
+kernel ABI authority, syscall authority, workflow-threshold authority,
+baseline authority, dependency authority, or Ring0 authority.
+
+## Conclusion
+
+This Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment candidate is based on the clean-fixed
+Phase-23 Concrete Accepted-Evidence Set Membership Assignment Post-Sync
+Concrete Assignment publication subject:
+
+```text
+3af79c98e8af6d19cead148ccb276cf0d19cdf36
+```
+
+It opens only the bounded post-sync membership assignment candidate
+boundary.
+
+It does not create membership assignment.
+
+It does not create accepted-evidence set membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize membership assignment, accepted-evidence set
+membership, accepted evidence, evidence item acceptance, validator
+output acceptance, receipt evidence acceptance, runtime implementation
+procedure, source modification, code implementation, code execution,
+process start, runtime state creation, package installation, package
+loading, package execution, capability issuance, registry publication,
+trust assignment, deployment, distribution, source acceptance, source
+merge, kernel ABI expansion, syscall expansion, workflow-threshold
+changes, baseline changes, dependency changes, or Ring0 authority.
+
+Any later Phase-23 membership-assignment, accepted-evidence set
+membership, accepted-evidence, evidence-item, validator-output,
+receipt-evidence, package-review, source-review,
+runtime-implementation-procedure, or non-authorization boundary record
+requires its own exact-SHA evidence, changed-file scope,
+non-authorization boundary, and reviewed decision path.


### PR DESCRIPTION
This PR changes only PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md and defines only a governance-only bounded post-sync membership assignment candidate boundary after the clean-fixed post-sync concrete assignment boundary at 3af79c98e8af6d19cead148ccb276cf0d19cdf36. It does not create a membership assignment, create accepted-evidence set membership, create accepted evidence, accept any evidence item, accept validator output, accept receipt evidence, or authorize runtime/source/package/source-merge/capability/registry/trust/deployment/distribution/kernel ABI/syscall/workflow-threshold/baseline/dependency/Ring0 authority.