### PR TITLE
Phase-23 concrete accepted-evidence set membership assignment post-sync membership assignment record

### DIFF
--- a/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_RECORD.md
+++ b/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_RECORD.md
@@ -1,0 +1,927 @@
+# Phase-23 Concrete Accepted-Evidence Set Membership Assignment Post-Sync Membership Assignment Record
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY_CLEAN_RECOVERY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_FIRST_BOUNDED_IMPLEMENTATION.md`,
+`PHASE22_CLOSURE_DECISION.md`,
+`PHASE23_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE23_POINTER_TRANSITION_DECISION.md`,
+`docs/roadmap/CURRENT_PHASE`,
+`PHASE23_GOVERNANCE_OVERVIEW.md`,
+`PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`,
+`PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`,
+`PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+and
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+In case of conflict, those documents prevail unless this document is the
+narrower Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record for the exact governance-only
+bounded post-sync membership-assignment-record boundary identified
+below.
+
+**Status:** PHASE-23 CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT
+POST-SYNC MEMBERSHIP ASSIGNMENT RECORD / LOCAL DRAFT / GOVERNANCE-ONLY
+POST-SYNC MEMBERSHIP ASSIGNMENT RECORD ONLY / BOUNDED POST-SYNC
+MEMBERSHIP ASSIGNMENT RECORD BOUNDARY ONLY / NO MEMBERSHIP ASSIGNMENT /
+NO ACCEPTED-EVIDENCE SET MEMBERSHIP / NO ACCEPTED-EVIDENCE SET / NO
+ACCEPTED EVIDENCE / NO EVIDENCE ITEM ACCEPTANCE / NO VALIDATOR OUTPUT
+ACCEPTANCE / NO RECEIPT EVIDENCE ACCEPTANCE / NO RUNTIME IMPLEMENTATION
+PROCEDURE / NO SOURCE MODIFICATION / NO CODE IMPLEMENTATION / NO CODE
+EXECUTION / NO PROCESS START / NO RUNTIME STATE CREATION / NO PACKAGE
+INSTALLATION / NO PACKAGE LOADING / NO PACKAGE EXECUTION / NO DEPLOYMENT /
+NO CAPABILITY ISSUANCE / NO TRUST ASSIGNMENT / NO REGISTRY PUBLICATION /
+NO DISTRIBUTION AUTHORITY / NO SOURCE ACCEPTANCE / NO SOURCE MERGE
+AUTHORITY / NO KERNEL ABI EXPANSION / NO SYSCALL EXPANSION / NO
+WORKFLOW-THRESHOLD CHANGE / NO BASELINE CHANGE / NO DEPENDENCY CHANGE /
+NO RING0 AUTHORITY
+**Record date:** 2026-07-27
+**Record id:**
+`ayken.phase23.concrete_accepted_evidence_set_membership_assignment_post_sync_membership_assignment_record.v1`
+**Record drafting base main SHA:**
+`14af9f7f529d90b62dfe11f3b6efaa238e0de850`
+**Record publication subject:** pending separate reviewed publication
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision publication subject:**
+`14af9f7f529d90b62dfe11f3b6efaa238e0de850`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision PR:** PR #298
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision exact-main ci-freeze run:**
+`30230962516`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision exact-main ci-freeze attempt:**
+attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision exact-main ci-freeze job:**
+`freeze / 89869645373`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision exact-main ci-freeze result:**
+PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision exact-main Dev Loop Validation
+run:** `30230962525`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision exact-main Dev Loop Validation
+attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision exact-main Dev Loop Validation
+job:** `devloop / 89869645329`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision exact-main Dev Loop Validation
+result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision exact-main Dev Loop CI run:**
+`30230962541`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision exact-main Dev Loop CI attempt:**
+attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision exact-main Dev Loop CI result:**
+PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision exact-main smoke job:**
+`smoke / 89869645370`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision exact-main smoke result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision exact-main contract job:**
+`contract / 89869778460`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision exact-main contract result:**
+PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision exact-main full job:**
+`full / 89870009596`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision exact-main full result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision exact-main isolation job:**
+`isolation / 89870337183`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision exact-main isolation result:**
+PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision exact-main performance job:**
+`performance / 89870644175`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision exact-main performance result:**
+PASS
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision publication subject:**
+`14af9f7f529d90b62dfe11f3b6efaa238e0de850`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment candidate publication subject:**
+`8fced9c00e8cde94c1710b48524b6c06dab68ff6`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment publication subject:**
+`3af79c98e8af6d19cead148ccb276cf0d19cdf36`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record publication subject:**
+`af894b8c0b49bc84d4671b98ce25a10e9467a1dc`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision publication subject:**
+`c97fecb9eaee548f67e9d7c6b1a819b320ac5304`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate publication subject:**
+`feb44834568a70bfe103f0fcbfaf37e2a8035619`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision publication subject:**
+`cf7cf2ca6f59c9e8e03a13171f9b3efee889fdb0`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate publication subject:**
+`004a886426b30a55cc8176941ac1553004e31f76`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate publication subject:**
+`39d7fa841e731cfbef8368288e19b6d404aa699c`
+**Current phase pointer:** `CURRENT_PHASE=23`
+**Accepted Phase-23 post-sync membership assignment record boundary:**
+bounded post-sync membership assignment record boundary as a governance
+record boundary only; membership assignment, accepted-evidence set
+membership, accepted evidence, evidence item acceptance, validator output
+acceptance, and receipt evidence acceptance remain pending separate
+reviewed records if ever authorized.
+**Authority boundary:** Post-sync membership assignment record boundary
+only; bounded post-sync membership assignment record boundary only; not
+membership assignment, not accepted-evidence set membership, not an
+accepted-evidence set, not accepted evidence, not evidence item
+acceptance, not validator output acceptance, not receipt evidence
+acceptance, not runtime implementation procedure, not source
+modification, not code implementation, not code execution, not process
+start, not runtime state creation, not general runtime authority, not
+unbounded execution authority, not package authority, not package
+installation, not package loading, not package execution, not source
+acceptance, not source merge authority, not source repository authority,
+not module loading, not workspace runtime, not plugin loading, not
+capability token minting, not capability issuance, not trust assignment,
+not trust issuer authority, not registry authority, not registry
+publication, not publication authority, not deployment authority, not
+distribution authority, not distribution execution, not Semantic CLI
+authority, not AI Runtime authority, not agent authority, not syscall
+expansion, not kernel ABI expansion, not workflow-threshold, baseline,
+dependency, or Ring0 authority.
+
+## Purpose
+
+This document records only a bounded post-sync membership assignment
+record boundary after the clean-fixed Phase-23 concrete accepted-evidence
+set membership assignment post-sync membership assignment decision at:
+
+```text
+14af9f7f529d90b62dfe11f3b6efaa238e0de850
+```
+
+It evaluates only:
+
+```text
+May a bounded post-sync membership assignment record boundary be recorded
+after the clean-fixed post-sync membership assignment decision boundary
+at 14af9f7f529d90b62dfe11f3b6efaa238e0de850 without creating a
+membership assignment, creating accepted-evidence set membership,
+creating accepted evidence, or accepting any evidence item?
+```
+
+This document answers that question only for the governance record
+boundary defined here.
+
+It does not create membership assignment.
+
+It does not assign accepted-evidence set membership.
+
+It does not create accepted-evidence set membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize runtime implementation procedure, source
+modification, package loading, package execution, source acceptance,
+source merge, capability issuance, registry publication, trust
+assignment, deployment, distribution, kernel ABI expansion, syscall
+expansion, workflow-threshold changes, baseline changes, dependency
+changes, or Ring0 authority.
+
+## Exact Subject
+
+The exact drafting base for this record is:
+
+```text
+14af9f7f529d90b62dfe11f3b6efaa238e0de850
+```
+
+That subject is the clean-fixed exact-main subject for PR #298:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_DECISION.md
+```
+
+The reviewed PR #298 changed-file scope was:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_DECISION.md
+```
+
+The post-merge exact-main verification for that subject is cited only as
+the prerequisite for this record boundary.
+
+It is not inherited as membership assignment, accepted-evidence set
+membership, accepted evidence, evidence item acceptance, validator output
+acceptance, receipt evidence acceptance, runtime authority, package
+authority, source authority, source merge authority, capability
+authority, registry authority, trust authority, distribution authority,
+deployment authority, kernel ABI authority, syscall authority,
+workflow-threshold authority, baseline authority, dependency authority,
+or Ring0 authority.
+
+## Core Rule
+
+```text
+post-sync membership assignment record == bounded post-sync membership assignment record boundary only
+post-sync membership assignment record != membership assignment
+post-sync membership assignment record != accepted-evidence set membership
+post-sync membership assignment record != accepted-evidence set
+post-sync membership assignment record != accepted evidence
+post-sync membership assignment record != evidence item acceptance
+post-sync membership assignment record != validator output acceptance
+post-sync membership assignment record != receipt evidence acceptance
+post-sync membership assignment record != runtime implementation procedure
+post-sync membership assignment record != source modification
+post-sync membership assignment record != package loading
+post-sync membership assignment record != package execution
+post-sync membership assignment record != source merge authority
+bounded post-sync membership assignment record boundary != membership assignment
+bounded post-sync membership assignment record boundary != accepted-evidence set membership
+bounded post-sync membership assignment record boundary != accepted evidence
+bounded post-sync membership assignment record boundary != evidence item acceptance
+post-sync membership assignment decision clean-fixed != post-sync membership assignment record
+post-sync membership assignment decision != post-sync membership assignment record unless separately reviewed
+post-sync membership assignment decision != membership assignment
+membership assignment record publication != membership assignment
+membership assignment record boundary != membership assignment
+membership assignment decision != membership assignment unless separately reviewed
+membership assignment != accepted-evidence set membership unless separately reviewed
+accepted-evidence set membership != accepted evidence unless separately reviewed
+accepted evidence != evidence item acceptance unless separately reviewed
+accepted evidence != validator output unless separately reviewed
+accepted evidence != receipt evidence unless separately reviewed
+validator output != accepted evidence
+receipt evidence != accepted evidence
+receipt evidence != validator output
+CI PASS != post-sync membership assignment record
+CI PASS != membership assignment
+CI PASS != accepted-evidence set membership
+CI PASS != accepted evidence
+ci-freeze PASS != post-sync membership assignment record
+ci-freeze PASS != membership assignment
+ci-freeze PASS != accepted evidence
+Dev Loop PASS != post-sync membership assignment record
+Dev Loop PASS != membership assignment
+AykenOS Dev Loop CI PASS != post-sync membership assignment record
+AykenOS Dev Loop CI PASS != membership assignment
+post-merge exact-main verification != post-sync membership assignment record
+post-merge exact-main verification != membership assignment
+clean-fixed != post-sync membership assignment record
+clean-fixed != membership assignment
+publication-status sync != post-sync membership assignment record
+publication-status sync != membership assignment
+CURRENT_PHASE=23 != post-sync membership assignment record
+CURRENT_PHASE=23 != membership assignment
+CURRENT_PHASE=23 != accepted-evidence set membership
+CURRENT_PHASE=23 != accepted evidence
+CURRENT_PHASE=23 != evidence item acceptance
+CURRENT_PHASE=23 != validator output acceptance
+CURRENT_PHASE=23 != receipt evidence acceptance
+CURRENT_PHASE=23 != runtime implementation procedure
+CURRENT_PHASE=23 != source modification
+CURRENT_PHASE=23 != execution authority
+CURRENT_PHASE=23 != package loading
+CURRENT_PHASE=23 != source merge authority
+CURRENT_PHASE=23 != kernel ABI expansion
+CURRENT_PHASE=23 != syscall expansion
+historical PASS != inherited evidence
+previous PR evidence != later PR evidence
+```
+
+The safe default remains no membership assignment, no accepted-evidence
+set membership, no accepted evidence, no evidence item acceptance, no
+validator output acceptance, no receipt evidence acceptance, no runtime
+behavior, no implementation procedure, no source modification, no code
+execution, no runtime state, and no package, capability, registry, trust,
+distribution, deployment, source acceptance, source merge, kernel ABI,
+syscall, workflow-threshold, baseline, dependency, or Ring0 authority
+unless a later reviewed Phase-23 decision or record grants a specific
+bounded authority with its own exact-SHA evidence.
+
+Unknown authority readings fail closed.
+
+## Post-Sync Membership Assignment Record Boundary
+
+The Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record is recorded only as:
+
+```text
+bounded post-sync membership assignment record boundary
+```
+
+This record boundary may be used only to evaluate whether a later
+separate reviewed membership assignment, accepted-evidence set
+membership, accepted-evidence, evidence item acceptance,
+validator-output acceptance, or receipt-evidence acceptance path may be
+proposed, without creating any of those later assignments, memberships,
+evidence statuses, records, or authorities.
+
+This record does not create membership assignment.
+
+This record does not assign accepted-evidence set membership.
+
+This record does not create accepted-evidence set membership.
+
+This record does not create accepted evidence.
+
+This record does not accept any evidence item.
+
+This record does not accept validator output.
+
+This record does not accept receipt evidence.
+
+This record does not authorize package loading.
+
+This record does not authorize source acceptance or source merge.
+
+This record does not authorize runtime implementation procedure, code
+execution, process start, runtime state creation, capability issuance,
+registry publication, trust assignment, deployment, distribution, kernel
+ABI expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Any later membership assignment, accepted-evidence set membership,
+accepted evidence, evidence item acceptance, validator output
+acceptance, or receipt evidence acceptance requires a separate reviewed
+decision or record path with its own exact subject, changed-file scope,
+non-authorization boundary, and post-merge exact-main verification.
+
+## Record Scope
+
+This record scope is limited to:
+
+1. Recording the Phase-23 post-sync membership assignment record boundary
+   only as a bounded governance record boundary.
+2. Binding this record to PR #298 as the clean-fixed post-sync
+   membership assignment decision boundary input.
+3. Preserving the distinction between membership assignment record
+   boundary and membership assignment.
+4. Preserving the distinction between membership assignment and
+   accepted-evidence set membership.
+5. Preserving the distinction between accepted-evidence set membership
+   and accepted evidence.
+6. Preserving the distinction between accepted evidence and evidence
+   item acceptance.
+7. Preserving separation from validator output acceptance and receipt
+   evidence acceptance.
+8. Establishing post-merge exact-main verification expectations for this
+   record.
+
+Record scope is governance text only.
+
+Record scope is bounded post-sync membership assignment record boundary
+only.
+
+Record scope is not membership assignment.
+
+Record scope is not accepted-evidence set membership.
+
+Record scope is not accepted evidence.
+
+Record scope is not evidence item acceptance.
+
+Record scope is not validator output acceptance.
+
+Record scope is not receipt evidence acceptance.
+
+Record scope is not runtime implementation procedure.
+
+Record scope is not package loading authority.
+
+Record scope is not execution authority.
+
+Record scope is not source merge authority.
+
+## Current Phase Pointer Boundary
+
+The current phase pointer remains:
+
+```text
+CURRENT_PHASE=23
+```
+
+This record does not modify:
+
+```text
+docs/roadmap/CURRENT_PHASE
+```
+
+This record does not change the active phase pointer.
+
+`CURRENT_PHASE=23` does not authorize membership assignment,
+accepted-evidence set membership, accepted evidence, evidence item
+acceptance, validator output acceptance, receipt evidence acceptance,
+runtime implementation procedure, source modification, code
+implementation, code execution, process start, runtime state creation,
+package loading, package execution, capability issuance, registry
+publication, trust assignment, deployment, distribution, source
+acceptance, source merge, kernel ABI expansion, syscall expansion,
+workflow-threshold changes, baseline changes, dependency changes, or
+Ring0 authority.
+
+## Post-Sync Membership Assignment Decision Input
+
+This record consumes the clean-fixed Phase-23 Concrete Accepted-Evidence
+Set Membership Assignment Post-Sync Membership Assignment Decision as
+its exact governance prerequisite.
+
+The post-sync membership assignment decision remains bound to:
+
+```text
+14af9f7f529d90b62dfe11f3b6efaa238e0de850
+```
+
+The post-sync membership assignment decision recorded only a bounded
+post-sync membership assignment decision boundary.
+
+This record does not reinterpret the post-sync membership assignment
+decision as membership assignment, accepted-evidence set membership,
+accepted evidence, evidence item acceptance, validator output
+acceptance, receipt evidence acceptance, runtime implementation
+procedure, execution authority, package loading authority, source
+acceptance, source merge authority, capability issuance, registry
+publication, trust assignment, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold change, baseline
+change, dependency change, or Ring0 authority.
+
+Any post-sync membership assignment decision conflict fails closed.
+
+## Relationship To Membership Assignment And Membership
+
+This record records only a bounded governance record boundary for later
+post-sync membership assignment evaluation.
+
+This record does not create membership assignment.
+
+This record does not assign accepted-evidence set membership.
+
+This record does not create accepted-evidence set membership.
+
+This record does not define assignment membership.
+
+This record does not define accepted-evidence set membership.
+
+This record does not make membership assignment inevitable.
+
+This record does not make accepted-evidence set membership inevitable.
+
+Any attempt to treat this record as membership assignment or
+accepted-evidence set membership fails closed.
+
+## Relationship To Accepted Evidence And Evidence Item Acceptance
+
+Membership assignment remains separate from accepted-evidence set
+membership unless a separate reviewed decision or record explicitly
+grants that narrower authority.
+
+Accepted-evidence set membership remains separate from accepted evidence
+unless a separate reviewed decision or record explicitly grants that
+narrower authority.
+
+This record does not create accepted evidence.
+
+This record does not identify accepted evidence.
+
+This record does not accept any evidence item.
+
+This record does not define accepted-evidence membership.
+
+This record does not define accepted-evidence set membership.
+
+This record does not make accepted evidence inevitable.
+
+Any attempt to treat this record as accepted evidence or evidence item
+acceptance fails closed.
+
+## Relationship To Validator Output And Receipt Evidence
+
+This record does not convert validator output into accepted evidence.
+
+This record does not convert receipt evidence into accepted evidence.
+
+This record does not accept validator output.
+
+This record does not accept receipt evidence.
+
+This record does not grant accepted-evidence membership over validator
+output, receipt evidence, package review output, source review output,
+historical PASS results, or clean-fixed claims.
+
+Any validator-output or receipt-evidence boundary conflict fails closed.
+
+## Relationship To Phase-19 Runtime Authority
+
+This record remains subordinate to Phase-19 runtime authority records.
+
+This record must not broaden, replace, supersede, weaken, or reinterpret
+Phase-19 runtime authority records.
+
+This record must not use membership assignment record status to infer
+runtime authority.
+
+This record must not use membership assignment, accepted-evidence set
+membership, accepted-evidence authority, accepted evidence,
+validator-output planning, receipt-evidence planning, exact-SHA evidence
+expectations, or `CURRENT_PHASE=23` to infer runtime authority.
+
+Any Phase-23 post-sync membership assignment record reading that
+conflicts with Phase-19 runtime authority records fails closed.
+
+## Not Authorized By This Record
+
+This record does not authorize:
+
+1. Membership assignment.
+2. Accepted-evidence set membership.
+3. Accepted-evidence set creation.
+4. Accepted evidence.
+5. Evidence item acceptance.
+6. Validator output acceptance.
+7. Receipt evidence acceptance.
+8. Runtime implementation procedure.
+9. Source modification.
+10. Source acceptance.
+11. Source merge.
+12. Code implementation.
+13. Code execution.
+14. Process start.
+15. Runtime state creation.
+16. Package installation.
+17. Package loading.
+18. Package execution.
+19. Module loading.
+20. Workspace runtime or real mounts.
+21. Plugin loading or plugin instantiation.
+22. Capability token minting.
+23. Capability issuance.
+24. Registry publication.
+25. Trust assignment.
+26. Distribution execution.
+27. Deployment.
+28. Semantic CLI authority.
+29. AI Runtime authority.
+30. Agent authority.
+31. Syscall expansion.
+32. Kernel ABI expansion.
+33. Ring0 policy movement.
+34. Workflow-threshold changes.
+35. Baseline changes.
+36. Dependency changes.
+37. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this record is published, the publication may change only this file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_RECORD.md
+```
+
+The publication must not change:
+
+1. `docs/roadmap/CURRENT_PHASE`.
+2. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+3. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+4. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT.md`.
+5. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_RECORD.md`.
+6. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md`.
+7. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_CANDIDATE.md`.
+8. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md`.
+9. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md`.
+10. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`.
+11. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`.
+12. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md`.
+13. CI workflows.
+14. Baselines.
+15. Dependencies.
+16. Runtime source or kernel source.
+17. Syscalls or kernel ABI.
+18. Package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution paths.
+19. `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md`.
+
+Any changed-file expansion beyond this record requires separate review
+and fails this record scope.
+
+## Post-Merge Exact-Main Evidence Rule
+
+If this record is later published, the record publication subject must
+receive its own post-merge exact-main verification:
+
+1. `ci-freeze` PASS for the exact record publication SHA.
+2. Dev Loop Validation PASS for the exact record publication SHA.
+3. AykenOS Dev Loop CI PASS for the exact record publication SHA.
+4. smoke PASS.
+5. contract PASS.
+6. full PASS.
+7. isolation PASS.
+8. performance PASS.
+9. Exact changed-file list confirmation.
+10. No `docs/roadmap/CURRENT_PHASE` change.
+11. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_DECISION.md`
+    change.
+12. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`
+    change.
+13. No membership assignment, accepted-evidence set membership, accepted
+    evidence, evidence item acceptance, validator output acceptance, or
+    receipt evidence acceptance.
+14. No CI workflow change.
+15. No baseline change.
+16. No dependency change.
+17. No runtime source or kernel source change.
+18. No syscall or kernel ABI change.
+19. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution change.
+
+Until that exact-main post-merge verification exists, this record must
+not be recorded as clean-fixed.
+
+Historical PASS results may be cited as context only.
+
+Failed attempts may be cited as transparent non-clean context only.
+
+They cannot be inherited as membership assignment, accepted-evidence set
+membership, accepted evidence, evidence item acceptance, validator output
+acceptance, receipt evidence acceptance, runtime authority, package
+loading authority, package execution authority, source merge authority,
+capability authority, registry authority, trust authority, kernel ABI
+authority, syscall authority, workflow-threshold authority, baseline
+authority, dependency authority, or Ring0 authority.
+
+## Later Membership Assignment Dependency
+
+This record is a prerequisite input for a possible later bounded
+post-sync membership assignment path.
+
+A later membership assignment decision or record, if ever proposed, must
+define:
+
+1. Exact membership assignment subject.
+2. Exact Phase-23 post-sync membership assignment record prerequisite.
+3. Exact changed-file boundary.
+4. Exact evidence item reference proposed for membership assignment, if
+   any, without evidence item acceptance unless separately reviewed.
+5. Exact accepted-evidence set membership proposed for assignment, if
+   any, without accepted-evidence set membership status unless separately
+   reviewed.
+6. Exact membership assignment grant, denial, or separate membership
+   assignment scope.
+7. Exact accepted-evidence set membership denial or separate membership
+   scope.
+8. Exact accepted-evidence denial or separate accepted-evidence scope.
+9. Exact evidence item acceptance denial or separate evidence item
+   acceptance scope.
+10. Exact validator-output acceptance denial or separate
+    validator-output acceptance scope.
+11. Exact receipt-evidence acceptance denial or separate receipt-evidence
+    acceptance scope.
+12. Exact runtime implementation procedure denial.
+13. Exact package loading and package execution denials.
+14. Exact source acceptance and source merge denials.
+15. Exact capability, registry, trust, deployment, distribution, kernel
+    ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+    denials.
+16. Exact post-merge verification requirements.
+
+Until such a later reviewed membership assignment record is published,
+no membership assignment exists from this record.
+
+Until such a later reviewed accepted-evidence set membership record is
+published, no accepted-evidence set membership exists from this record.
+
+Until such a later reviewed accepted-evidence record is published, no
+accepted evidence exists from this record.
+
+Until such a later reviewed evidence item acceptance record is published,
+no evidence item acceptance exists from this record.
+
+Until such a later reviewed validator-output acceptance record is
+published, no validator output acceptance exists from this record.
+
+Until such a later reviewed receipt-evidence acceptance record is
+published, no receipt evidence acceptance exists from this record.
+
+## Excluded Local Draft
+
+This record does not consume:
+
+```text
+PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md
+```
+
+If that file exists locally as an untracked file, it remains:
+
+```text
+untracked
+PR-disjoint
+not record input
+not membership assignment input
+not accepted-evidence set membership input
+not accepted evidence
+not evidence item acceptance
+not validator output
+not receipt evidence
+not runtime authority
+not package acceptance
+not source authority
+```
+
+It must not be staged, committed, or included in any Phase-23 post-sync
+membership assignment record PR unless a separate reviewed scope
+explicitly authorizes that file.
+
+## Governance Boundary Invariants
+
+Every later RFC must preserve these Phase-23 post-sync membership
+assignment record invariants:
+
+1. This record is bounded post-sync membership assignment record
+   boundary only.
+2. This record is not membership assignment.
+3. This record is not accepted-evidence set membership.
+4. This record is not an accepted-evidence set.
+5. This record is not accepted evidence.
+6. This record is not evidence item acceptance.
+7. This record is not validator output acceptance.
+8. This record is not receipt evidence acceptance.
+9. This record is not runtime implementation procedure.
+10. This record is not source modification.
+11. This record is not code implementation.
+12. This record is not code execution.
+13. This record is not process start.
+14. This record is not runtime state creation.
+15. This record is not package installation.
+16. This record is not package loading.
+17. This record is not package execution.
+18. This record is not capability issuance.
+19. This record is not registry publication.
+20. This record is not trust assignment.
+21. This record is not deployment.
+22. This record is not distribution authority.
+23. This record is not source acceptance.
+24. This record is not source merge authority.
+25. This record does not modify `docs/roadmap/CURRENT_PHASE`.
+26. This record does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+27. This record does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+28. This record does not broaden Phase-19 runtime authority.
+29. This record does not reopen Phase-20.
+30. This record does not reopen Phase-21.
+31. This record does not reopen Phase-22.
+32. This record does not expand kernel ABI or syscalls.
+33. This record does not change workflow thresholds, baselines, or
+    dependencies.
+34. Membership assignment record boundary is not membership assignment.
+35. Membership assignment is not accepted-evidence set membership unless
+    separately reviewed.
+36. Accepted-evidence set membership is not accepted evidence unless
+    separately reviewed.
+37. Accepted evidence is not evidence item acceptance unless separately
+    reviewed.
+38. Validator output is not accepted evidence.
+39. Receipt evidence is not accepted evidence.
+40. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-23 concrete accepted-evidence set membership
+assignment post-sync membership assignment record
+**Architecture status:** Local draft post-sync membership assignment
+record / pending separate reviewed publication
+**Authority notice:** This signature identifies the architectural
+authorship of this record. If separately reviewed and published, it
+grants only the bounded post-sync membership assignment record boundary
+defined in this record. It grants no membership assignment authority, no
+accepted-evidence set membership authority, no accepted evidence status,
+no evidence item acceptance authority, no validator output acceptance
+authority, no receipt evidence acceptance authority, no runtime
+implementation procedure authority, no source modification authority, no
+code implementation authority, no code execution authority, no process
+start authority, no general runtime authority, no unbounded execution
+authority, no runtime state authority, no package installation authority,
+no package loading authority, no package execution authority, no source
+merge authority, no trust authority, no registry authority, no
+distribution authority, no publication authority, no capability issuance
+authority, no deployment authority, no module authority, no plugin
+authority, no Semantic CLI authority, no AI Runtime authority, no agent
+authority, no kernel ABI authority, no syscall authority, no
+workflow-threshold authority, no baseline authority, no dependency
+authority, or Ring0 authority.
+
+## Conclusion
+
+This Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record is based on the clean-fixed
+Phase-23 concrete accepted-evidence set membership assignment post-sync
+membership assignment decision publication subject:
+
+```text
+14af9f7f529d90b62dfe11f3b6efaa238e0de850
+```
+
+It records only the bounded post-sync membership assignment record
+boundary.
+
+It does not create membership assignment.
+
+It does not create accepted-evidence set membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, capability issuance, registry publication, trust assignment,
+deployment, distribution, source acceptance, source merge, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Any later Phase-23 membership-assignment, accepted-evidence-set
+membership, accepted-evidence, evidence-item-acceptance,
+validator-output-acceptance, receipt-evidence-acceptance,
+package-review, source-review, runtime-implementation-procedure, or
+non-authorization boundary record requires its own exact-SHA evidence,
+changed-file scope, non-authorization boundary, and reviewed decision
+path.


### PR DESCRIPTION
This PR changes only PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_RECORD.md and records only a governance-only bounded post-sync membership assignment record boundary after the clean-fixed post-sync membership assignment decision boundary at 14af9f7f529d90b62dfe11f3b6efaa238e0de850. It does not create a membership assignment, create accepted-evidence set membership, create accepted evidence, accept any evidence item, accept validator output, accept receipt evidence, or authorize runtime/source/package/source-merge/capability/registry/trust/deployment/distribution/kernel ABI/syscall/workflow-threshold/baseline/dependency/Ring0 authority.