### PR TITLE
Phase-23 concrete accepted-evidence set membership assignment post-sync membership assignment

### DIFF
--- a/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT.md
+++ b/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT.md
@@ -1,0 +1,876 @@
+# Phase-23 Concrete Accepted-Evidence Set Membership Assignment Post-Sync Membership Assignment
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY_CLEAN_RECOVERY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_FIRST_BOUNDED_IMPLEMENTATION.md`,
+`PHASE22_CLOSURE_DECISION.md`,
+`PHASE23_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE23_POINTER_TRANSITION_DECISION.md`,
+`docs/roadmap/CURRENT_PHASE`,
+`PHASE23_GOVERNANCE_OVERVIEW.md`,
+`PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`,
+`PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`,
+`PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+and
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+In case of conflict, those documents prevail unless this document is the
+narrower Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment for the exact governance-only bounded
+post-sync membership-assignment boundary identified below.
+
+**Status:** PHASE-23 CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT
+POST-SYNC MEMBERSHIP ASSIGNMENT / LOCAL DRAFT / GOVERNANCE-ONLY
+POST-SYNC MEMBERSHIP ASSIGNMENT ONLY / BOUNDED POST-SYNC MEMBERSHIP
+ASSIGNMENT BOUNDARY ONLY / NO ACCEPTED-EVIDENCE SET MEMBERSHIP / NO
+ACCEPTED-EVIDENCE SET / NO ACCEPTED EVIDENCE / NO EVIDENCE ITEM
+ACCEPTANCE / NO VALIDATOR OUTPUT ACCEPTANCE / NO RECEIPT EVIDENCE
+ACCEPTANCE / NO RUNTIME IMPLEMENTATION PROCEDURE / NO SOURCE
+MODIFICATION / NO CODE IMPLEMENTATION / NO CODE EXECUTION / NO PROCESS
+START / NO RUNTIME STATE CREATION / NO PACKAGE INSTALLATION / NO PACKAGE
+LOADING / NO PACKAGE EXECUTION / NO DEPLOYMENT / NO CAPABILITY ISSUANCE /
+NO TRUST ASSIGNMENT / NO REGISTRY PUBLICATION / NO DISTRIBUTION
+AUTHORITY / NO SOURCE ACCEPTANCE / NO SOURCE MERGE AUTHORITY / NO KERNEL
+ABI EXPANSION / NO SYSCALL EXPANSION / NO WORKFLOW-THRESHOLD CHANGE / NO
+BASELINE CHANGE / NO DEPENDENCY CHANGE / NO RING0 AUTHORITY
+**Assignment date:** 2026-07-27
+**Assignment id:**
+`ayken.phase23.concrete_accepted_evidence_set_membership_assignment_post_sync_membership_assignment.v1`
+**Assignment drafting base main SHA:**
+`00f514e4cdb8decb64b9222fee24ab4a41cacf23`
+**Assignment publication subject:** pending separate reviewed publication
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record publication subject:**
+`00f514e4cdb8decb64b9222fee24ab4a41cacf23`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record PR:** PR #299
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record exact-main ci-freeze run:**
+`30255652364`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record exact-main ci-freeze attempt:**
+attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record exact-main ci-freeze job:**
+`freeze / 89943519180`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record exact-main ci-freeze result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record exact-main Dev Loop Validation
+run:** `30255652378`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record exact-main Dev Loop Validation
+attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record exact-main Dev Loop Validation
+job:** `devloop / 89943519086`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record exact-main Dev Loop Validation
+result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record exact-main Dev Loop CI run:**
+`30255652563`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record exact-main Dev Loop CI attempt:**
+attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record exact-main Dev Loop CI result:**
+PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record exact-main smoke job:**
+`smoke / 89943519823`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record exact-main smoke result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record exact-main contract job:**
+`contract / 89943913676`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record exact-main contract result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record exact-main full job:**
+`full / 89944364642`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record exact-main full result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record exact-main isolation job:**
+`isolation / 89944934081`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record exact-main isolation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record exact-main performance job:**
+`performance / 89945590892`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record exact-main performance result:**
+PASS
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record publication subject:**
+`00f514e4cdb8decb64b9222fee24ab4a41cacf23`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision publication subject:**
+`14af9f7f529d90b62dfe11f3b6efaa238e0de850`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment candidate publication subject:**
+`8fced9c00e8cde94c1710b48524b6c06dab68ff6`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment publication subject:**
+`3af79c98e8af6d19cead148ccb276cf0d19cdf36`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment record publication subject:**
+`af894b8c0b49bc84d4671b98ce25a10e9467a1dc`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment decision publication subject:**
+`c97fecb9eaee548f67e9d7c6b1a819b320ac5304`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment candidate publication subject:**
+`feb44834568a70bfe103f0fcbfaf37e2a8035619`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision publication subject:**
+`cf7cf2ca6f59c9e8e03a13171f9b3efee889fdb0`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync decision candidate publication subject:**
+`004a886426b30a55cc8176941ac1553004e31f76`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync candidate publication subject:**
+`39d7fa841e731cfbef8368288e19b6d404aa699c`
+**Current phase pointer:** `CURRENT_PHASE=23`
+**Accepted Phase-23 post-sync membership assignment boundary:** bounded
+post-sync membership assignment boundary as a governance assignment
+boundary only; accepted-evidence set membership, accepted evidence,
+evidence item acceptance, validator output acceptance, and receipt
+evidence acceptance remain pending separate reviewed records if ever
+authorized.
+**Authority boundary:** Post-sync membership assignment boundary only;
+bounded post-sync membership assignment boundary only; not
+accepted-evidence set membership, not an accepted-evidence set, not
+accepted evidence, not evidence item acceptance, not validator output
+acceptance, not receipt evidence acceptance, not runtime implementation
+procedure, not source modification, not code implementation, not code
+execution, not process start, not runtime state creation, not general
+runtime authority, not unbounded execution authority, not package
+authority, not package installation, not package loading, not package
+execution, not source acceptance, not source merge authority, not source
+repository authority, not module loading, not workspace runtime, not
+plugin loading, not capability token minting, not capability issuance,
+not trust assignment, not trust issuer authority, not registry authority,
+not registry publication, not publication authority, not deployment
+authority, not distribution authority, not distribution execution, not
+Semantic CLI authority, not AI Runtime authority, not agent authority,
+not syscall expansion, not kernel ABI expansion, not workflow-threshold,
+baseline, dependency, or Ring0 authority.
+
+## Purpose
+
+This document records only a bounded post-sync membership assignment
+boundary after the clean-fixed Phase-23 concrete accepted-evidence set
+membership assignment post-sync membership assignment record at:
+
+```text
+00f514e4cdb8decb64b9222fee24ab4a41cacf23
+```
+
+It evaluates only:
+
+```text
+May a bounded post-sync membership assignment boundary be recorded after
+the clean-fixed post-sync membership assignment record boundary at
+00f514e4cdb8decb64b9222fee24ab4a41cacf23 without creating
+accepted-evidence set membership, creating accepted evidence, or
+accepting any evidence item?
+```
+
+This document answers that question only for the governance assignment
+boundary defined here.
+
+It does not create accepted-evidence set membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize runtime implementation procedure, source
+modification, package loading, package execution, source acceptance,
+source merge, capability issuance, registry publication, trust
+assignment, deployment, distribution, kernel ABI expansion, syscall
+expansion, workflow-threshold changes, baseline changes, dependency
+changes, or Ring0 authority.
+
+## Exact Subject
+
+The exact drafting base for this assignment boundary is:
+
+```text
+00f514e4cdb8decb64b9222fee24ab4a41cacf23
+```
+
+That subject is the clean-fixed exact-main subject for PR #299:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_RECORD.md
+```
+
+The reviewed PR #299 changed-file scope was:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_RECORD.md
+```
+
+The post-merge exact-main verification for that subject is cited only as
+the prerequisite for this membership assignment boundary.
+
+It is not inherited as accepted-evidence set membership, accepted
+evidence, evidence item acceptance, validator output acceptance, receipt
+evidence acceptance, runtime authority, package authority, source
+authority, source merge authority, capability authority, registry
+authority, trust authority, distribution authority, deployment
+authority, kernel ABI authority, syscall authority, workflow-threshold
+authority, baseline authority, dependency authority, or Ring0 authority.
+
+## Core Rule
+
+```text
+post-sync membership assignment == bounded post-sync membership assignment boundary only
+post-sync membership assignment != accepted-evidence set membership
+post-sync membership assignment != accepted-evidence set
+post-sync membership assignment != accepted evidence
+post-sync membership assignment != evidence item acceptance
+post-sync membership assignment != validator output acceptance
+post-sync membership assignment != receipt evidence acceptance
+post-sync membership assignment != runtime implementation procedure
+post-sync membership assignment != source modification
+post-sync membership assignment != package loading
+post-sync membership assignment != package execution
+post-sync membership assignment != source merge authority
+bounded post-sync membership assignment boundary != accepted-evidence set membership
+bounded post-sync membership assignment boundary != accepted evidence
+bounded post-sync membership assignment boundary != evidence item acceptance
+post-sync membership assignment record clean-fixed != post-sync membership assignment
+post-sync membership assignment record != post-sync membership assignment unless separately reviewed
+membership assignment record boundary != accepted-evidence set membership
+membership assignment != accepted-evidence set membership unless separately reviewed
+accepted-evidence set membership != accepted evidence unless separately reviewed
+accepted evidence != evidence item acceptance unless separately reviewed
+accepted evidence != validator output unless separately reviewed
+accepted evidence != receipt evidence unless separately reviewed
+validator output != accepted evidence
+receipt evidence != accepted evidence
+receipt evidence != validator output
+CI PASS != post-sync membership assignment
+CI PASS != accepted-evidence set membership
+CI PASS != accepted evidence
+ci-freeze PASS != post-sync membership assignment
+ci-freeze PASS != accepted evidence
+Dev Loop PASS != post-sync membership assignment
+AykenOS Dev Loop CI PASS != post-sync membership assignment
+post-merge exact-main verification != post-sync membership assignment
+post-merge exact-main verification != accepted-evidence set membership
+clean-fixed != post-sync membership assignment
+clean-fixed != accepted-evidence set membership
+publication-status sync != post-sync membership assignment
+publication-status sync != accepted-evidence set membership
+CURRENT_PHASE=23 != post-sync membership assignment
+CURRENT_PHASE=23 != accepted-evidence set membership
+CURRENT_PHASE=23 != accepted evidence
+CURRENT_PHASE=23 != evidence item acceptance
+CURRENT_PHASE=23 != validator output acceptance
+CURRENT_PHASE=23 != receipt evidence acceptance
+CURRENT_PHASE=23 != runtime implementation procedure
+CURRENT_PHASE=23 != source modification
+CURRENT_PHASE=23 != execution authority
+CURRENT_PHASE=23 != package loading
+CURRENT_PHASE=23 != source merge authority
+CURRENT_PHASE=23 != kernel ABI expansion
+CURRENT_PHASE=23 != syscall expansion
+historical PASS != inherited evidence
+previous PR evidence != later PR evidence
+```
+
+The safe default remains no accepted-evidence set membership, no
+accepted evidence, no evidence item acceptance, no validator output
+acceptance, no receipt evidence acceptance, no runtime behavior, no
+implementation procedure, no source modification, no code execution, no
+runtime state, and no package, capability, registry, trust,
+distribution, deployment, source acceptance, source merge, kernel ABI,
+syscall, workflow-threshold, baseline, dependency, or Ring0 authority
+unless a later reviewed Phase-23 decision or record grants a specific
+bounded authority with its own exact-SHA evidence.
+
+Unknown authority readings fail closed.
+
+## Post-Sync Membership Assignment Boundary
+
+The Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment is recorded only as:
+
+```text
+bounded post-sync membership assignment boundary
+```
+
+This assignment boundary may be used only to evaluate whether a later
+separate reviewed accepted-evidence set membership, accepted-evidence,
+evidence item acceptance, validator-output acceptance, or
+receipt-evidence acceptance path may be proposed, without creating any
+of those later memberships, evidence statuses, records, or authorities.
+
+This assignment boundary does not create accepted-evidence set
+membership.
+
+This assignment boundary does not create accepted evidence.
+
+This assignment boundary does not accept any evidence item.
+
+This assignment boundary does not accept validator output.
+
+This assignment boundary does not accept receipt evidence.
+
+This assignment boundary does not authorize package loading.
+
+This assignment boundary does not authorize source acceptance or source
+merge.
+
+This assignment boundary does not authorize runtime implementation
+procedure, code execution, process start, runtime state creation,
+capability issuance, registry publication, trust assignment, deployment,
+distribution, kernel ABI expansion, syscall expansion,
+workflow-threshold changes, baseline changes, dependency changes, or
+Ring0 authority.
+
+Any later accepted-evidence set membership, accepted evidence, evidence
+item acceptance, validator output acceptance, or receipt evidence
+acceptance requires a separate reviewed decision or record path with its
+own exact subject, changed-file scope, non-authorization boundary, and
+post-merge exact-main verification.
+
+## Assignment Scope
+
+This assignment scope is limited to:
+
+1. Recording the Phase-23 post-sync membership assignment boundary only
+   as a bounded governance assignment boundary.
+2. Binding this assignment to PR #299 as the clean-fixed post-sync
+   membership assignment record boundary input.
+3. Preserving the distinction between membership assignment and
+   accepted-evidence set membership.
+4. Preserving the distinction between accepted-evidence set membership
+   and accepted evidence.
+5. Preserving the distinction between accepted evidence and evidence
+   item acceptance.
+6. Preserving separation from validator output acceptance and receipt
+   evidence acceptance.
+7. Establishing post-merge exact-main verification expectations for this
+   assignment boundary.
+
+Assignment scope is governance text only.
+
+Assignment scope is bounded post-sync membership assignment boundary
+only.
+
+Assignment scope is not accepted-evidence set membership.
+
+Assignment scope is not accepted evidence.
+
+Assignment scope is not evidence item acceptance.
+
+Assignment scope is not validator output acceptance.
+
+Assignment scope is not receipt evidence acceptance.
+
+Assignment scope is not runtime implementation procedure.
+
+Assignment scope is not package loading authority.
+
+Assignment scope is not execution authority.
+
+Assignment scope is not source merge authority.
+
+## Current Phase Pointer Boundary
+
+The current phase pointer remains:
+
+```text
+CURRENT_PHASE=23
+```
+
+This assignment does not modify:
+
+```text
+docs/roadmap/CURRENT_PHASE
+```
+
+This assignment does not change the active phase pointer.
+
+`CURRENT_PHASE=23` does not authorize accepted-evidence set membership,
+accepted evidence, evidence item acceptance, validator output
+acceptance, receipt evidence acceptance, runtime implementation
+procedure, source modification, code implementation, code execution,
+process start, runtime state creation, package loading, package
+execution, capability issuance, registry publication, trust assignment,
+deployment, distribution, source acceptance, source merge, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+## Post-Sync Membership Assignment Record Input
+
+This assignment consumes the clean-fixed Phase-23 Concrete
+Accepted-Evidence Set Membership Assignment Post-Sync Membership
+Assignment Record as its exact governance prerequisite.
+
+The post-sync membership assignment record remains bound to:
+
+```text
+00f514e4cdb8decb64b9222fee24ab4a41cacf23
+```
+
+The post-sync membership assignment record recorded only a bounded
+post-sync membership assignment record boundary.
+
+This assignment does not reinterpret the post-sync membership assignment
+record as accepted-evidence set membership, accepted evidence, evidence
+item acceptance, validator output acceptance, receipt evidence
+acceptance, runtime implementation procedure, execution authority,
+package loading authority, source acceptance, source merge authority,
+capability issuance, registry publication, trust assignment, deployment,
+distribution, kernel ABI expansion, syscall expansion,
+workflow-threshold change, baseline change, dependency change, or Ring0
+authority.
+
+Any post-sync membership assignment record conflict fails closed.
+
+## Relationship To Accepted-Evidence Set Membership
+
+This assignment records only a bounded governance assignment boundary for
+post-sync membership assignment evaluation.
+
+This assignment does not create accepted-evidence set membership.
+
+This assignment does not define accepted-evidence set membership.
+
+This assignment does not make accepted-evidence set membership
+inevitable.
+
+Any attempt to treat this assignment as accepted-evidence set membership
+fails closed.
+
+## Relationship To Accepted Evidence And Evidence Item Acceptance
+
+Accepted-evidence set membership remains separate from accepted evidence
+unless a separate reviewed decision or record explicitly grants that
+narrower authority.
+
+This assignment does not create accepted evidence.
+
+This assignment does not identify accepted evidence.
+
+This assignment does not accept any evidence item.
+
+This assignment does not define accepted-evidence membership.
+
+This assignment does not make accepted evidence inevitable.
+
+Any attempt to treat this assignment as accepted evidence or evidence
+item acceptance fails closed.
+
+## Relationship To Validator Output And Receipt Evidence
+
+This assignment does not convert validator output into accepted evidence.
+
+This assignment does not convert receipt evidence into accepted evidence.
+
+This assignment does not accept validator output.
+
+This assignment does not accept receipt evidence.
+
+This assignment does not grant accepted-evidence membership over
+validator output, receipt evidence, package review output, source review
+output, historical PASS results, or clean-fixed claims.
+
+Any validator-output or receipt-evidence boundary conflict fails closed.
+
+## Relationship To Phase-19 Runtime Authority
+
+This assignment remains subordinate to Phase-19 runtime authority
+records.
+
+This assignment must not broaden, replace, supersede, weaken, or
+reinterpret Phase-19 runtime authority records.
+
+This assignment must not use membership assignment status to infer
+runtime authority.
+
+This assignment must not use accepted-evidence set membership,
+accepted-evidence authority, accepted evidence, validator-output
+planning, receipt-evidence planning, exact-SHA evidence expectations, or
+`CURRENT_PHASE=23` to infer runtime authority.
+
+Any Phase-23 post-sync membership assignment reading that conflicts with
+Phase-19 runtime authority records fails closed.
+
+## Not Authorized By This Assignment
+
+This assignment does not authorize:
+
+1. Accepted-evidence set membership.
+2. Accepted-evidence set creation.
+3. Accepted evidence.
+4. Evidence item acceptance.
+5. Validator output acceptance.
+6. Receipt evidence acceptance.
+7. Runtime implementation procedure.
+8. Source modification.
+9. Source acceptance.
+10. Source merge.
+11. Code implementation.
+12. Code execution.
+13. Process start.
+14. Runtime state creation.
+15. Package installation.
+16. Package loading.
+17. Package execution.
+18. Module loading.
+19. Workspace runtime or real mounts.
+20. Plugin loading or plugin instantiation.
+21. Capability token minting.
+22. Capability issuance.
+23. Registry publication.
+24. Trust assignment.
+25. Distribution execution.
+26. Deployment.
+27. Semantic CLI authority.
+28. AI Runtime authority.
+29. Agent authority.
+30. Syscall expansion.
+31. Kernel ABI expansion.
+32. Ring0 policy movement.
+33. Workflow-threshold changes.
+34. Baseline changes.
+35. Dependency changes.
+36. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this assignment is published, the publication may change only this
+file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT.md
+```
+
+The publication must not change:
+
+1. `docs/roadmap/CURRENT_PHASE`.
+2. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+3. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+4. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+5. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT.md`.
+6. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_RECORD.md`.
+7. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md`.
+8. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_CANDIDATE.md`.
+9. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md`.
+10. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md`.
+11. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`.
+12. CI workflows.
+13. Baselines.
+14. Dependencies.
+15. Runtime source or kernel source.
+16. Syscalls or kernel ABI.
+17. Package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution paths.
+18. `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md`.
+
+Any changed-file expansion beyond this assignment requires separate
+review and fails this assignment scope.
+
+## Post-Merge Exact-Main Evidence Rule
+
+If this assignment is later published, the assignment publication subject
+must receive its own post-merge exact-main verification:
+
+1. `ci-freeze` PASS for the exact assignment publication SHA.
+2. Dev Loop Validation PASS for the exact assignment publication SHA.
+3. AykenOS Dev Loop CI PASS for the exact assignment publication SHA.
+4. smoke PASS.
+5. contract PASS.
+6. full PASS.
+7. isolation PASS.
+8. performance PASS.
+9. Exact changed-file list confirmation.
+10. No `docs/roadmap/CURRENT_PHASE` change.
+11. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_RECORD.md`
+    change.
+12. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_DECISION.md`
+    change.
+13. No accepted-evidence set membership, accepted evidence, evidence
+    item acceptance, validator output acceptance, or receipt evidence
+    acceptance.
+14. No CI workflow change.
+15. No baseline change.
+16. No dependency change.
+17. No runtime source or kernel source change.
+18. No syscall or kernel ABI change.
+19. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment, or
+    distribution execution change.
+
+Until that exact-main post-merge verification exists, this assignment
+must not be recorded as clean-fixed.
+
+Historical PASS results may be cited as context only.
+
+Failed attempts may be cited as transparent non-clean context only.
+
+They cannot be inherited as accepted-evidence set membership, accepted
+evidence, evidence item acceptance, validator output acceptance, receipt
+evidence acceptance, runtime authority, package loading authority,
+package execution authority, source merge authority, capability
+authority, registry authority, trust authority, kernel ABI authority,
+syscall authority, workflow-threshold authority, baseline authority,
+dependency authority, or Ring0 authority.
+
+## Later Accepted-Evidence Set Membership Dependency
+
+This assignment is a prerequisite input for a possible later bounded
+accepted-evidence set membership path.
+
+A later accepted-evidence set membership decision or record, if ever
+proposed, must define:
+
+1. Exact accepted-evidence set membership subject.
+2. Exact Phase-23 post-sync membership assignment prerequisite.
+3. Exact changed-file boundary.
+4. Exact evidence item reference proposed for accepted-evidence set
+   membership, if any, without evidence item acceptance unless
+   separately reviewed.
+5. Exact accepted-evidence set membership grant, denial, or separate
+   membership scope.
+6. Exact accepted-evidence denial or separate accepted-evidence scope.
+7. Exact evidence item acceptance denial or separate evidence item
+   acceptance scope.
+8. Exact validator-output acceptance denial or separate
+   validator-output acceptance scope.
+9. Exact receipt-evidence acceptance denial or separate receipt-evidence
+   acceptance scope.
+10. Exact runtime implementation procedure denial.
+11. Exact package loading and package execution denials.
+12. Exact source acceptance and source merge denials.
+13. Exact capability, registry, trust, deployment, distribution, kernel
+    ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+    denials.
+14. Exact post-merge verification requirements.
+
+Until such a later reviewed accepted-evidence set membership record is
+published, no accepted-evidence set membership exists from this
+assignment.
+
+Until such a later reviewed accepted-evidence record is published, no
+accepted evidence exists from this assignment.
+
+Until such a later reviewed evidence item acceptance record is published,
+no evidence item acceptance exists from this assignment.
+
+Until such a later reviewed validator-output acceptance record is
+published, no validator output acceptance exists from this assignment.
+
+Until such a later reviewed receipt-evidence acceptance record is
+published, no receipt evidence acceptance exists from this assignment.
+
+## Excluded Local Draft
+
+This assignment does not consume:
+
+```text
+PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md
+```
+
+If that file exists locally as an untracked file, it remains:
+
+```text
+untracked
+PR-disjoint
+not assignment input
+not accepted-evidence set membership input
+not accepted evidence
+not evidence item acceptance
+not validator output
+not receipt evidence
+not runtime authority
+not package acceptance
+not source authority
+```
+
+It must not be staged, committed, or included in any Phase-23 post-sync
+membership assignment PR unless a separate reviewed scope explicitly
+authorizes that file.
+
+## Governance Boundary Invariants
+
+Every later RFC must preserve these Phase-23 post-sync membership
+assignment invariants:
+
+1. This assignment is bounded post-sync membership assignment boundary
+   only.
+2. This assignment is not accepted-evidence set membership.
+3. This assignment is not an accepted-evidence set.
+4. This assignment is not accepted evidence.
+5. This assignment is not evidence item acceptance.
+6. This assignment is not validator output acceptance.
+7. This assignment is not receipt evidence acceptance.
+8. This assignment is not runtime implementation procedure.
+9. This assignment is not source modification.
+10. This assignment is not code implementation.
+11. This assignment is not code execution.
+12. This assignment is not process start.
+13. This assignment is not runtime state creation.
+14. This assignment is not package installation.
+15. This assignment is not package loading.
+16. This assignment is not package execution.
+17. This assignment is not capability issuance.
+18. This assignment is not registry publication.
+19. This assignment is not trust assignment.
+20. This assignment is not deployment.
+21. This assignment is not distribution authority.
+22. This assignment is not source acceptance.
+23. This assignment is not source merge authority.
+24. This assignment does not modify `docs/roadmap/CURRENT_PHASE`.
+25. This assignment does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+26. This assignment does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+27. This assignment does not broaden Phase-19 runtime authority.
+28. This assignment does not reopen Phase-20.
+29. This assignment does not reopen Phase-21.
+30. This assignment does not reopen Phase-22.
+31. This assignment does not expand kernel ABI or syscalls.
+32. This assignment does not change workflow thresholds, baselines, or
+    dependencies.
+33. Membership assignment boundary is not accepted-evidence set
+    membership.
+34. Accepted-evidence set membership is not accepted evidence unless
+    separately reviewed.
+35. Accepted evidence is not evidence item acceptance unless separately
+    reviewed.
+36. Validator output is not accepted evidence.
+37. Receipt evidence is not accepted evidence.
+38. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-23 concrete accepted-evidence set membership
+assignment post-sync membership assignment
+**Architecture status:** Local draft post-sync membership assignment /
+pending separate reviewed publication
+**Authority notice:** This signature identifies the architectural
+authorship of this assignment. If separately reviewed and published, it
+grants only the bounded post-sync membership assignment boundary defined
+in this assignment. It grants no accepted-evidence set membership
+authority, no accepted evidence status, no evidence item acceptance
+authority, no validator output acceptance authority, no receipt evidence
+acceptance authority, no runtime implementation procedure authority, no
+source modification authority, no code implementation authority, no code
+execution authority, no process start authority, no general runtime
+authority, no unbounded execution authority, no runtime state authority,
+no package installation authority, no package loading authority, no
+package execution authority, no source merge authority, no trust
+authority, no registry authority, no distribution authority, no
+publication authority, no capability issuance authority, no deployment
+authority, no module authority, no plugin authority, no Semantic CLI
+authority, no AI Runtime authority, no agent authority, no kernel ABI
+authority, no syscall authority, no workflow-threshold authority, no
+baseline authority, no dependency authority, or Ring0 authority.
+
+## Conclusion
+
+This Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment is based on the clean-fixed Phase-23
+concrete accepted-evidence set membership assignment post-sync membership
+assignment record publication subject:
+
+```text
+00f514e4cdb8decb64b9222fee24ab4a41cacf23
+```
+
+It records only the bounded post-sync membership assignment boundary.
+
+It does not create accepted-evidence set membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, capability issuance, registry publication, trust assignment,
+deployment, distribution, source acceptance, source merge, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Any later Phase-23 accepted-evidence-set membership, accepted-evidence,
+evidence-item-acceptance, validator-output-acceptance,
+receipt-evidence-acceptance, package-review, source-review,
+runtime-implementation-procedure, or non-authorization boundary record
+requires its own exact-SHA evidence, changed-file scope,
+non-authorization boundary, and reviewed decision path.


### PR DESCRIPTION
This PR changes only PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT.md and records only a governance-only bounded post-sync membership assignment boundary after the clean-fixed post-sync membership assignment record boundary at 00f514e4cdb8decb64b9222fee24ab4a41cacf23. It does not create accepted-evidence set membership, create accepted evidence, accept any evidence item, accept validator output, accept receipt evidence, or authorize runtime/source/package/source-merge/capability/registry/trust/deployment/distribution/kernel ABI/syscall/workflow-threshold/baseline/dependency/Ring0 authority.