### PR TITLE
Phase-23 concrete accepted-evidence set membership assignment post-sync accepted-evidence set membership record

### DIFF
--- a/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_RECORD.md
+++ b/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_RECORD.md
@@ -1,0 +1,989 @@
+# Phase-23 Concrete Accepted-Evidence Set Membership Assignment Post-Sync Accepted-Evidence Set Membership Record
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY_CLEAN_RECOVERY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_FIRST_BOUNDED_IMPLEMENTATION.md`,
+`PHASE22_CLOSURE_DECISION.md`,
+`PHASE23_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE23_POINTER_TRANSITION_DECISION.md`,
+`docs/roadmap/CURRENT_PHASE`,
+`PHASE23_GOVERNANCE_OVERVIEW.md`,
+`PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`,
+`PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`,
+`PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_CANDIDATE.md`,
+and
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`.
+In case of conflict, those documents prevail unless this document is the
+narrower Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record for the exact
+governance-only bounded post-sync accepted-evidence-set-membership
+record boundary identified below.
+
+**Status:** PHASE-23 CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT
+POST-SYNC ACCEPTED-EVIDENCE SET MEMBERSHIP RECORD / LOCAL DRAFT /
+GOVERNANCE-ONLY POST-SYNC ACCEPTED-EVIDENCE SET MEMBERSHIP RECORD ONLY /
+BOUNDED POST-SYNC ACCEPTED-EVIDENCE SET MEMBERSHIP RECORD BOUNDARY ONLY /
+NO ACCEPTED-EVIDENCE SET MEMBERSHIP / NO ACCEPTED EVIDENCE / NO EVIDENCE
+ITEM ACCEPTANCE / NO VALIDATOR OUTPUT ACCEPTANCE / NO RECEIPT EVIDENCE
+ACCEPTANCE / NO RUNTIME IMPLEMENTATION PROCEDURE / NO SOURCE
+MODIFICATION / NO CODE IMPLEMENTATION / NO CODE EXECUTION / NO PROCESS
+START / NO RUNTIME STATE CREATION / NO PACKAGE INSTALLATION / NO PACKAGE
+LOADING / NO PACKAGE EXECUTION / NO DEPLOYMENT / NO CAPABILITY ISSUANCE
+/ NO TRUST ASSIGNMENT / NO REGISTRY PUBLICATION / NO DISTRIBUTION
+AUTHORITY / NO SOURCE ACCEPTANCE / NO SOURCE MERGE AUTHORITY / NO KERNEL
+ABI EXPANSION / NO SYSCALL EXPANSION / NO WORKFLOW-THRESHOLD CHANGE / NO
+BASELINE CHANGE / NO DEPENDENCY CHANGE / NO RING0 AUTHORITY
+**Record date:** 2026-07-28
+**Record id:**
+`ayken.phase23.concrete_accepted_evidence_set_membership_assignment_post_sync_accepted_evidence_set_membership_record.v1`
+**Record drafting base main SHA:**
+`854bdb5534fd67f17973170f3483b62f99c58593`
+**Record publication subject:** pending separate reviewed publication
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision publication subject:**
+`854bdb5534fd67f17973170f3483b62f99c58593`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision PR:** PR #302
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision exact-main ci-freeze run:**
+`30303069537`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision exact-main ci-freeze
+attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision exact-main ci-freeze
+job:** `freeze / 90100498572`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision exact-main ci-freeze
+result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision exact-main Dev Loop
+Validation run:** `30303069623`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision exact-main Dev Loop
+Validation attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision exact-main Dev Loop
+Validation job:** `devloop / 90100498640`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision exact-main Dev Loop
+Validation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision exact-main Dev Loop CI
+run:** `30303069558`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision exact-main Dev Loop CI
+attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision exact-main Dev Loop CI
+result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision exact-main smoke job:**
+`smoke / 90100498602`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision exact-main smoke
+result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision exact-main contract job:**
+`contract / 90100770739`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision exact-main contract
+result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision exact-main full job:**
+`full / 90101409252`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision exact-main full
+result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision exact-main isolation
+job:** `isolation / 90102024208`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision exact-main isolation
+result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision exact-main performance
+job:** `performance / 90102652989`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision exact-main performance
+result:** PASS
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision publication subject:**
+`854bdb5534fd67f17973170f3483b62f99c58593`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership candidate publication subject:**
+`ff56acc274da72f28d88671d19eb5c49b699e091`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment publication subject:**
+`1826977742dcbdf16f21d4a0a921f8fb72cfdeb3`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment record publication subject:**
+`00f514e4cdb8decb64b9222fee24ab4a41cacf23`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment decision publication subject:**
+`14af9f7f529d90b62dfe11f3b6efaa238e0de850`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync concrete assignment publication subject:**
+`3af79c98e8af6d19cead148ccb276cf0d19cdf36`
+**Current phase pointer:** `CURRENT_PHASE=23`
+**Record theme:** Governance-only bounded post-sync accepted-evidence set
+membership record boundary after the clean-fixed post-sync
+accepted-evidence set membership decision boundary at
+`854bdb5534fd67f17973170f3483b62f99c58593`.
+**Authority boundary:** Post-sync accepted-evidence set membership record
+boundary only; not accepted-evidence set membership, not an
+accepted-evidence set, not accepted evidence, not evidence item
+acceptance, not validator output acceptance, not receipt evidence
+acceptance, not runtime implementation procedure, not source
+modification, not code implementation, not code execution, not process
+start, not runtime state creation, not general runtime authority, not
+unbounded execution authority, not package authority, not package
+installation, not package loading, not package execution, not source
+acceptance, not source merge authority, not source repository authority,
+not module loading, not workspace runtime, not plugin loading, not
+capability token minting, not capability issuance, not trust assignment,
+not trust issuer authority, not registry authority, not registry
+publication, not publication authority, not deployment authority, not
+distribution authority, not distribution execution, not Semantic CLI
+authority, not AI Runtime authority, not agent authority, not syscall
+expansion, not kernel ABI expansion, not workflow-threshold, baseline,
+dependency, or Ring0 authority.
+
+## Purpose
+
+This document records only a bounded post-sync accepted-evidence set
+membership record boundary after the clean-fixed Phase-23 concrete
+accepted-evidence set membership assignment post-sync accepted-evidence
+set membership decision at:
+
+```text
+854bdb5534fd67f17973170f3483b62f99c58593
+```
+
+It evaluates only:
+
+```text
+May a bounded post-sync accepted-evidence set membership record boundary
+be recorded after the clean-fixed post-sync accepted-evidence set
+membership decision boundary at
+854bdb5534fd67f17973170f3483b62f99c58593 without creating
+accepted-evidence set membership, creating accepted evidence, accepting
+any evidence item, accepting validator output, or accepting receipt
+evidence?
+```
+
+It records only the bounded post-sync accepted-evidence set membership
+record boundary as a governance record boundary.
+
+This record is not accepted-evidence set membership.
+
+This record does not create accepted-evidence set membership.
+
+This record does not create an accepted-evidence set.
+
+This record does not create accepted evidence.
+
+This record does not accept any evidence item.
+
+This record does not accept validator output.
+
+This record does not accept receipt evidence.
+
+It does not convert CI PASS results, receipts, validator output, package
+review output, source review output, historical results, clean-fixed
+claims, post-sync membership-assignment claims, accepted-evidence set
+membership candidate claims, or accepted-evidence set membership
+decision claims into accepted-evidence set membership, accepted
+evidence, evidence item acceptance, validator output acceptance, or
+receipt evidence acceptance.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, source acceptance, source merge, registry publication, trust
+assignment, capability issuance, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+It does not answer:
+
+```text
+Which accepted-evidence set membership exists?
+Which evidence is accepted?
+Which evidence item is accepted?
+How is validator output accepted?
+How is receipt evidence accepted?
+How is runtime implementation procedure defined?
+How is source modified?
+How is code implemented or executed?
+How is a process started?
+How is runtime state created?
+How is a package installed, loaded, executed, deployed, or distributed?
+How is source accepted or merged?
+How is a capability issued?
+How is trust assigned?
+How is a registry entry published?
+How is kernel ABI or syscall surface expanded?
+How are workflow thresholds, baselines, or dependencies changed?
+```
+
+Those questions require later reviewed decision or record paths, if ever
+authorized.
+
+## Exact Subject
+
+This record draft is based on exact main SHA:
+
+```text
+854bdb5534fd67f17973170f3483b62f99c58593
+```
+
+That subject is the squash merge of PR #302:
+
+```text
+Phase-23 concrete accepted-evidence set membership assignment post-sync accepted-evidence set membership decision
+```
+
+PR #302 changed only:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md
+```
+
+PR #302 produced post-merge exact-main verification:
+
+| Evidence | Run / job | Result |
+|---|---|---|
+| `ci-freeze` | run `30303069537`, attempt 1, job `freeze / 90100498572` | PASS |
+| Dev Loop Validation | run `30303069623`, attempt 1, job `devloop / 90100498640` | PASS |
+| AykenOS Dev Loop CI | run `30303069558`, attempt 1 | PASS |
+| smoke | job `90100498602` | PASS |
+| contract | job `90100770739` | PASS |
+| full | job `90101409252` | PASS |
+| isolation | job `90102024208` | PASS |
+| performance | job `90102652989` | PASS |
+
+The Phase-23 Concrete Accepted-Evidence Set Membership Assignment
+Post-Sync Accepted-Evidence Set Membership Decision boundary remains
+bound to:
+
+```text
+854bdb5534fd67f17973170f3483b62f99c58593
+```
+
+That decision opened only a bounded post-sync accepted-evidence set
+membership decision boundary. It did not create accepted-evidence set
+membership, create accepted evidence, accept evidence items, accept
+validator output, accept receipt evidence, or grant runtime, source,
+package, source-merge, capability, registry, trust, deployment,
+distribution, kernel ABI, syscall, workflow-threshold, baseline,
+dependency, or Ring0 authority.
+
+This record consumes that exact subject as governance input only. It
+does not replace, broaden, reinterpret, or supersede the post-sync
+accepted-evidence set membership decision boundary or any earlier
+Phase-23 governance boundary.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped subject readings fail closed.
+
+## Core Rule
+
+```text
+post-sync accepted-evidence set membership record == bounded post-sync accepted-evidence set membership record boundary only
+post-sync accepted-evidence set membership record != accepted-evidence set membership
+post-sync accepted-evidence set membership record != accepted-evidence set
+post-sync accepted-evidence set membership record != accepted evidence
+post-sync accepted-evidence set membership record != evidence item acceptance
+post-sync accepted-evidence set membership record != validator output acceptance
+post-sync accepted-evidence set membership record != receipt evidence acceptance
+post-sync accepted-evidence set membership record != runtime implementation procedure
+post-sync accepted-evidence set membership record != source modification
+post-sync accepted-evidence set membership record != package loading
+post-sync accepted-evidence set membership record != package execution
+post-sync accepted-evidence set membership record != source merge authority
+bounded post-sync accepted-evidence set membership record boundary != accepted-evidence set membership
+bounded post-sync accepted-evidence set membership record boundary != accepted evidence
+bounded post-sync accepted-evidence set membership record boundary != evidence item acceptance
+post-sync accepted-evidence set membership decision clean-fixed != post-sync accepted-evidence set membership record
+post-sync accepted-evidence set membership decision != post-sync accepted-evidence set membership record unless separately reviewed
+post-sync accepted-evidence set membership decision != accepted-evidence set membership
+post-sync accepted-evidence set membership record clean-fixed != accepted-evidence set membership
+accepted-evidence set membership record publication != accepted-evidence set membership
+accepted-evidence set membership record != accepted-evidence set membership unless a later separate reviewed accepted-evidence set membership path grants that narrower authority
+accepted-evidence set membership decision != accepted-evidence set membership unless separately reviewed
+accepted-evidence set membership candidate != accepted-evidence set membership unless separately reviewed
+membership assignment boundary != accepted-evidence set membership
+membership assignment != accepted-evidence set membership unless separately reviewed
+accepted-evidence set membership != accepted evidence unless separately reviewed
+accepted evidence != evidence item acceptance unless separately reviewed
+accepted evidence != validator output unless separately reviewed
+accepted evidence != receipt evidence unless separately reviewed
+validator output != accepted evidence
+receipt evidence != accepted evidence
+receipt evidence != validator output
+CI PASS != post-sync accepted-evidence set membership record
+CI PASS != accepted-evidence set membership
+CI PASS != accepted evidence
+ci-freeze PASS != post-sync accepted-evidence set membership record
+ci-freeze PASS != accepted-evidence set membership
+ci-freeze PASS != accepted evidence
+Dev Loop PASS != post-sync accepted-evidence set membership record
+Dev Loop PASS != accepted-evidence set membership
+AykenOS Dev Loop CI PASS != post-sync accepted-evidence set membership record
+AykenOS Dev Loop CI PASS != accepted-evidence set membership
+post-merge exact-main verification != accepted-evidence set membership
+post-merge exact-main verification != accepted evidence
+clean-fixed != accepted-evidence set membership
+clean-fixed != accepted evidence
+publication-status sync != accepted-evidence set membership
+publication-status sync != accepted evidence
+CURRENT_PHASE=23 != post-sync accepted-evidence set membership record
+CURRENT_PHASE=23 != accepted-evidence set membership
+CURRENT_PHASE=23 != accepted evidence
+CURRENT_PHASE=23 != evidence item acceptance
+CURRENT_PHASE=23 != validator output acceptance
+CURRENT_PHASE=23 != receipt evidence acceptance
+CURRENT_PHASE=23 != runtime implementation procedure
+CURRENT_PHASE=23 != source modification
+CURRENT_PHASE=23 != execution authority
+CURRENT_PHASE=23 != package loading
+CURRENT_PHASE=23 != source merge authority
+CURRENT_PHASE=23 != kernel ABI expansion
+CURRENT_PHASE=23 != syscall expansion
+historical PASS != inherited evidence
+previous PR evidence != later PR evidence
+```
+
+The safe default remains no accepted-evidence set membership, no
+accepted evidence, no evidence item acceptance, no validator output
+acceptance, no receipt evidence acceptance, no runtime behavior, no
+implementation procedure, no source modification, no code execution, no
+runtime state, and no package, capability, registry, trust,
+distribution, deployment, source acceptance, source merge, kernel ABI,
+syscall, workflow-threshold, baseline, dependency, or Ring0 authority
+unless a later reviewed Phase-23 decision or record grants a specific
+bounded authority with its own exact-SHA evidence.
+
+Unknown authority readings fail closed.
+
+## Post-Sync Accepted-Evidence Set Membership Record Boundary
+
+The Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record is recorded only as:
+
+```text
+bounded post-sync accepted-evidence set membership record boundary
+```
+
+This record boundary may be used only to evaluate whether a later
+separate reviewed accepted-evidence set membership path, accepted
+evidence path, or evidence item acceptance path may be proposed, without
+creating accepted-evidence set membership, accepted evidence, evidence
+item acceptance, validator output acceptance, receipt evidence
+acceptance, or related authority.
+
+This record boundary does not create accepted-evidence set membership.
+
+This record boundary does not create an accepted-evidence set.
+
+This record boundary does not create accepted evidence.
+
+This record boundary does not accept any evidence item.
+
+This record boundary does not accept validator output.
+
+This record boundary does not accept receipt evidence.
+
+This record boundary does not authorize package loading.
+
+This record boundary does not authorize source acceptance or source
+merge.
+
+This record boundary does not authorize runtime implementation
+procedure, code execution, process start, runtime state creation,
+capability issuance, registry publication, trust assignment, deployment,
+distribution, kernel ABI expansion, syscall expansion,
+workflow-threshold changes, baseline changes, dependency changes, or
+Ring0 authority.
+
+Any later accepted-evidence set membership, accepted evidence, evidence
+item acceptance, validator output acceptance, or receipt evidence
+acceptance requires a separate reviewed decision or record path with its
+own exact subject, changed-file scope, non-authorization boundary, and
+post-merge exact-main verification.
+
+## Record Scope
+
+This record scope is limited to:
+
+1. Recording the Phase-23 post-sync accepted-evidence set membership
+   record boundary only as a bounded governance record boundary.
+2. Binding this record to PR #302 as the clean-fixed post-sync
+   accepted-evidence set membership decision boundary input.
+3. Preserving the distinction between accepted-evidence set membership
+   record and accepted-evidence set membership.
+4. Preserving the distinction between membership assignment and
+   accepted-evidence set membership.
+5. Preserving the distinction between accepted-evidence set membership
+   and accepted evidence.
+6. Preserving the distinction between accepted evidence and evidence
+   item acceptance.
+7. Preserving separation from validator output acceptance and receipt
+   evidence acceptance.
+8. Establishing post-merge exact-main verification expectations for this
+   record.
+
+Record scope is governance text only.
+
+Record scope is bounded post-sync accepted-evidence set membership
+record boundary only.
+
+Record scope is not accepted-evidence set membership.
+
+Record scope is not accepted evidence.
+
+Record scope is not evidence item acceptance.
+
+Record scope is not validator output acceptance.
+
+Record scope is not receipt evidence acceptance.
+
+Record scope is not runtime implementation procedure.
+
+Record scope is not package loading authority.
+
+Record scope is not execution authority.
+
+Record scope is not source merge authority.
+
+## Current Phase Pointer Boundary
+
+The current phase pointer remains:
+
+```text
+CURRENT_PHASE=23
+```
+
+This record does not modify:
+
+```text
+docs/roadmap/CURRENT_PHASE
+```
+
+This record does not change the active phase pointer.
+
+`CURRENT_PHASE=23` does not authorize accepted-evidence set membership,
+accepted evidence, evidence item acceptance, validator output
+acceptance, receipt evidence acceptance, runtime implementation
+procedure, source modification, code implementation, code execution,
+process start, runtime state creation, package loading, package
+execution, capability issuance, registry publication, trust assignment,
+deployment, distribution, source acceptance, source merge, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+## Post-Sync Accepted-Evidence Set Membership Decision Input
+
+This record consumes the clean-fixed Phase-23 Concrete Accepted-Evidence
+Set Membership Assignment Post-Sync Accepted-Evidence Set Membership
+Decision boundary as its exact governance prerequisite.
+
+The post-sync accepted-evidence set membership decision boundary remains
+bound to:
+
+```text
+854bdb5534fd67f17973170f3483b62f99c58593
+```
+
+The post-sync accepted-evidence set membership decision boundary
+recorded only a bounded post-sync accepted-evidence set membership
+decision boundary.
+
+This record does not reinterpret the post-sync accepted-evidence set
+membership decision boundary as accepted-evidence set membership,
+accepted evidence, evidence item acceptance, validator output
+acceptance, receipt evidence acceptance, runtime implementation
+procedure, execution authority, package loading authority, source
+acceptance, source merge authority, capability issuance, registry
+publication, trust assignment, deployment, distribution, kernel ABI
+expansion, syscall expansion, workflow-threshold change, baseline
+change, dependency change, or Ring0 authority.
+
+Any post-sync accepted-evidence set membership decision boundary
+conflict fails closed.
+
+## Relationship To Membership Assignment
+
+This record is downstream of the clean-fixed bounded post-sync
+membership assignment boundary.
+
+That prior membership assignment boundary is not accepted-evidence set
+membership.
+
+This record does not broaden the prior membership assignment boundary.
+
+This record does not convert membership assignment into accepted-evidence
+set membership.
+
+Any attempt to use this record to infer accepted-evidence set membership
+from membership assignment fails closed.
+
+## Relationship To Accepted-Evidence Set Membership
+
+This record records only a bounded governance record boundary for
+whether a later accepted-evidence set membership path may be proposed.
+
+This record does not create accepted-evidence set membership.
+
+This record does not define accepted-evidence set membership.
+
+This record does not make accepted-evidence set membership inevitable.
+
+Any attempt to treat this record as accepted-evidence set membership
+fails closed.
+
+## Relationship To Accepted Evidence And Evidence Item Acceptance
+
+Accepted-evidence set membership remains separate from accepted evidence
+unless a separate reviewed decision or record explicitly grants that
+narrower authority.
+
+This record does not create accepted evidence.
+
+This record does not identify accepted evidence.
+
+This record does not accept any evidence item.
+
+This record does not define accepted-evidence membership.
+
+This record does not define accepted-evidence set membership.
+
+This record does not make accepted evidence inevitable.
+
+Any attempt to treat this record as accepted evidence or evidence item
+acceptance fails closed.
+
+## Relationship To Validator Output And Receipt Evidence
+
+This record does not convert validator output into accepted evidence.
+
+This record does not convert receipt evidence into accepted evidence.
+
+This record does not accept validator output.
+
+This record does not accept receipt evidence.
+
+This record does not grant accepted-evidence membership over validator
+output, receipt evidence, package review output, source review output,
+historical PASS results, or clean-fixed claims.
+
+Any validator-output or receipt-evidence boundary conflict fails closed.
+
+## Relationship To Phase-19 Runtime Authority
+
+This record remains subordinate to Phase-19 runtime authority records.
+
+This record must not broaden, replace, supersede, weaken, or reinterpret
+Phase-19 runtime authority records.
+
+This record must not use post-sync accepted-evidence set membership
+record status to infer runtime authority.
+
+This record must not use membership assignment, accepted-evidence set
+membership, accepted-evidence authority, accepted evidence,
+validator-output planning, receipt-evidence planning, exact-SHA evidence
+expectations, or `CURRENT_PHASE=23` to infer runtime authority.
+
+Any Phase-23 post-sync accepted-evidence set membership record reading
+that conflicts with Phase-19 runtime authority records fails closed.
+
+## Not Authorized By This Record
+
+This record does not authorize:
+
+1. Accepted-evidence set membership.
+2. Accepted-evidence set creation.
+3. Accepted evidence.
+4. Evidence item acceptance.
+5. Validator output acceptance.
+6. Receipt evidence acceptance.
+7. Runtime implementation procedure.
+8. Source modification.
+9. Source acceptance.
+10. Source merge.
+11. Code implementation.
+12. Code execution.
+13. Process start.
+14. Runtime state creation.
+15. Package installation.
+16. Package loading.
+17. Package execution.
+18. Module loading.
+19. Workspace runtime or real mounts.
+20. Plugin loading or plugin instantiation.
+21. Capability token minting.
+22. Capability issuance.
+23. Registry publication.
+24. Trust assignment.
+25. Distribution execution.
+26. Deployment.
+27. Semantic CLI authority.
+28. AI Runtime authority.
+29. Agent authority.
+30. Syscall expansion.
+31. Kernel ABI expansion.
+32. Ring0 policy movement.
+33. Workflow-threshold changes.
+34. Baseline changes.
+35. Dependency changes.
+36. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this record is published, the publication may change only this file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_RECORD.md
+```
+
+The publication must not change:
+
+1. `docs/roadmap/CURRENT_PHASE`.
+2. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`.
+3. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_CANDIDATE.md`.
+4. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT.md`.
+5. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+6. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+7. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+8. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT.md`.
+9. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_RECORD.md`.
+10. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md`.
+11. CI workflows.
+12. Baselines.
+13. Dependencies.
+14. Runtime source or kernel source.
+15. Syscalls or kernel ABI.
+16. Package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment,
+    or distribution execution paths.
+17. `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md`.
+
+Any changed-file expansion beyond this record requires separate review
+and fails this record scope.
+
+## Post-Merge Exact-Main Evidence Rule
+
+If this record is later published, the record publication subject must
+receive its own post-merge exact-main verification:
+
+1. `ci-freeze` PASS for the exact record publication SHA.
+2. Dev Loop Validation PASS for the exact record publication SHA.
+3. AykenOS Dev Loop CI PASS for the exact record publication SHA.
+4. smoke PASS.
+5. contract PASS.
+6. full PASS.
+7. isolation PASS.
+8. performance PASS.
+9. Exact changed-file list confirmation.
+10. No `docs/roadmap/CURRENT_PHASE` change.
+11. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`
+    change.
+12. No accepted-evidence set membership, accepted evidence, evidence
+    item acceptance, validator output acceptance, or receipt evidence
+    acceptance.
+13. No CI workflow change.
+14. No baseline change.
+15. No dependency change.
+16. No runtime source or kernel source change.
+17. No syscall or kernel ABI change.
+18. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment,
+    or distribution execution change.
+
+Until that exact-main post-merge verification exists, this record must
+not be recorded as clean-fixed.
+
+Historical PASS results may be cited as context only.
+
+Failed attempts may be cited as transparent non-clean context only.
+
+They cannot be inherited as accepted-evidence set membership, accepted
+evidence, evidence item acceptance, validator output acceptance, receipt
+evidence acceptance, runtime authority, package loading authority,
+package execution authority, source merge authority, capability
+authority, registry authority, trust authority, kernel ABI authority,
+syscall authority, workflow-threshold authority, baseline authority,
+dependency authority, or Ring0 authority.
+
+## Later Accepted-Evidence Set Membership Dependency
+
+This record is a prerequisite input for a possible later bounded
+accepted-evidence set membership path.
+
+A later accepted-evidence set membership, if ever proposed, must define:
+
+1. Exact accepted-evidence set membership subject.
+2. Exact Phase-23 post-sync accepted-evidence set membership record
+   prerequisite.
+3. Exact Phase-23 post-sync accepted-evidence set membership decision
+   prerequisite.
+4. Exact Phase-23 post-sync membership assignment prerequisite.
+5. Exact changed-file boundary.
+6. Exact evidence item reference proposed for accepted-evidence set
+   membership, if any, without evidence item acceptance unless
+   separately reviewed.
+7. Exact accepted-evidence set membership grant, denial, or separate
+   membership scope.
+8. Exact accepted-evidence denial or separate accepted-evidence scope.
+9. Exact evidence item acceptance denial or separate evidence item
+   acceptance scope.
+10. Exact validator-output acceptance denial or separate
+    validator-output acceptance scope.
+11. Exact receipt-evidence acceptance denial or separate receipt-evidence
+    acceptance scope.
+12. Exact runtime implementation procedure denial.
+13. Exact package loading and package execution denials.
+14. Exact source acceptance and source merge denials.
+15. Exact capability, registry, trust, deployment, distribution, kernel
+    ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+    denials.
+16. Exact post-merge verification requirements.
+
+Until such a later reviewed accepted-evidence set membership path is
+published, no accepted-evidence set membership exists from this record.
+
+Until such a later reviewed accepted-evidence record is published, no
+accepted evidence exists from this record.
+
+Until such a later reviewed evidence item acceptance record is published,
+no evidence item acceptance exists from this record.
+
+Until such a later reviewed validator-output acceptance record is
+published, no validator output acceptance exists from this record.
+
+Until such a later reviewed receipt-evidence acceptance record is
+published, no receipt evidence acceptance exists from this record.
+
+## Excluded Local Draft
+
+This record does not consume:
+
+```text
+PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md
+```
+
+If that file exists locally as an untracked file, it remains:
+
+```text
+untracked
+PR-disjoint
+not record input
+not accepted-evidence set membership input
+not accepted evidence
+not evidence item acceptance
+not validator output
+not receipt evidence
+not runtime authority
+not package acceptance
+not source authority
+```
+
+It must not be staged, committed, or included in any Phase-23 post-sync
+accepted-evidence set membership record PR unless a separate reviewed
+scope explicitly authorizes that file.
+
+## Governance Boundary Invariants
+
+Every later RFC must preserve these Phase-23 post-sync accepted-evidence
+set membership record invariants:
+
+1. This record is bounded post-sync accepted-evidence set membership
+   record boundary only.
+2. This record is not accepted-evidence set membership.
+3. This record is not an accepted-evidence set.
+4. This record is not accepted evidence.
+5. This record is not evidence item acceptance.
+6. This record is not validator output acceptance.
+7. This record is not receipt evidence acceptance.
+8. Accepted-evidence set membership record publication is not
+   accepted-evidence set membership.
+9. Accepted-evidence set membership decision is not accepted-evidence
+   set membership unless separately reviewed.
+10. Membership assignment boundary is not accepted-evidence set
+    membership.
+11. Membership assignment is not accepted-evidence set membership unless
+    separately reviewed.
+12. Accepted-evidence set membership is not accepted evidence unless
+    separately reviewed.
+13. Accepted evidence is not evidence item acceptance unless separately
+    reviewed.
+14. Validator output is not accepted evidence.
+15. Receipt evidence is not accepted evidence.
+16. This record is not runtime implementation procedure.
+17. This record is not source modification.
+18. This record is not code implementation.
+19. This record is not code execution.
+20. This record is not process start.
+21. This record is not runtime state creation.
+22. This record is not package installation.
+23. This record is not package loading.
+24. This record is not package execution.
+25. This record is not capability issuance.
+26. This record is not registry publication.
+27. This record is not trust assignment.
+28. This record is not deployment.
+29. This record is not distribution authority.
+30. This record is not source acceptance.
+31. This record is not source merge authority.
+32. This record does not modify `docs/roadmap/CURRENT_PHASE`.
+33. This record does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`.
+34. This record does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_CANDIDATE.md`.
+35. This record does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT.md`.
+36. `CURRENT_PHASE=23` is not post-sync accepted-evidence set
+    membership record.
+37. `CURRENT_PHASE=23` is not accepted-evidence set membership.
+38. `CURRENT_PHASE=23` is not accepted evidence.
+39. `CURRENT_PHASE=23` is not evidence item acceptance.
+40. `CURRENT_PHASE=23` is not validator output acceptance.
+41. `CURRENT_PHASE=23` is not receipt evidence acceptance.
+42. `CURRENT_PHASE=23` is not runtime implementation procedure.
+43. `CURRENT_PHASE=23` is not source modification.
+44. `CURRENT_PHASE=23` is not execution authority.
+45. `CURRENT_PHASE=23` is not package loading.
+46. `CURRENT_PHASE=23` is not source merge authority.
+47. This record does not broaden Phase-19 runtime authority.
+48. This record does not reopen Phase-20.
+49. This record does not reopen Phase-21.
+50. This record does not reopen Phase-22.
+51. This record does not expand kernel ABI or syscalls.
+52. This record does not change workflow thresholds, baselines, or
+    dependencies.
+53. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-23 concrete accepted-evidence set membership
+assignment post-sync accepted-evidence set membership record
+**Architecture status:** Local draft post-sync accepted-evidence set
+membership record / pending separate reviewed publication
+**Authority notice:** This signature identifies the architectural
+authorship of this record. If separately reviewed and published, this
+record grants only the bounded post-sync accepted-evidence set
+membership record boundary defined in this record. It grants no
+accepted-evidence set membership authority, no accepted evidence status,
+no evidence item acceptance authority, no validator output acceptance
+authority, no receipt evidence acceptance authority, no runtime
+implementation procedure authority, no source modification authority, no
+code implementation authority, no code execution authority, no process
+start authority, no general runtime authority, no unbounded execution
+authority, no runtime state authority, no package installation
+authority, no package loading authority, no package execution authority,
+no source merge authority, no trust authority, no registry authority, no
+distribution authority, no publication authority, no capability issuance
+authority, no deployment authority, no module authority, no plugin
+authority, no Semantic CLI authority, no AI Runtime authority, no agent
+authority, no kernel ABI authority, no syscall authority, no
+workflow-threshold authority, no baseline authority, no dependency
+authority, or Ring0 authority.
+
+## Conclusion
+
+This Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record is based on the
+clean-fixed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision publication subject:
+
+```text
+854bdb5534fd67f17973170f3483b62f99c58593
+```
+
+It records only the bounded post-sync accepted-evidence set membership
+record boundary.
+
+It does not create accepted-evidence set membership.
+
+It does not create accepted evidence.
+
+It does not accept any evidence item.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, capability issuance, registry publication, trust assignment,
+deployment, distribution, source acceptance, source merge, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Any later Phase-23 accepted-evidence-set membership, accepted-evidence,
+evidence-item-acceptance, validator-output-acceptance,
+receipt-evidence-acceptance, package-review, source-review,
+runtime-implementation-procedure, or non-authorization boundary record
+requires its own exact-SHA evidence, changed-file scope,
+non-authorization boundary, and reviewed decision path.


### PR DESCRIPTION
This PR changes only PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_RECORD.md and records only a governance-only bounded post-sync accepted-evidence set membership record boundary after the clean-fixed post-sync accepted-evidence set membership decision boundary at 854bdb5534fd67f17973170f3483b62f99c58593. It does not create accepted-evidence set membership, create accepted evidence, accept any evidence item, accept validator output, accept receipt evidence, or authorize runtime/source/package/source-merge/capability/registry/trust/deployment/distribution/kernel ABI/syscall/workflow-threshold/baseline/dependency/Ring0 authority.