### PR TITLE
Phase-23 concrete accepted-evidence set membership assignment post-sync accepted-evidence set membership

### DIFF
--- a/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP.md
+++ b/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP.md
@@ -1,0 +1,695 @@
+# Phase-23 Concrete Accepted-Evidence Set Membership Assignment Post-Sync Accepted-Evidence Set Membership
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY_CLEAN_RECOVERY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_FIRST_BOUNDED_IMPLEMENTATION.md`,
+`PHASE22_CLOSURE_DECISION.md`,
+`PHASE23_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE23_POINTER_TRANSITION_DECISION.md`,
+`docs/roadmap/CURRENT_PHASE`,
+`PHASE23_GOVERNANCE_OVERVIEW.md`,
+`PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`,
+`PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`,
+`PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+and
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_RECORD.md`.
+In case of conflict, those documents prevail unless this document is the
+narrower Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership boundary for the exact
+governance-only bounded post-sync accepted-evidence-set-membership
+boundary identified below.
+
+**Status:** PHASE-23 CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT
+POST-SYNC ACCEPTED-EVIDENCE SET MEMBERSHIP / LOCAL DRAFT /
+GOVERNANCE-ONLY POST-SYNC ACCEPTED-EVIDENCE SET MEMBERSHIP ONLY /
+BOUNDED POST-SYNC ACCEPTED-EVIDENCE SET MEMBERSHIP BOUNDARY ONLY / NO
+ACCEPTED EVIDENCE / NO EVIDENCE ITEM ACCEPTANCE / NO VALIDATOR OUTPUT
+ACCEPTANCE / NO RECEIPT EVIDENCE ACCEPTANCE / NO RUNTIME IMPLEMENTATION
+PROCEDURE / NO SOURCE MODIFICATION / NO CODE IMPLEMENTATION / NO CODE
+EXECUTION / NO PROCESS START / NO RUNTIME STATE CREATION / NO PACKAGE
+INSTALLATION / NO PACKAGE LOADING / NO PACKAGE EXECUTION / NO
+DEPLOYMENT / NO CAPABILITY ISSUANCE / NO TRUST ASSIGNMENT / NO REGISTRY
+PUBLICATION / NO DISTRIBUTION AUTHORITY / NO SOURCE ACCEPTANCE / NO
+SOURCE MERGE AUTHORITY / NO KERNEL ABI EXPANSION / NO SYSCALL EXPANSION
+/ NO WORKFLOW-THRESHOLD CHANGE / NO BASELINE CHANGE / NO DEPENDENCY
+CHANGE / NO RING0 AUTHORITY
+**Membership date:** 2026-07-28
+**Membership id:**
+`ayken.phase23.concrete_accepted_evidence_set_membership_assignment_post_sync_accepted_evidence_set_membership.v1`
+**Membership drafting base main SHA:**
+`278ba1e14229380fa32f2c85de5efb4b59a81a7e`
+**Membership publication subject:** pending separate reviewed publication
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record publication subject:**
+`278ba1e14229380fa32f2c85de5efb4b59a81a7e`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record PR:** PR #303
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record exact-main ci-freeze
+run:** `30306568623`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record exact-main ci-freeze
+attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record exact-main ci-freeze
+job:** `freeze / 90112149365`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record exact-main ci-freeze
+result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record exact-main Dev Loop
+Validation run:** `30306568750`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record exact-main Dev Loop
+Validation attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record exact-main Dev Loop
+Validation job:** `devloop / 90112149689`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record exact-main Dev Loop
+Validation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record exact-main Dev Loop CI
+run:** `30306568604`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record exact-main Dev Loop CI
+attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record exact-main Dev Loop CI
+result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record exact-main smoke job:**
+`smoke / 90112149321`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record exact-main smoke
+result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record exact-main contract
+job:** `contract / 90112451975`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record exact-main contract
+result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record exact-main full job:**
+`full / 90113144572`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record exact-main full
+result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record exact-main isolation
+job:** `isolation / 90113736823`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record exact-main isolation
+result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record exact-main performance
+job:** `performance / 90114336770`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record exact-main performance
+result:** PASS
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record publication subject:**
+`278ba1e14229380fa32f2c85de5efb4b59a81a7e`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision publication subject:**
+`854bdb5534fd67f17973170f3483b62f99c58593`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership candidate publication subject:**
+`ff56acc274da72f28d88671d19eb5c49b699e091`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync membership assignment publication subject:**
+`1826977742dcbdf16f21d4a0a921f8fb72cfdeb3`
+**Current phase pointer:** `CURRENT_PHASE=23`
+**Accepted Phase-23 post-sync accepted-evidence set membership boundary:**
+bounded post-sync accepted-evidence set membership boundary as a
+governance membership boundary only; accepted evidence, evidence item
+acceptance, validator output acceptance, and receipt evidence
+acceptance remain pending separate reviewed records if ever authorized.
+**Authority boundary:** Post-sync accepted-evidence set membership
+boundary only; bounded post-sync accepted-evidence set membership
+boundary only; not accepted evidence, not evidence item acceptance, not
+validator output acceptance, not receipt evidence acceptance, not runtime
+implementation procedure, not source modification, not code
+implementation, not code execution, not process start, not runtime state
+creation, not general runtime authority, not unbounded execution
+authority, not package authority, not package installation, not package
+loading, not package execution, not source acceptance, not source merge
+authority, not source repository authority, not module loading, not
+workspace runtime, not plugin loading, not capability token minting, not
+capability issuance, not trust assignment, not trust issuer authority,
+not registry authority, not registry publication, not publication
+authority, not deployment authority, not distribution authority, not
+distribution execution, not Semantic CLI authority, not AI Runtime
+authority, not agent authority, not syscall expansion, not kernel ABI
+expansion, not workflow-threshold, baseline, dependency, or Ring0
+authority.
+
+## Purpose
+
+This document records only a bounded post-sync accepted-evidence set
+membership boundary after the clean-fixed Phase-23 concrete
+accepted-evidence set membership assignment post-sync accepted-evidence
+set membership record at:
+
+```text
+278ba1e14229380fa32f2c85de5efb4b59a81a7e
+```
+
+It evaluates only:
+
+```text
+May a bounded post-sync accepted-evidence set membership boundary be
+recorded after the clean-fixed post-sync accepted-evidence set membership
+record boundary at 278ba1e14229380fa32f2c85de5efb4b59a81a7e without
+creating accepted evidence, accepting any evidence item, accepting
+validator output, accepting receipt evidence, or authorizing runtime,
+source, package, source-merge, capability, registry, trust, deployment,
+distribution, kernel ABI, syscall, workflow-threshold, baseline,
+dependency, or Ring0 authority?
+```
+
+This document answers only for the bounded membership boundary described
+in this document.
+
+It does not answer for accepted evidence, evidence item acceptance,
+validator output acceptance, receipt evidence acceptance, runtime
+behavior, implementation procedure, source modification, code execution,
+package loading, source merge, capability issuance, registry
+publication, trust assignment, deployment, distribution, kernel ABI,
+syscall, workflow-threshold, baseline, dependency, or Ring0 authority.
+
+## Decision
+
+The bounded post-sync accepted-evidence set membership boundary may be
+recorded after the clean-fixed Phase-23 concrete accepted-evidence set
+membership assignment post-sync accepted-evidence set membership record
+subject:
+
+```text
+278ba1e14229380fa32f2c85de5efb4b59a81a7e
+```
+
+The decision is limited to:
+
+```text
+bounded post-sync accepted-evidence set membership boundary
+```
+
+The decision is not accepted evidence.
+
+The decision is not evidence item acceptance.
+
+The decision is not validator output acceptance.
+
+The decision is not receipt evidence acceptance.
+
+The decision is not runtime, source, package, source-merge, capability,
+registry, trust, deployment, distribution, kernel ABI, syscall,
+workflow-threshold, baseline, dependency, or Ring0 authority.
+
+## Subject Binding
+
+The only base subject for this local draft is:
+
+```text
+278ba1e14229380fa32f2c85de5efb4b59a81a7e
+```
+
+That subject is consumed only as the clean-fixed exact-main publication
+of PR #303:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_RECORD.md
+```
+
+The consumed PR #303 scope was exactly one file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_RECORD.md
+```
+
+The consumed PR #303 post-merge exact-main evidence was:
+
+```text
+ci-freeze: PASS / run 30306568623 / attempt 1 / freeze 90112149365
+Dev Loop Validation: PASS / run 30306568750 / attempt 1 / devloop 90112149689
+AykenOS Dev Loop CI: PASS / run 30306568604 / attempt 1
+smoke: PASS / 90112149321
+contract: PASS / 90112451975
+full: PASS / 90113144572
+isolation: PASS / 90113736823
+performance: PASS / 90114336770
+```
+
+This document consumes that exact subject as governance input only. It
+does not replace, broaden, reinterpret, or supersede the post-sync
+accepted-evidence set membership record boundary or any earlier
+Phase-23 governance boundary.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped subject readings fail closed.
+
+## Core Rule
+
+```text
+post-sync accepted-evidence set membership == bounded post-sync accepted-evidence set membership boundary only
+post-sync accepted-evidence set membership != accepted evidence
+post-sync accepted-evidence set membership != evidence item acceptance
+post-sync accepted-evidence set membership != validator output acceptance
+post-sync accepted-evidence set membership != receipt evidence acceptance
+post-sync accepted-evidence set membership != runtime implementation procedure
+post-sync accepted-evidence set membership != source modification
+post-sync accepted-evidence set membership != package loading
+post-sync accepted-evidence set membership != package execution
+post-sync accepted-evidence set membership != source merge authority
+bounded post-sync accepted-evidence set membership boundary != accepted evidence
+bounded post-sync accepted-evidence set membership boundary != evidence item acceptance
+bounded post-sync accepted-evidence set membership boundary != validator output acceptance
+bounded post-sync accepted-evidence set membership boundary != receipt evidence acceptance
+post-sync accepted-evidence set membership record clean-fixed != post-sync accepted-evidence set membership
+post-sync accepted-evidence set membership record != post-sync accepted-evidence set membership unless separately reviewed
+accepted-evidence set membership record publication != accepted-evidence set membership unless separately reviewed
+accepted-evidence set membership decision != accepted-evidence set membership unless separately reviewed
+accepted-evidence set membership candidate != accepted-evidence set membership unless separately reviewed
+membership assignment boundary != accepted-evidence set membership unless separately reviewed
+membership assignment != accepted-evidence set membership unless separately reviewed
+accepted-evidence set membership != accepted evidence unless separately reviewed
+accepted evidence != evidence item acceptance unless separately reviewed
+accepted evidence != validator output unless separately reviewed
+accepted evidence != receipt evidence unless separately reviewed
+validator output != accepted evidence
+receipt evidence != accepted evidence
+receipt evidence != validator output
+CI PASS != accepted-evidence set membership
+CI PASS != accepted evidence
+ci-freeze PASS != accepted-evidence set membership
+ci-freeze PASS != accepted evidence
+Dev Loop PASS != accepted-evidence set membership
+Dev Loop PASS != accepted evidence
+AykenOS Dev Loop CI PASS != accepted-evidence set membership
+AykenOS Dev Loop CI PASS != accepted evidence
+post-merge exact-main verification != accepted evidence
+clean-fixed != accepted evidence
+publication-status sync != accepted-evidence set membership
+publication-status sync != accepted evidence
+CURRENT_PHASE=23 != accepted evidence
+CURRENT_PHASE=23 != evidence item acceptance
+CURRENT_PHASE=23 != validator output acceptance
+CURRENT_PHASE=23 != receipt evidence acceptance
+CURRENT_PHASE=23 != runtime implementation procedure
+CURRENT_PHASE=23 != source modification
+CURRENT_PHASE=23 != execution authority
+CURRENT_PHASE=23 != package loading
+CURRENT_PHASE=23 != source merge authority
+CURRENT_PHASE=23 != kernel ABI expansion
+CURRENT_PHASE=23 != syscall expansion
+historical PASS != inherited evidence
+previous PR evidence != later PR evidence
+```
+
+The safe default remains no accepted evidence, no evidence item
+acceptance, no validator output acceptance, no receipt evidence
+acceptance, no runtime behavior, no implementation procedure, no source
+modification, no code execution, no runtime state, and no package,
+capability, registry, trust, distribution, deployment, source
+acceptance, source merge, kernel ABI, syscall, workflow-threshold,
+baseline, dependency, or Ring0 authority unless a later reviewed
+Phase-23 decision or record grants a specific bounded authority with its
+own exact-SHA evidence.
+
+Unknown authority readings fail closed.
+
+## Post-Sync Accepted-Evidence Set Membership Boundary
+
+The Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership is recorded only as:
+
+```text
+bounded post-sync accepted-evidence set membership boundary
+```
+
+This means only:
+
+1. The clean-fixed PR #303 accepted-evidence set membership record
+   boundary may be used as the immediate prerequisite for this bounded
+   membership boundary.
+2. The bounded post-sync accepted-evidence set membership boundary may
+   be named as the latest Phase-23 governance boundary in later reviewed
+   accepted-evidence membership or accepted-evidence paths.
+3. Any later accepted evidence, evidence item acceptance, validator
+   output acceptance, receipt evidence acceptance, runtime authority,
+   package authority, source authority, source-merge authority,
+   capability authority, registry authority, trust authority, deployment
+   authority, distribution authority, kernel ABI authority, syscall
+   authority, workflow-threshold authority, baseline authority,
+   dependency authority, or Ring0 authority still requires its own
+   separate reviewed record and its own exact-main evidence.
+
+This document does not create accepted evidence.
+
+This document does not accept an evidence item.
+
+This document does not accept validator output.
+
+This document does not accept receipt evidence.
+
+This document does not authorize source merge, package loading, runtime
+execution, capability issuance, registry publication, trust assignment,
+deployment, distribution, kernel ABI expansion, syscall expansion,
+workflow-threshold change, baseline change, dependency change, or Ring0
+authority.
+
+## Non-Authority Boundary
+
+This document does not authorize:
+
+1. Accepted evidence.
+2. Evidence item acceptance.
+3. Validator output acceptance.
+4. Receipt evidence acceptance.
+5. Runtime implementation procedure.
+6. Source modification.
+7. Code implementation.
+8. Code execution.
+9. Process start.
+10. Runtime state creation.
+11. Package installation.
+12. Package loading.
+13. Package execution.
+14. Source acceptance.
+15. Source merge.
+16. Source repository authority.
+17. Module loading.
+18. Workspace runtime.
+19. Plugin loading.
+20. Capability token minting.
+21. Capability issuance.
+22. Trust assignment.
+23. Trust issuer authority.
+24. Registry authority.
+25. Registry publication.
+26. Publication authority beyond this document.
+27. Deployment authority.
+28. Distribution authority.
+29. Distribution execution.
+30. Semantic CLI authority.
+31. AI Runtime authority.
+32. Kernel ABI expansion.
+33. Syscall expansion.
+34. Workflow-threshold changes.
+35. Baseline changes.
+36. Dependency changes.
+37. Ring0 authority.
+38. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this membership boundary is published, the publication may change only
+this file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP.md
+```
+
+The publication must not change:
+
+1. `docs/roadmap/CURRENT_PHASE`.
+2. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_RECORD.md`.
+3. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`.
+4. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_CANDIDATE.md`.
+5. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT.md`.
+6. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_RECORD.md`.
+7. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_DECISION.md`.
+8. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`.
+9. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT.md`.
+10. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_RECORD.md`.
+11. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md`.
+12. CI workflows.
+13. Baselines.
+14. Dependencies.
+15. Runtime source or kernel source.
+16. Syscalls or kernel ABI.
+17. Package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment,
+    or distribution execution paths.
+18. `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md`.
+
+Any changed-file expansion beyond this membership boundary requires
+separate review and fails this document scope.
+
+## Post-Merge Exact-Main Evidence Rule
+
+If this membership boundary is later published, the membership
+publication subject must receive its own post-merge exact-main
+verification:
+
+1. `ci-freeze` PASS for the exact membership publication SHA.
+2. Dev Loop Validation PASS for the exact membership publication SHA.
+3. AykenOS Dev Loop CI PASS for the exact membership publication SHA.
+4. smoke PASS.
+5. contract PASS.
+6. full PASS.
+7. isolation PASS.
+8. performance PASS.
+9. Exact changed-file list confirmation.
+10. No `docs/roadmap/CURRENT_PHASE` change.
+11. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_RECORD.md`
+    change.
+12. No accepted evidence, evidence item acceptance, validator output
+    acceptance, or receipt evidence acceptance.
+13. No CI workflow change.
+14. No baseline change.
+15. No dependency change.
+16. No runtime source or kernel source change.
+17. No syscall or kernel ABI change.
+18. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment,
+    or distribution execution change.
+
+Until that exact-main post-merge verification exists, this membership
+boundary must not be recorded as clean-fixed.
+
+Historical PASS results may be cited as context only.
+
+Failed attempts may be cited as transparent non-clean context only.
+
+They cannot be inherited as accepted evidence, evidence item acceptance,
+validator output acceptance, receipt evidence acceptance, runtime
+authority, package loading authority, package execution authority,
+source merge authority, capability authority, registry authority, trust
+authority, kernel ABI authority, syscall authority, workflow-threshold
+authority, baseline authority, dependency authority, or Ring0 authority.
+
+## Later Accepted-Evidence Dependency
+
+This membership boundary is a prerequisite input for a possible later
+bounded accepted-evidence path.
+
+A later accepted-evidence record, if ever proposed, must define:
+
+1. Exact accepted-evidence subject.
+2. Exact Phase-23 post-sync accepted-evidence set membership
+   prerequisite.
+3. Exact Phase-23 post-sync accepted-evidence set membership record
+   prerequisite.
+4. Exact Phase-23 post-sync accepted-evidence set membership decision
+   prerequisite.
+5. Exact changed-file boundary.
+6. Exact evidence item reference proposed for accepted evidence, if any,
+   without evidence item acceptance unless separately reviewed.
+7. Exact accepted-evidence grant, denial, or separate accepted-evidence
+   scope.
+8. Exact evidence item acceptance denial or separate evidence item
+   acceptance scope.
+9. Exact validator-output acceptance denial or separate
+   validator-output acceptance scope.
+10. Exact receipt-evidence acceptance denial or separate receipt-evidence
+    acceptance scope.
+11. Exact runtime implementation procedure denial.
+12. Exact package loading and package execution denials.
+13. Exact source acceptance and source merge denials.
+14. Exact capability, registry, trust, deployment, distribution, kernel
+    ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+    denials.
+15. Exact post-merge verification requirements.
+
+Until such a later reviewed accepted-evidence record is published, no
+accepted evidence exists from this membership boundary.
+
+Until such a later reviewed evidence item acceptance record is published,
+no evidence item acceptance exists from this membership boundary.
+
+Until such a later reviewed validator-output acceptance record is
+published, no validator output acceptance exists from this membership
+boundary.
+
+Until such a later reviewed receipt-evidence acceptance record is
+published, no receipt evidence acceptance exists from this membership
+boundary.
+
+## Excluded Local Draft
+
+This membership boundary does not consume:
+
+```text
+PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md
+```
+
+If that file exists locally as an untracked file, it remains:
+
+```text
+untracked
+PR-disjoint
+not membership input
+not accepted evidence
+not evidence item acceptance
+not validator output
+not receipt evidence
+not runtime authority
+not package acceptance
+not source authority
+```
+
+It must not be staged, committed, or included in any Phase-23 post-sync
+accepted-evidence set membership PR unless a separate reviewed scope
+explicitly authorizes that file.
+
+## Governance Boundary Invariants
+
+Every later RFC must preserve these Phase-23 post-sync accepted-evidence
+set membership invariants:
+
+1. This document is bounded post-sync accepted-evidence set membership
+   boundary only.
+2. This document is not accepted evidence.
+3. This document is not evidence item acceptance.
+4. This document is not validator output acceptance.
+5. This document is not receipt evidence acceptance.
+6. Accepted-evidence set membership is not accepted evidence unless
+   separately reviewed.
+7. Accepted evidence is not evidence item acceptance unless separately
+   reviewed.
+8. Validator output is not accepted evidence.
+9. Receipt evidence is not accepted evidence.
+10. This document is not runtime implementation procedure.
+11. This document is not source modification.
+12. This document is not code implementation.
+13. This document is not code execution.
+14. This document is not process start.
+15. This document is not runtime state creation.
+16. This document is not package installation.
+17. This document is not package loading.
+18. This document is not package execution.
+19. This document is not capability issuance.
+20. This document is not registry publication.
+21. This document is not trust assignment.
+22. This document is not deployment.
+23. This document is not distribution authority.
+24. This document is not source acceptance.
+25. This document is not source merge authority.
+26. This document does not modify `docs/roadmap/CURRENT_PHASE`.
+27. This document does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_RECORD.md`.
+28. This document does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`.
+29. This document does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_CANDIDATE.md`.
+30. `CURRENT_PHASE=23` is not accepted evidence.
+31. `CURRENT_PHASE=23` is not evidence item acceptance.
+32. `CURRENT_PHASE=23` is not validator output acceptance.
+33. `CURRENT_PHASE=23` is not receipt evidence acceptance.
+34. `CURRENT_PHASE=23` is not runtime implementation procedure.
+35. `CURRENT_PHASE=23` is not source modification.
+36. `CURRENT_PHASE=23` is not execution authority.
+37. `CURRENT_PHASE=23` is not package loading.
+38. `CURRENT_PHASE=23` is not source merge authority.
+39. This document does not broaden Phase-19 runtime authority.
+40. This document does not reopen Phase-20.
+41. This document does not reopen Phase-21.
+42. This document does not reopen Phase-22.
+43. This document does not expand kernel ABI or syscalls.
+44. This document does not change workflow thresholds, baselines, or
+    dependencies.
+45. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-23 concrete accepted-evidence set membership
+assignment post-sync accepted-evidence set membership
+**Architecture status:** Local draft post-sync accepted-evidence set
+membership / pending separate reviewed publication
+**Authority notice:** This signature identifies the architectural
+authorship of this membership boundary. If separately reviewed and
+published, this document grants only the bounded post-sync
+accepted-evidence set membership boundary defined in this document. It
+grants no accepted evidence status, no evidence item acceptance
+authority, no validator output acceptance authority, no receipt evidence
+acceptance authority, no runtime implementation procedure authority, no
+source modification authority, no code implementation authority, no code
+execution authority, no process start authority, no runtime state
+creation authority, no package authority, no package installation
+authority, no package loading authority, no package execution authority,
+no source acceptance authority, no source merge authority, no capability
+authority, no registry authority, no trust authority, no kernel ABI
+authority, no syscall authority, no workflow-threshold authority, no
+baseline authority, no dependency authority, and no Ring0 authority.


### PR DESCRIPTION
This PR changes only PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP.md and records only a governance-only bounded post-sync accepted-evidence set membership boundary after the clean-fixed post-sync accepted-evidence set membership record boundary at 278ba1e14229380fa32f2c85de5efb4b59a81a7e. It does not create accepted evidence, accept any evidence item, accept validator output, accept receipt evidence, or authorize runtime/source/package/source-merge/capability/registry/trust/deployment/distribution/kernel ABI/syscall/workflow-threshold/baseline/dependency/Ring0 authority.