### PR TITLE
Phase-23 concrete accepted-evidence set membership assignment post-sync accepted evidence

### DIFF
--- a/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE.md
+++ b/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE.md
@@ -1,0 +1,659 @@
+# Phase-23 Concrete Accepted-Evidence Set Membership Assignment Post-Sync Accepted Evidence
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY_CLEAN_RECOVERY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_FIRST_BOUNDED_IMPLEMENTATION.md`,
+`PHASE22_CLOSURE_DECISION.md`,
+`PHASE23_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE23_POINTER_TRANSITION_DECISION.md`,
+`docs/roadmap/CURRENT_PHASE`,
+`PHASE23_GOVERNANCE_OVERVIEW.md`,
+`PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`,
+`PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`,
+`PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_RECORD.md`,
+and
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP.md`.
+In case of conflict, those documents prevail unless this document is the
+narrower Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence boundary for the exact governance-only
+bounded post-sync accepted-evidence boundary identified below.
+
+**Status:** PHASE-23 CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT
+POST-SYNC ACCEPTED EVIDENCE / LOCAL DRAFT / GOVERNANCE-ONLY POST-SYNC
+ACCEPTED EVIDENCE ONLY / BOUNDED POST-SYNC ACCEPTED EVIDENCE BOUNDARY
+ONLY / NO EVIDENCE ITEM ACCEPTANCE / NO VALIDATOR OUTPUT ACCEPTANCE / NO
+RECEIPT EVIDENCE ACCEPTANCE / NO RUNTIME IMPLEMENTATION PROCEDURE / NO
+SOURCE MODIFICATION / NO CODE IMPLEMENTATION / NO CODE EXECUTION / NO
+PROCESS START / NO RUNTIME STATE CREATION / NO PACKAGE INSTALLATION / NO
+PACKAGE LOADING / NO PACKAGE EXECUTION / NO DEPLOYMENT / NO CAPABILITY
+ISSUANCE / NO TRUST ASSIGNMENT / NO REGISTRY PUBLICATION / NO
+DISTRIBUTION AUTHORITY / NO SOURCE ACCEPTANCE / NO SOURCE MERGE
+AUTHORITY / NO KERNEL ABI EXPANSION / NO SYSCALL EXPANSION / NO
+WORKFLOW-THRESHOLD CHANGE / NO BASELINE CHANGE / NO DEPENDENCY CHANGE /
+NO RING0 AUTHORITY
+**Accepted-evidence date:** 2026-07-29
+**Accepted-evidence id:**
+`ayken.phase23.concrete_accepted_evidence_set_membership_assignment_post_sync_accepted_evidence.v1`
+**Accepted-evidence drafting base main SHA:**
+`e9665402893dbd6af81615bdcf00705863f2f705`
+**Accepted-evidence publication subject:** pending separate reviewed publication
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership publication subject:**
+`e9665402893dbd6af81615bdcf00705863f2f705`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership PR:** PR #304
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership exact-main ci-freeze run:**
+`30441711804`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership exact-main ci-freeze
+attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership exact-main ci-freeze job:**
+`freeze / 90542334727`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership exact-main ci-freeze result:**
+PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership exact-main Dev Loop
+Validation run:** `30441711779`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership exact-main Dev Loop
+Validation attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership exact-main Dev Loop
+Validation job:** `devloop / 90542334779`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership exact-main Dev Loop
+Validation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership exact-main Dev Loop CI run:**
+`30441711922`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership exact-main Dev Loop CI
+attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership exact-main Dev Loop CI result:**
+PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership exact-main smoke job:**
+`smoke / 90542334957`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership exact-main smoke result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership exact-main contract job:**
+`contract / 90542603630`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership exact-main contract result:**
+PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership exact-main full job:**
+`full / 90543075668`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership exact-main full result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership exact-main isolation job:**
+`isolation / 90543681224`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership exact-main isolation result:**
+PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership exact-main performance job:**
+`performance / 90544365079`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership exact-main performance result:**
+PASS
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership publication subject:**
+`e9665402893dbd6af81615bdcf00705863f2f705`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership record publication subject:**
+`278ba1e14229380fa32f2c85de5efb4b59a81a7e`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership decision publication subject:**
+`854bdb5534fd67f17973170f3483b62f99c58593`
+**Current phase pointer:** `CURRENT_PHASE=23`
+**Accepted Phase-23 post-sync accepted-evidence boundary:** bounded
+post-sync accepted-evidence boundary as a governance accepted-evidence
+boundary only; evidence item acceptance, validator output acceptance,
+and receipt evidence acceptance remain pending separate reviewed records
+if ever authorized.
+**Authority boundary:** Post-sync accepted-evidence boundary only;
+bounded post-sync accepted-evidence boundary only; not evidence item
+acceptance, not validator output acceptance, not receipt evidence
+acceptance, not runtime implementation procedure, not source
+modification, not code implementation, not code execution, not process
+start, not runtime state creation, not general runtime authority, not
+unbounded execution authority, not package authority, not package
+installation, not package loading, not package execution, not source
+acceptance, not source merge authority, not source repository authority,
+not module loading, not workspace runtime, not plugin loading, not
+capability token minting, not capability issuance, not trust assignment,
+not trust issuer authority, not registry authority, not registry
+publication, not publication authority, not deployment authority, not
+distribution authority, not distribution execution, not Semantic CLI
+authority, not AI Runtime authority, not syscall expansion, not kernel
+ABI expansion, not workflow-threshold, baseline, dependency, or Ring0
+authority.
+
+## Purpose
+
+This document records only a bounded post-sync accepted-evidence boundary
+after the clean-fixed Phase-23 concrete accepted-evidence set membership
+assignment post-sync accepted-evidence set membership at:
+
+```text
+e9665402893dbd6af81615bdcf00705863f2f705
+```
+
+It evaluates only:
+
+```text
+May a bounded post-sync accepted-evidence boundary be recorded after the
+clean-fixed post-sync accepted-evidence set membership boundary at
+e9665402893dbd6af81615bdcf00705863f2f705 without accepting any evidence
+item, accepting validator output, accepting receipt evidence, or
+authorizing runtime, source, package, source-merge, capability,
+registry, trust, deployment, distribution, kernel ABI, syscall,
+workflow-threshold, baseline, dependency, or Ring0 authority?
+```
+
+This document answers only for the bounded accepted-evidence boundary
+described in this document.
+
+It does not answer for evidence item acceptance, validator output
+acceptance, receipt evidence acceptance, runtime behavior,
+implementation procedure, source modification, code execution, package
+loading, source merge, capability issuance, registry publication, trust
+assignment, deployment, distribution, kernel ABI, syscall,
+workflow-threshold, baseline, dependency, or Ring0 authority.
+
+## Decision
+
+The bounded post-sync accepted-evidence boundary may be recorded after
+the clean-fixed Phase-23 concrete accepted-evidence set membership
+assignment post-sync accepted-evidence set membership subject:
+
+```text
+e9665402893dbd6af81615bdcf00705863f2f705
+```
+
+The decision is limited to:
+
+```text
+bounded post-sync accepted-evidence boundary
+```
+
+The decision is not evidence item acceptance.
+
+The decision is not validator output acceptance.
+
+The decision is not receipt evidence acceptance.
+
+The decision is not runtime, source, package, source-merge, capability,
+registry, trust, deployment, distribution, kernel ABI, syscall,
+workflow-threshold, baseline, dependency, or Ring0 authority.
+
+## Subject Binding
+
+The only base subject for this local draft is:
+
+```text
+e9665402893dbd6af81615bdcf00705863f2f705
+```
+
+That subject is consumed only as the clean-fixed exact-main publication
+of PR #304:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP.md
+```
+
+The consumed PR #304 scope was exactly one file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP.md
+```
+
+The consumed PR #304 post-merge exact-main evidence was:
+
+```text
+ci-freeze: PASS / run 30441711804 / attempt 1 / freeze 90542334727
+Dev Loop Validation: PASS / run 30441711779 / attempt 1 / devloop 90542334779
+AykenOS Dev Loop CI: PASS / run 30441711922 / attempt 1
+smoke: PASS / 90542334957
+contract: PASS / 90542603630
+full: PASS / 90543075668
+isolation: PASS / 90543681224
+performance: PASS / 90544365079
+```
+
+This document consumes that exact subject as governance input only. It
+does not replace, broaden, reinterpret, or supersede the post-sync
+accepted-evidence set membership boundary or any earlier Phase-23
+governance boundary.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped subject readings fail closed.
+
+## Core Rule
+
+```text
+post-sync accepted evidence == bounded post-sync accepted-evidence boundary only
+post-sync accepted evidence != evidence item acceptance
+post-sync accepted evidence != validator output acceptance
+post-sync accepted evidence != receipt evidence acceptance
+post-sync accepted evidence != runtime implementation procedure
+post-sync accepted evidence != source modification
+post-sync accepted evidence != package loading
+post-sync accepted evidence != package execution
+post-sync accepted evidence != source merge authority
+bounded post-sync accepted-evidence boundary != evidence item acceptance
+bounded post-sync accepted-evidence boundary != validator output acceptance
+bounded post-sync accepted-evidence boundary != receipt evidence acceptance
+accepted-evidence set membership clean-fixed != accepted evidence
+accepted-evidence set membership != accepted evidence unless separately reviewed
+accepted evidence != evidence item acceptance unless separately reviewed
+accepted evidence != validator output acceptance unless separately reviewed
+accepted evidence != receipt evidence acceptance unless separately reviewed
+accepted evidence != runtime implementation procedure
+accepted evidence != source modification
+accepted evidence != package loading
+accepted evidence != package execution
+accepted evidence != source merge authority
+validator output != accepted evidence unless separately reviewed
+receipt evidence != accepted evidence unless separately reviewed
+receipt evidence != validator output
+CI PASS != accepted evidence
+CI PASS != evidence item acceptance
+ci-freeze PASS != accepted evidence
+ci-freeze PASS != evidence item acceptance
+Dev Loop PASS != accepted evidence
+Dev Loop PASS != evidence item acceptance
+AykenOS Dev Loop CI PASS != accepted evidence item acceptance
+post-merge exact-main verification != evidence item acceptance
+clean-fixed != evidence item acceptance
+publication-status sync != accepted evidence
+publication-status sync != evidence item acceptance
+CURRENT_PHASE=23 != evidence item acceptance
+CURRENT_PHASE=23 != validator output acceptance
+CURRENT_PHASE=23 != receipt evidence acceptance
+CURRENT_PHASE=23 != runtime implementation procedure
+CURRENT_PHASE=23 != source modification
+CURRENT_PHASE=23 != execution authority
+CURRENT_PHASE=23 != package loading
+CURRENT_PHASE=23 != source merge authority
+CURRENT_PHASE=23 != kernel ABI expansion
+CURRENT_PHASE=23 != syscall expansion
+historical PASS != inherited evidence
+previous PR evidence != later PR evidence
+```
+
+The safe default remains no evidence item acceptance, no validator
+output acceptance, no receipt evidence acceptance, no runtime behavior,
+no implementation procedure, no source modification, no code execution,
+no runtime state, and no package, capability, registry, trust,
+distribution, deployment, source acceptance, source merge, kernel ABI,
+syscall, workflow-threshold, baseline, dependency, or Ring0 authority
+unless a later reviewed Phase-23 decision or record grants a specific
+bounded authority with its own exact-SHA evidence.
+
+Unknown authority readings fail closed.
+
+## Post-Sync Accepted-Evidence Boundary
+
+The Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted evidence is recorded only as:
+
+```text
+bounded post-sync accepted-evidence boundary
+```
+
+This means only:
+
+1. The clean-fixed PR #304 accepted-evidence set membership boundary may
+   be used as the immediate prerequisite for this bounded accepted
+   evidence boundary.
+2. The bounded post-sync accepted-evidence boundary may be named as the
+   latest Phase-23 governance boundary in later reviewed evidence item,
+   validator-output, receipt-evidence, or runtime-denial paths.
+3. Any later evidence item acceptance, validator output acceptance,
+   receipt evidence acceptance, runtime authority, package authority,
+   source authority, source-merge authority, capability authority,
+   registry authority, trust authority, deployment authority,
+   distribution authority, kernel ABI authority, syscall authority,
+   workflow-threshold authority, baseline authority, dependency
+   authority, or Ring0 authority still requires its own separate
+   reviewed record and its own exact-main evidence.
+
+This document does not accept an evidence item.
+
+This document does not accept validator output.
+
+This document does not accept receipt evidence.
+
+This document does not authorize source merge, package loading, runtime
+execution, capability issuance, registry publication, trust assignment,
+deployment, distribution, kernel ABI expansion, syscall expansion,
+workflow-threshold change, baseline change, dependency change, or Ring0
+authority.
+
+## Non-Authority Boundary
+
+This document does not authorize:
+
+1. Evidence item acceptance.
+2. Validator output acceptance.
+3. Receipt evidence acceptance.
+4. Runtime implementation procedure.
+5. Source modification.
+6. Code implementation.
+7. Code execution.
+8. Process start.
+9. Runtime state creation.
+10. Package installation.
+11. Package loading.
+12. Package execution.
+13. Source acceptance.
+14. Source merge.
+15. Source repository authority.
+16. Module loading.
+17. Workspace runtime.
+18. Plugin loading.
+19. Capability token minting.
+20. Capability issuance.
+21. Trust assignment.
+22. Trust issuer authority.
+23. Registry authority.
+24. Registry publication.
+25. Publication authority beyond this document.
+26. Deployment authority.
+27. Distribution authority.
+28. Distribution execution.
+29. Semantic CLI authority.
+30. AI Runtime authority.
+31. Kernel ABI expansion.
+32. Syscall expansion.
+33. Workflow-threshold changes.
+34. Baseline changes.
+35. Dependency changes.
+36. Ring0 authority.
+37. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this accepted-evidence boundary is published, the publication may
+change only this file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE.md
+```
+
+The publication must not change:
+
+1. `docs/roadmap/CURRENT_PHASE`.
+2. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP.md`.
+3. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_RECORD.md`.
+4. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`.
+5. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_CANDIDATE.md`.
+6. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT.md`.
+7. CI workflows.
+8. Baselines.
+9. Dependencies.
+10. Runtime source or kernel source.
+11. Syscalls or kernel ABI.
+12. Package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment,
+    or distribution execution paths.
+13. `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md`.
+
+Any changed-file expansion beyond this accepted-evidence boundary
+requires separate review and fails this document scope.
+
+## Post-Merge Exact-Main Evidence Rule
+
+If this accepted-evidence boundary is later published, the
+accepted-evidence publication subject must receive its own post-merge
+exact-main verification:
+
+1. `ci-freeze` PASS for the exact accepted-evidence publication SHA.
+2. Dev Loop Validation PASS for the exact accepted-evidence publication
+   SHA.
+3. AykenOS Dev Loop CI PASS for the exact accepted-evidence publication
+   SHA.
+4. smoke PASS.
+5. contract PASS.
+6. full PASS.
+7. isolation PASS.
+8. performance PASS.
+9. Exact changed-file list confirmation.
+10. No `docs/roadmap/CURRENT_PHASE` change.
+11. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP.md`
+    change.
+12. No evidence item acceptance, validator output acceptance, or receipt
+    evidence acceptance.
+13. No CI workflow change.
+14. No baseline change.
+15. No dependency change.
+16. No runtime source or kernel source change.
+17. No syscall or kernel ABI change.
+18. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment,
+    or distribution execution change.
+
+Until that exact-main post-merge verification exists, this
+accepted-evidence boundary must not be recorded as clean-fixed.
+
+Historical PASS results may be cited as context only.
+
+Failed attempts may be cited as transparent non-clean context only.
+
+They cannot be inherited as evidence item acceptance, validator output
+acceptance, receipt evidence acceptance, runtime authority, package
+loading authority, package execution authority, source merge authority,
+capability authority, registry authority, trust authority, kernel ABI
+authority, syscall authority, workflow-threshold authority, baseline
+authority, dependency authority, or Ring0 authority.
+
+## Later Evidence Item Acceptance Dependency
+
+This accepted-evidence boundary is a prerequisite input for a possible
+later bounded evidence item acceptance path.
+
+A later evidence item acceptance record, if ever proposed, must define:
+
+1. Exact evidence item subject.
+2. Exact Phase-23 post-sync accepted-evidence prerequisite.
+3. Exact Phase-23 post-sync accepted-evidence set membership
+   prerequisite.
+4. Exact changed-file boundary.
+5. Exact evidence item acceptance grant, denial, or separate evidence
+   item acceptance scope.
+6. Exact validator-output acceptance denial or separate
+   validator-output acceptance scope.
+7. Exact receipt-evidence acceptance denial or separate receipt-evidence
+   acceptance scope.
+8. Exact runtime implementation procedure denial.
+9. Exact package loading and package execution denials.
+10. Exact source acceptance and source merge denials.
+11. Exact capability, registry, trust, deployment, distribution, kernel
+    ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+    denials.
+12. Exact post-merge verification requirements.
+
+Until such a later reviewed evidence item acceptance record is published,
+no evidence item acceptance exists from this accepted-evidence boundary.
+
+Until such a later reviewed validator-output acceptance record is
+published, no validator output acceptance exists from this
+accepted-evidence boundary.
+
+Until such a later reviewed receipt-evidence acceptance record is
+published, no receipt evidence acceptance exists from this
+accepted-evidence boundary.
+
+## Excluded Local Draft
+
+This accepted-evidence boundary does not consume:
+
+```text
+PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md
+```
+
+If that file exists locally as an untracked file, it remains:
+
+```text
+untracked
+PR-disjoint
+not accepted-evidence input
+not evidence item acceptance
+not validator output
+not receipt evidence
+not runtime authority
+not package acceptance
+not source authority
+```
+
+It must not be staged, committed, or included in any Phase-23 post-sync
+accepted-evidence PR unless a separate reviewed scope explicitly
+authorizes that file.
+
+## Governance Boundary Invariants
+
+Every later RFC must preserve these Phase-23 post-sync accepted-evidence
+invariants:
+
+1. This document is bounded post-sync accepted-evidence boundary only.
+2. This document is not evidence item acceptance.
+3. This document is not validator output acceptance.
+4. This document is not receipt evidence acceptance.
+5. Accepted evidence is not evidence item acceptance unless separately
+   reviewed.
+6. Accepted evidence is not validator output acceptance unless
+   separately reviewed.
+7. Accepted evidence is not receipt evidence acceptance unless
+   separately reviewed.
+8. Validator output is not accepted evidence unless separately reviewed.
+9. Receipt evidence is not accepted evidence unless separately reviewed.
+10. This document is not runtime implementation procedure.
+11. This document is not source modification.
+12. This document is not code implementation.
+13. This document is not code execution.
+14. This document is not process start.
+15. This document is not runtime state creation.
+16. This document is not package installation.
+17. This document is not package loading.
+18. This document is not package execution.
+19. This document is not capability issuance.
+20. This document is not registry publication.
+21. This document is not trust assignment.
+22. This document is not deployment.
+23. This document is not distribution authority.
+24. This document is not source acceptance.
+25. This document is not source merge authority.
+26. This document does not modify `docs/roadmap/CURRENT_PHASE`.
+27. This document does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP.md`.
+28. This document does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_RECORD.md`.
+29. This document does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`.
+30. `CURRENT_PHASE=23` is not evidence item acceptance.
+31. `CURRENT_PHASE=23` is not validator output acceptance.
+32. `CURRENT_PHASE=23` is not receipt evidence acceptance.
+33. `CURRENT_PHASE=23` is not runtime implementation procedure.
+34. `CURRENT_PHASE=23` is not source modification.
+35. `CURRENT_PHASE=23` is not execution authority.
+36. `CURRENT_PHASE=23` is not package loading.
+37. `CURRENT_PHASE=23` is not source merge authority.
+38. This document does not broaden Phase-19 runtime authority.
+39. This document does not reopen Phase-20.
+40. This document does not reopen Phase-21.
+41. This document does not reopen Phase-22.
+42. This document does not expand kernel ABI or syscalls.
+43. This document does not change workflow thresholds, baselines, or
+    dependencies.
+44. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-23 concrete accepted-evidence set membership
+assignment post-sync accepted evidence
+**Architecture status:** Local draft post-sync accepted evidence /
+pending separate reviewed publication
+**Authority notice:** This signature identifies the architectural
+authorship of this accepted-evidence boundary. If separately reviewed
+and published, this document grants only the bounded post-sync
+accepted-evidence boundary defined in this document. It grants no
+evidence item acceptance authority, no validator output acceptance
+authority, no receipt evidence acceptance authority, no runtime
+implementation procedure authority, no source modification authority, no
+code implementation authority, no code execution authority, no process
+start authority, no runtime state creation authority, no package
+authority, no package installation authority, no package loading
+authority, no package execution authority, no source acceptance
+authority, no source merge authority, no capability authority, no
+registry authority, no trust authority, no kernel ABI authority, no
+syscall authority, no workflow-threshold authority, no baseline
+authority, no dependency authority, and no Ring0 authority.


### PR DESCRIPTION
This PR changes only PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE.md and records only a governance-only bounded post-sync accepted-evidence boundary after the clean-fixed post-sync accepted-evidence set membership boundary at e9665402893dbd6af81615bdcf00705863f2f705. It does not accept any evidence item, accept validator output, accept receipt evidence, or authorize runtime/source/package/source-merge/capability/registry/trust/deployment/distribution/kernel ABI/syscall/workflow-threshold/baseline/dependency/Ring0 authority.