### PR TITLE
Phase-23 concrete accepted-evidence set membership assignment post-sync evidence item acceptance

### DIFF
--- a/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_EVIDENCE_ITEM_ACCEPTANCE.md
+++ b/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_EVIDENCE_ITEM_ACCEPTANCE.md
@@ -1,0 +1,681 @@
+# Phase-23 Concrete Accepted-Evidence Set Membership Assignment Post-Sync Evidence Item Acceptance
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY_CLEAN_RECOVERY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_FIRST_BOUNDED_IMPLEMENTATION.md`,
+`PHASE22_CLOSURE_DECISION.md`,
+`PHASE23_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE23_POINTER_TRANSITION_DECISION.md`,
+`docs/roadmap/CURRENT_PHASE`,
+`PHASE23_GOVERNANCE_OVERVIEW.md`,
+`PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`,
+`PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`,
+`PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP.md`,
+and
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE.md`.
+In case of conflict, those documents prevail unless this document is the
+narrower Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance boundary for the exact
+governance-only bounded post-sync evidence item acceptance boundary
+identified below.
+
+**Status:** PHASE-23 CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT
+POST-SYNC EVIDENCE ITEM ACCEPTANCE / LOCAL DRAFT / GOVERNANCE-ONLY
+POST-SYNC EVIDENCE ITEM ACCEPTANCE ONLY / BOUNDED POST-SYNC EVIDENCE
+ITEM ACCEPTANCE BOUNDARY ONLY / NO VALIDATOR OUTPUT ACCEPTANCE / NO
+RECEIPT EVIDENCE ACCEPTANCE / NO RUNTIME IMPLEMENTATION PROCEDURE / NO
+SOURCE MODIFICATION / NO CODE IMPLEMENTATION / NO CODE EXECUTION / NO
+PROCESS START / NO RUNTIME STATE CREATION / NO PACKAGE INSTALLATION /
+NO PACKAGE LOADING / NO PACKAGE EXECUTION / NO DEPLOYMENT / NO
+CAPABILITY ISSUANCE / NO TRUST ASSIGNMENT / NO REGISTRY PUBLICATION /
+NO DISTRIBUTION AUTHORITY / NO SOURCE ACCEPTANCE / NO SOURCE MERGE
+AUTHORITY / NO KERNEL ABI EXPANSION / NO SYSCALL EXPANSION / NO
+WORKFLOW-THRESHOLD CHANGE / NO BASELINE CHANGE / NO DEPENDENCY CHANGE /
+NO RING0 AUTHORITY
+**Evidence-item-acceptance date:** 2026-07-29
+**Evidence-item-acceptance id:**
+`ayken.phase23.concrete_accepted_evidence_set_membership_assignment_post_sync_evidence_item_acceptance.v1`
+**Evidence-item-acceptance drafting base main SHA:**
+`a02276935ed52333fabf9b901d05ee06ac579b68`
+**Evidence-item-acceptance publication subject:** pending separate reviewed
+publication
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence publication subject:**
+`a02276935ed52333fabf9b901d05ee06ac579b68`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence PR:** PR #305
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence exact-main ci-freeze run:** `30480868203`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence exact-main ci-freeze attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence exact-main ci-freeze job:**
+`freeze / 90674332698`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence exact-main ci-freeze result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence exact-main Dev Loop Validation run:**
+`30480870546`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence exact-main Dev Loop Validation attempt:**
+attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence exact-main Dev Loop Validation job:**
+`devloop / 90674340165`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence exact-main Dev Loop Validation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence exact-main Dev Loop CI run:** `30480873588`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence exact-main Dev Loop CI attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence exact-main Dev Loop CI result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence exact-main smoke job:** `smoke / 90674350823`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence exact-main smoke result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence exact-main contract job:**
+`contract / 90674635362`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence exact-main contract result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence exact-main full job:** `full / 90675199549`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence exact-main full result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence exact-main isolation job:**
+`isolation / 90675928595`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence exact-main isolation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence exact-main performance job:**
+`performance / 90676551369`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence exact-main performance result:** PASS
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence publication subject:**
+`a02276935ed52333fabf9b901d05ee06ac579b68`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence set membership publication subject:**
+`e9665402893dbd6af81615bdcf00705863f2f705`
+**Current phase pointer:** `CURRENT_PHASE=23`
+**Accepted Phase-23 post-sync evidence item acceptance boundary:** bounded
+post-sync evidence item acceptance boundary as governance evidence item
+acceptance boundary only; validator output acceptance and receipt
+evidence acceptance remain pending separate reviewed records if ever
+authorized.
+**Authority boundary:** Post-sync evidence item acceptance boundary only;
+bounded post-sync evidence item acceptance boundary only; not validator
+output acceptance, not receipt evidence acceptance, not runtime
+implementation procedure, not source modification, not code
+implementation, not code execution, not process start, not runtime state
+creation, not general runtime authority, not unbounded execution
+authority, not package authority, not package installation, not package
+loading, not package execution, not source acceptance, not source merge
+authority, not source repository authority, not module loading, not
+workspace runtime, not plugin loading, not capability token minting, not
+capability issuance, not trust assignment, not trust issuer authority,
+not registry authority, not registry publication, not publication
+authority, not deployment authority, not distribution authority, not
+distribution execution, not Semantic CLI authority, not AI Runtime
+authority, not syscall expansion, not kernel ABI expansion, not
+workflow-threshold, baseline, dependency, or Ring0 authority.
+
+## Purpose
+
+This document records only a bounded post-sync evidence item acceptance
+boundary after the clean-fixed Phase-23 concrete accepted-evidence set
+membership assignment post-sync accepted-evidence boundary at:
+
+```text
+a02276935ed52333fabf9b901d05ee06ac579b68
+```
+
+It evaluates only:
+
+```text
+May a bounded post-sync evidence item acceptance boundary be recorded
+after the clean-fixed post-sync accepted-evidence boundary at
+a02276935ed52333fabf9b901d05ee06ac579b68 without accepting validator
+output, accepting receipt evidence, or authorizing runtime, source,
+package, source-merge, capability, registry, trust, deployment,
+distribution, kernel ABI, syscall, workflow-threshold, baseline,
+dependency, or Ring0 authority?
+```
+
+This document answers only for the bounded evidence item acceptance
+boundary described in this document.
+
+It does not answer for validator output acceptance, receipt evidence
+acceptance, runtime behavior, implementation procedure, source
+modification, code execution, package loading, source merge, capability
+issuance, registry publication, trust assignment, deployment,
+distribution, kernel ABI, syscall, workflow-threshold, baseline,
+dependency, or Ring0 authority.
+
+## Decision
+
+The bounded post-sync evidence item acceptance boundary may be recorded
+after the clean-fixed Phase-23 concrete accepted-evidence set membership
+assignment post-sync accepted-evidence subject:
+
+```text
+a02276935ed52333fabf9b901d05ee06ac579b68
+```
+
+The decision is limited to:
+
+```text
+bounded post-sync evidence item acceptance boundary
+```
+
+The decision is not validator output acceptance.
+
+The decision is not receipt evidence acceptance.
+
+The decision is not runtime, source, package, source-merge, capability,
+registry, trust, deployment, distribution, kernel ABI, syscall,
+workflow-threshold, baseline, dependency, or Ring0 authority.
+
+## Subject Binding
+
+The only base subject for this local draft is:
+
+```text
+a02276935ed52333fabf9b901d05ee06ac579b68
+```
+
+That subject is consumed only as the clean-fixed exact-main publication
+of PR #305:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE.md
+```
+
+The consumed PR #305 scope was exactly one file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE.md
+```
+
+The consumed PR #305 post-merge exact-main evidence was:
+
+```text
+ci-freeze: PASS / run 30480868203 / attempt 1 / freeze 90674332698
+Dev Loop Validation: PASS / run 30480870546 / attempt 1 / devloop 90674340165
+AykenOS Dev Loop CI: PASS / run 30480873588 / attempt 1
+smoke: PASS / 90674350823
+contract: PASS / 90674635362
+full: PASS / 90675199549
+isolation: PASS / 90675928595
+performance: PASS / 90676551369
+```
+
+This document consumes that exact subject as governance input only. It
+does not replace, broaden, reinterpret, or supersede the post-sync
+accepted-evidence boundary or any earlier Phase-23 governance boundary.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped subject readings fail closed.
+
+## Core Rule
+
+```text
+post-sync evidence item acceptance == bounded post-sync evidence item acceptance boundary only
+post-sync evidence item acceptance != validator output acceptance
+post-sync evidence item acceptance != receipt evidence acceptance
+post-sync evidence item acceptance != runtime implementation procedure
+post-sync evidence item acceptance != source modification
+post-sync evidence item acceptance != package loading
+post-sync evidence item acceptance != package execution
+post-sync evidence item acceptance != source merge authority
+bounded post-sync evidence item acceptance boundary != validator output acceptance
+bounded post-sync evidence item acceptance boundary != receipt evidence acceptance
+accepted evidence clean-fixed != evidence item acceptance unless separately reviewed
+accepted evidence != validator output acceptance unless separately reviewed
+accepted evidence != receipt evidence acceptance unless separately reviewed
+evidence item acceptance != validator output acceptance unless separately reviewed
+evidence item acceptance != receipt evidence acceptance unless separately reviewed
+evidence item acceptance != runtime implementation procedure
+evidence item acceptance != source modification
+evidence item acceptance != package loading
+evidence item acceptance != package execution
+evidence item acceptance != source merge authority
+validator output != accepted evidence unless separately reviewed
+receipt evidence != accepted evidence unless separately reviewed
+validator output != evidence item acceptance unless separately reviewed
+receipt evidence != evidence item acceptance unless separately reviewed
+receipt evidence != validator output
+CI PASS != evidence item acceptance
+CI PASS != validator output acceptance
+CI PASS != receipt evidence acceptance
+ci-freeze PASS != evidence item acceptance
+ci-freeze PASS != validator output acceptance
+ci-freeze PASS != receipt evidence acceptance
+Dev Loop PASS != evidence item acceptance
+Dev Loop PASS != validator output acceptance
+Dev Loop PASS != receipt evidence acceptance
+AykenOS Dev Loop CI PASS != evidence item acceptance authority
+post-merge exact-main verification != validator output acceptance
+post-merge exact-main verification != receipt evidence acceptance
+clean-fixed != validator output acceptance
+clean-fixed != receipt evidence acceptance
+publication-status sync != evidence item acceptance
+publication-status sync != validator output acceptance
+publication-status sync != receipt evidence acceptance
+CURRENT_PHASE=23 != validator output acceptance
+CURRENT_PHASE=23 != receipt evidence acceptance
+CURRENT_PHASE=23 != runtime implementation procedure
+CURRENT_PHASE=23 != source modification
+CURRENT_PHASE=23 != execution authority
+CURRENT_PHASE=23 != package loading
+CURRENT_PHASE=23 != source merge authority
+CURRENT_PHASE=23 != kernel ABI expansion
+CURRENT_PHASE=23 != syscall expansion
+historical PASS != inherited evidence item acceptance
+previous PR evidence != later PR evidence
+```
+
+The safe default remains no validator output acceptance, no receipt
+evidence acceptance, no runtime behavior, no implementation procedure,
+no source modification, no code execution, no runtime state, and no
+package, capability, registry, trust, distribution, deployment, source
+acceptance, source merge, kernel ABI, syscall, workflow-threshold,
+baseline, dependency, or Ring0 authority unless a later reviewed
+Phase-23 decision or record grants a specific bounded authority with its
+own exact-SHA evidence.
+
+Unknown authority readings fail closed.
+
+## Post-Sync Evidence Item Acceptance Boundary
+
+The Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance is recorded only as:
+
+```text
+bounded post-sync evidence item acceptance boundary
+```
+
+This means only:
+
+1. The clean-fixed PR #305 accepted-evidence boundary may be used as the
+   immediate prerequisite for this bounded evidence item acceptance
+   boundary.
+2. The bounded post-sync evidence item acceptance boundary may be named
+   as the latest Phase-23 governance boundary in later reviewed
+   validator-output, receipt-evidence, runtime-denial, or package-denial
+   paths.
+3. Any later validator output acceptance, receipt evidence acceptance,
+   runtime authority, package authority, source authority, source-merge
+   authority, capability authority, registry authority, trust authority,
+   deployment authority, distribution authority, kernel ABI authority,
+   syscall authority, workflow-threshold authority, baseline authority,
+   dependency authority, or Ring0 authority still requires its own
+   separate reviewed record and its own exact-main evidence.
+
+This document does not accept validator output.
+
+This document does not accept receipt evidence.
+
+This document does not authorize source merge, package loading, runtime
+execution, capability issuance, registry publication, trust assignment,
+deployment, distribution, kernel ABI expansion, syscall expansion,
+workflow-threshold change, baseline change, dependency change, or Ring0
+authority.
+
+## Non-Authority Boundary
+
+This document does not authorize:
+
+1. Validator output acceptance.
+2. Receipt evidence acceptance.
+3. Runtime implementation procedure.
+4. Source modification.
+5. Code implementation.
+6. Code execution.
+7. Process start.
+8. Runtime state creation.
+9. Package installation.
+10. Package loading.
+11. Package execution.
+12. Source acceptance.
+13. Source merge.
+14. Source repository authority.
+15. Module loading.
+16. Workspace runtime.
+17. Plugin loading.
+18. Capability token minting.
+19. Capability issuance.
+20. Trust assignment.
+21. Trust issuer authority.
+22. Registry authority.
+23. Registry publication.
+24. Publication authority beyond this document.
+25. Deployment authority.
+26. Distribution authority.
+27. Distribution execution.
+28. Semantic CLI authority.
+29. AI Runtime authority.
+30. Kernel ABI expansion.
+31. Syscall expansion.
+32. Workflow-threshold changes.
+33. Baseline changes.
+34. Dependency changes.
+35. Ring0 authority.
+36. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this evidence item acceptance boundary is published, the publication
+may change only this file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_EVIDENCE_ITEM_ACCEPTANCE.md
+```
+
+The publication must not change:
+
+1. `docs/roadmap/CURRENT_PHASE`.
+2. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE.md`.
+3. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP.md`.
+4. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_RECORD.md`.
+5. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`.
+6. CI workflows.
+7. Baselines.
+8. Dependencies.
+9. Runtime source or kernel source.
+10. Syscalls or kernel ABI.
+11. Package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment,
+    or distribution execution paths.
+12. `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md`.
+
+Any changed-file expansion beyond this evidence item acceptance boundary
+requires separate review and fails this document scope.
+
+## Post-Merge Exact-Main Evidence Rule
+
+If this evidence item acceptance boundary is later published, the
+evidence-item-acceptance publication subject must receive its own
+post-merge exact-main verification:
+
+1. `ci-freeze` PASS for the exact evidence-item-acceptance publication
+   SHA.
+2. Dev Loop Validation PASS for the exact evidence-item-acceptance
+   publication SHA.
+3. AykenOS Dev Loop CI PASS for the exact evidence-item-acceptance
+   publication SHA.
+4. smoke PASS.
+5. contract PASS.
+6. full PASS.
+7. isolation PASS.
+8. performance PASS.
+9. Exact changed-file list confirmation.
+10. No `docs/roadmap/CURRENT_PHASE` change.
+11. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE.md`
+    change.
+12. No validator output acceptance or receipt evidence acceptance.
+13. No CI workflow change.
+14. No baseline change.
+15. No dependency change.
+16. No runtime source or kernel source change.
+17. No syscall or kernel ABI change.
+18. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment,
+    or distribution execution change.
+
+Until that exact-main post-merge verification exists, this evidence item
+acceptance boundary must not be recorded as clean-fixed.
+
+Historical PASS results may be cited as context only.
+
+Failed attempts may be cited as transparent non-clean context only.
+
+They cannot be inherited as validator output acceptance, receipt
+evidence acceptance, runtime authority, package loading authority,
+package execution authority, source merge authority, capability
+authority, registry authority, trust authority, kernel ABI authority,
+syscall authority, workflow-threshold authority, baseline authority,
+dependency authority, or Ring0 authority.
+
+## Later Validator And Receipt Dependency
+
+This evidence item acceptance boundary is a prerequisite input for
+possible later bounded validator-output and receipt-evidence acceptance
+paths.
+
+A later validator output acceptance record, if ever proposed, must
+define:
+
+1. Exact validator output subject.
+2. Exact Phase-23 post-sync evidence item acceptance prerequisite.
+3. Exact changed-file boundary.
+4. Exact validator-output acceptance grant, denial, or separate
+   validator-output acceptance scope.
+5. Exact receipt-evidence acceptance denial or separate
+   receipt-evidence acceptance scope.
+6. Exact runtime implementation procedure denial.
+7. Exact package loading and package execution denials.
+8. Exact source acceptance and source merge denials.
+9. Exact capability, registry, trust, deployment, distribution, kernel
+   ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+   denials.
+10. Exact post-merge verification requirements.
+
+A later receipt evidence acceptance record, if ever proposed, must
+define:
+
+1. Exact receipt evidence subject.
+2. Exact Phase-23 post-sync evidence item acceptance prerequisite.
+3. Exact changed-file boundary.
+4. Exact receipt-evidence acceptance grant, denial, or separate
+   receipt-evidence acceptance scope.
+5. Exact validator-output acceptance denial or separate
+   validator-output acceptance scope.
+6. Exact runtime implementation procedure denial.
+7. Exact package loading and package execution denials.
+8. Exact source acceptance and source merge denials.
+9. Exact capability, registry, trust, deployment, distribution, kernel
+   ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+   denials.
+10. Exact post-merge verification requirements.
+
+Until such a later reviewed validator-output acceptance record is
+published, no validator output acceptance exists from this evidence item
+acceptance boundary.
+
+Until such a later reviewed receipt-evidence acceptance record is
+published, no receipt evidence acceptance exists from this evidence item
+acceptance boundary.
+
+## Excluded Local Draft
+
+This evidence item acceptance boundary does not consume:
+
+```text
+PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md
+```
+
+If that file exists locally as an untracked file, it remains:
+
+```text
+untracked
+PR-disjoint
+not evidence item acceptance input
+not validator output
+not receipt evidence
+not runtime authority
+not package acceptance
+not source authority
+```
+
+It must not be staged, committed, or included in any Phase-23 post-sync
+evidence item acceptance PR unless a separate reviewed scope explicitly
+authorizes that file.
+
+## Governance Boundary Invariants
+
+Every later RFC must preserve these Phase-23 post-sync evidence item
+acceptance invariants:
+
+1. This document is bounded post-sync evidence item acceptance boundary
+   only.
+2. This document is not validator output acceptance.
+3. This document is not receipt evidence acceptance.
+4. Evidence item acceptance is not validator output acceptance unless
+   separately reviewed.
+5. Evidence item acceptance is not receipt evidence acceptance unless
+   separately reviewed.
+6. Validator output is not accepted evidence unless separately reviewed.
+7. Receipt evidence is not accepted evidence unless separately reviewed.
+8. This document is not runtime implementation procedure.
+9. This document is not source modification.
+10. This document is not code implementation.
+11. This document is not code execution.
+12. This document is not process start.
+13. This document is not runtime state creation.
+14. This document is not package installation.
+15. This document is not package loading.
+16. This document is not package execution.
+17. This document is not capability issuance.
+18. This document is not registry publication.
+19. This document is not trust assignment.
+20. This document is not deployment.
+21. This document is not distribution authority.
+22. This document is not source acceptance.
+23. This document is not source merge authority.
+24. This document does not modify `docs/roadmap/CURRENT_PHASE`.
+25. This document does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE.md`.
+26. This document does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP.md`.
+27. `CURRENT_PHASE=23` is not validator output acceptance.
+28. `CURRENT_PHASE=23` is not receipt evidence acceptance.
+29. `CURRENT_PHASE=23` is not runtime implementation procedure.
+30. `CURRENT_PHASE=23` is not source modification.
+31. `CURRENT_PHASE=23` is not execution authority.
+32. `CURRENT_PHASE=23` is not package loading.
+33. `CURRENT_PHASE=23` is not source merge authority.
+34. This document does not broaden Phase-19 runtime authority.
+35. This document does not reopen Phase-20.
+36. This document does not reopen Phase-21.
+37. This document does not reopen Phase-22.
+38. This document does not expand kernel ABI or syscalls.
+39. This document does not change workflow thresholds, baselines, or
+    dependencies.
+40. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Conclusion
+
+This Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance is based on the clean-fixed Phase-23
+concrete accepted-evidence set membership assignment post-sync accepted
+evidence publication subject:
+
+```text
+a02276935ed52333fabf9b901d05ee06ac579b68
+```
+
+It records only the bounded post-sync evidence item acceptance boundary.
+
+It does not accept validator output.
+
+It does not accept receipt evidence.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, capability issuance, registry publication, trust assignment,
+deployment, distribution, source acceptance, source merge, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Any later Phase-23 validator-output-acceptance,
+receipt-evidence-acceptance, package-review, source-review,
+runtime-implementation-procedure, or non-authorization boundary record
+requires its own exact-SHA evidence, changed-file scope,
+non-authorization boundary, and reviewed decision path.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-23 concrete accepted-evidence set membership
+assignment post-sync evidence item acceptance
+**Architecture status:** Local draft post-sync evidence item acceptance /
+pending separate reviewed publication
+**Authority notice:** This signature identifies the architectural
+authorship of this evidence item acceptance boundary. If separately
+reviewed and published, this document grants only the bounded post-sync
+evidence item acceptance boundary defined in this document. It grants no
+validator output acceptance authority, no receipt evidence acceptance
+authority, no runtime implementation procedure authority, no source
+modification authority, no code implementation authority, no code
+execution authority, no process start authority, no runtime state
+creation authority, no package authority, no package installation
+authority, no package loading authority, no package execution authority,
+no source acceptance authority, no source merge authority, no capability
+authority, no registry authority, no trust authority, no kernel ABI
+authority, no syscall authority, no workflow-threshold authority, no
+baseline authority, no dependency authority, and no Ring0 authority.


### PR DESCRIPTION
This PR changes only PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_EVIDENCE_ITEM_ACCEPTANCE.md and records only a governance-only bounded post-sync evidence item acceptance boundary after the clean-fixed post-sync accepted-evidence boundary at a02276935ed52333fabf9b901d05ee06ac579b68. It does not accept validator output, accept receipt evidence, or authorize runtime/source/package/source-merge/capability/registry/trust/deployment/distribution/kernel ABI/syscall/workflow-threshold/baseline/dependency/Ring0 authority.