### PR TITLE
Phase-23 concrete accepted-evidence set membership assignment post-sync validator output acceptance

### DIFF
--- a/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_VALIDATOR_OUTPUT_ACCEPTANCE.md
+++ b/PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_VALIDATOR_OUTPUT_ACCEPTANCE.md
@@ -1,0 +1,633 @@
+# Phase-23 Concrete Accepted-Evidence Set Membership Assignment Post-Sync Validator Output Acceptance
+
+This document is subordinate to PHASE 0 - FOUNDATIONAL OATH,
+`ARCHITECTURE_FREEZE.md`, the Phase-18 Platform Constitution reference set,
+`docs/specs/phase18-platform-constitution/AUTHORITY_DRIFT_GUARD.md`,
+`docs/specs/phase18-platform-constitution/TERMINOLOGY_AUDIT.md`,
+`PHASE19_RUNTIME_DECISION.md`, the Phase-19 Runtime RFC set,
+`docs/specs/phase19-platform-runtime/RUNTIME_EVIDENCE_MATRIX.md`,
+`PHASE19_CLOSURE_DECISION.md`,
+`PHASE20_CLOSURE_DECISION.md`,
+`PHASE21_CLOSURE_DECISION.md`,
+`PHASE22_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE22_POINTER_TRANSITION_DECISION.md`,
+`PHASE22_GOVERNANCE_OVERVIEW.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_PLAN.md`,
+`PHASE22_ACTUAL_SKELETON_REVIEW_RESULT.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_BOUNDARY_CLEAN_RECOVERY.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_PLAN.md`,
+`PHASE22_STATIC_PACKAGE_ACCEPTANCE_DECISION_FIRST_BOUNDED_IMPLEMENTATION.md`,
+`PHASE22_CLOSURE_DECISION.md`,
+`PHASE23_POINTER_TRANSITION_CANDIDATE.md`,
+`PHASE23_POINTER_TRANSITION_DECISION.md`,
+`docs/roadmap/CURRENT_PHASE`,
+`PHASE23_GOVERNANCE_OVERVIEW.md`,
+`PHASE23_INITIAL_GOVERNANCE_BOUNDARY.md`,
+`PHASE23_EXACT_SHA_EVIDENCE_EXPECTATION_BOUNDARY.md`,
+`PHASE23_ACCEPTED_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_RECEIPT_EVIDENCE_BOUNDARY_PLANNING.md`,
+`PHASE23_VALIDATOR_OUTPUT_BOUNDARY_PLANNING.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_AUTHORITY_DECISION.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION_CANDIDATE.md`,
+`PHASE23_EVIDENCE_ACCEPTANCE_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_PUBLICATION_STATUS_SYNC.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_CONCRETE_ASSIGNMENT.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_MEMBERSHIP_ASSIGNMENT.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_CANDIDATE.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_DECISION.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_RECORD.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP.md`,
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE.md`,
+and
+`PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_EVIDENCE_ITEM_ACCEPTANCE.md`.
+In case of conflict, those documents prevail unless this document is the
+narrower Phase-23 concrete accepted-evidence set membership assignment
+post-sync validator output acceptance boundary for the exact
+governance-only bounded post-sync validator output acceptance boundary
+identified below.
+
+**Status:** PHASE-23 CONCRETE ACCEPTED-EVIDENCE SET MEMBERSHIP ASSIGNMENT
+POST-SYNC VALIDATOR OUTPUT ACCEPTANCE / LOCAL DRAFT / GOVERNANCE-ONLY
+POST-SYNC VALIDATOR OUTPUT ACCEPTANCE ONLY / BOUNDED POST-SYNC VALIDATOR
+OUTPUT ACCEPTANCE BOUNDARY ONLY / NO RECEIPT EVIDENCE ACCEPTANCE / NO
+RUNTIME IMPLEMENTATION PROCEDURE / NO SOURCE MODIFICATION / NO CODE
+IMPLEMENTATION / NO CODE EXECUTION / NO PROCESS START / NO RUNTIME
+STATE CREATION / NO PACKAGE INSTALLATION / NO PACKAGE LOADING / NO
+PACKAGE EXECUTION / NO DEPLOYMENT / NO CAPABILITY ISSUANCE / NO TRUST
+ASSIGNMENT / NO REGISTRY PUBLICATION / NO DISTRIBUTION AUTHORITY / NO
+SOURCE ACCEPTANCE / NO SOURCE MERGE AUTHORITY / NO KERNEL ABI EXPANSION
+/ NO SYSCALL EXPANSION / NO WORKFLOW-THRESHOLD CHANGE / NO BASELINE
+CHANGE / NO DEPENDENCY CHANGE / NO RING0 AUTHORITY
+**Validator-output-acceptance date:** 2026-07-29
+**Validator-output-acceptance id:**
+`ayken.phase23.concrete_accepted_evidence_set_membership_assignment_post_sync_validator_output_acceptance.v1`
+**Validator-output-acceptance drafting base main SHA:**
+`1e14761675b02c149743671c035399dd2310d0f2`
+**Validator-output-acceptance publication subject:** pending separate
+reviewed publication
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance publication subject:**
+`1e14761675b02c149743671c035399dd2310d0f2`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance PR:** PR #306
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance exact-main ci-freeze run:**
+`30486008152`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance exact-main ci-freeze attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance exact-main ci-freeze job:**
+`freeze / 90691717185`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance exact-main ci-freeze result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance exact-main Dev Loop Validation run:**
+`30486008069`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance exact-main Dev Loop Validation
+attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance exact-main Dev Loop Validation job:**
+`devloop / 90691716748`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance exact-main Dev Loop Validation result:**
+PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance exact-main Dev Loop CI run:**
+`30486008115`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance exact-main Dev Loop CI attempt:** attempt 1
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance exact-main Dev Loop CI result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance exact-main smoke job:**
+`smoke / 90691717083`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance exact-main smoke result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance exact-main contract job:**
+`contract / 90691951074`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance exact-main contract result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance exact-main full job:** `full / 90692505406`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance exact-main full result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance exact-main isolation job:**
+`isolation / 90693063072`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance exact-main isolation result:** PASS
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance exact-main performance job:**
+`performance / 90693537588`
+**Reviewed Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance exact-main performance result:** PASS
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync evidence item acceptance publication subject:**
+`1e14761675b02c149743671c035399dd2310d0f2`
+**Phase-23 concrete accepted-evidence set membership assignment
+post-sync accepted-evidence publication subject:**
+`a02276935ed52333fabf9b901d05ee06ac579b68`
+**Current phase pointer:** `CURRENT_PHASE=23`
+**Accepted Phase-23 post-sync validator output acceptance boundary:**
+bounded post-sync validator output acceptance boundary as governance
+validator output acceptance boundary only; receipt evidence acceptance
+remains pending a separate reviewed record if ever authorized.
+**Authority boundary:** Post-sync validator output acceptance boundary
+only; bounded post-sync validator output acceptance boundary only; not
+receipt evidence acceptance, not runtime implementation procedure, not
+source modification, not code implementation, not code execution, not
+process start, not runtime state creation, not general runtime
+authority, not unbounded execution authority, not package authority, not
+package installation, not package loading, not package execution, not
+source acceptance, not source merge authority, not source repository
+authority, not module loading, not workspace runtime, not plugin
+loading, not capability token minting, not capability issuance, not
+trust assignment, not trust issuer authority, not registry authority,
+not registry publication, not publication authority, not deployment
+authority, not distribution authority, not distribution execution, not
+Semantic CLI authority, not AI Runtime authority, not syscall
+expansion, not kernel ABI expansion, not workflow-threshold, baseline,
+dependency, or Ring0 authority.
+
+## Purpose
+
+This document records only a bounded post-sync validator output
+acceptance boundary after the clean-fixed Phase-23 concrete
+accepted-evidence set membership assignment post-sync evidence item
+acceptance boundary at:
+
+```text
+1e14761675b02c149743671c035399dd2310d0f2
+```
+
+It evaluates only:
+
+```text
+May a bounded post-sync validator output acceptance boundary be recorded
+after the clean-fixed post-sync evidence item acceptance boundary at
+1e14761675b02c149743671c035399dd2310d0f2 without accepting receipt
+evidence or authorizing runtime, source, package, source-merge,
+capability, registry, trust, deployment, distribution, kernel ABI,
+syscall, workflow-threshold, baseline, dependency, or Ring0 authority?
+```
+
+This document answers only for the bounded validator output acceptance
+boundary described in this document.
+
+It does not answer for receipt evidence acceptance, runtime behavior,
+implementation procedure, source modification, code execution, package
+loading, source merge, capability issuance, registry publication, trust
+assignment, deployment, distribution, kernel ABI, syscall,
+workflow-threshold, baseline, dependency, or Ring0 authority.
+
+## Decision
+
+The bounded post-sync validator output acceptance boundary may be
+recorded after the clean-fixed Phase-23 concrete accepted-evidence set
+membership assignment post-sync evidence item acceptance subject:
+
+```text
+1e14761675b02c149743671c035399dd2310d0f2
+```
+
+The decision is limited to:
+
+```text
+bounded post-sync validator output acceptance boundary
+```
+
+The decision is not receipt evidence acceptance.
+
+The decision is not runtime, source, package, source-merge, capability,
+registry, trust, deployment, distribution, kernel ABI, syscall,
+workflow-threshold, baseline, dependency, or Ring0 authority.
+
+## Subject Binding
+
+The only base subject for this local draft is:
+
+```text
+1e14761675b02c149743671c035399dd2310d0f2
+```
+
+That subject is consumed only as the clean-fixed exact-main publication
+of PR #306:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_EVIDENCE_ITEM_ACCEPTANCE.md
+```
+
+The consumed PR #306 scope was exactly one file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_EVIDENCE_ITEM_ACCEPTANCE.md
+```
+
+The consumed PR #306 post-merge exact-main evidence was:
+
+```text
+ci-freeze: PASS / run 30486008152 / attempt 1 / freeze 90691717185
+Dev Loop Validation: PASS / run 30486008069 / attempt 1 / devloop 90691716748
+AykenOS Dev Loop CI: PASS / run 30486008115 / attempt 1
+smoke: PASS / 90691717083
+contract: PASS / 90691951074
+full: PASS / 90692505406
+isolation: PASS / 90693063072
+performance: PASS / 90693537588
+```
+
+This document consumes that exact subject as governance input only. It
+does not replace, broaden, reinterpret, or supersede the post-sync
+evidence item acceptance boundary or any earlier Phase-23 governance
+boundary.
+
+Missing, ambiguous, stale, inherited, aliased, superseded, or differently
+scoped subject readings fail closed.
+
+## Core Rule
+
+```text
+post-sync validator output acceptance == bounded post-sync validator output acceptance boundary only
+post-sync validator output acceptance != receipt evidence acceptance
+post-sync validator output acceptance != runtime implementation procedure
+post-sync validator output acceptance != source modification
+post-sync validator output acceptance != package loading
+post-sync validator output acceptance != package execution
+post-sync validator output acceptance != source merge authority
+bounded post-sync validator output acceptance boundary != receipt evidence acceptance
+evidence item acceptance clean-fixed != validator output acceptance unless separately reviewed
+evidence item acceptance != receipt evidence acceptance unless separately reviewed
+validator output acceptance != receipt evidence acceptance unless separately reviewed
+validator output acceptance != runtime implementation procedure
+validator output acceptance != source modification
+validator output acceptance != package loading
+validator output acceptance != package execution
+validator output acceptance != source merge authority
+receipt evidence != accepted evidence unless separately reviewed
+receipt evidence != evidence item acceptance unless separately reviewed
+receipt evidence != validator output acceptance unless separately reviewed
+receipt evidence != validator output
+CI PASS != validator output acceptance
+CI PASS != receipt evidence acceptance
+ci-freeze PASS != validator output acceptance
+ci-freeze PASS != receipt evidence acceptance
+Dev Loop PASS != validator output acceptance
+Dev Loop PASS != receipt evidence acceptance
+AykenOS Dev Loop CI PASS != validator output acceptance authority
+post-merge exact-main verification != receipt evidence acceptance
+clean-fixed != receipt evidence acceptance
+publication-status sync != validator output acceptance
+publication-status sync != receipt evidence acceptance
+CURRENT_PHASE=23 != receipt evidence acceptance
+CURRENT_PHASE=23 != runtime implementation procedure
+CURRENT_PHASE=23 != source modification
+CURRENT_PHASE=23 != execution authority
+CURRENT_PHASE=23 != package loading
+CURRENT_PHASE=23 != source merge authority
+CURRENT_PHASE=23 != kernel ABI expansion
+CURRENT_PHASE=23 != syscall expansion
+historical PASS != inherited validator output acceptance
+previous PR evidence != later PR evidence
+```
+
+The safe default remains no receipt evidence acceptance, no runtime
+behavior, no implementation procedure, no source modification, no code
+execution, no runtime state, and no package, capability, registry,
+trust, distribution, deployment, source acceptance, source merge, kernel
+ABI, syscall, workflow-threshold, baseline, dependency, or Ring0
+authority unless a later reviewed Phase-23 decision or record grants a
+specific bounded authority with its own exact-SHA evidence.
+
+Unknown authority readings fail closed.
+
+## Post-Sync Validator Output Acceptance Boundary
+
+The Phase-23 concrete accepted-evidence set membership assignment
+post-sync validator output acceptance is recorded only as:
+
+```text
+bounded post-sync validator output acceptance boundary
+```
+
+This means only:
+
+1. The clean-fixed PR #306 evidence item acceptance boundary may be used
+   as the immediate prerequisite for this bounded validator output
+   acceptance boundary.
+2. The bounded post-sync validator output acceptance boundary may be
+   named as the latest Phase-23 governance boundary in later reviewed
+   receipt-evidence, runtime-denial, or package-denial paths.
+3. Any later receipt evidence acceptance, runtime authority, package
+   authority, source authority, source-merge authority, capability
+   authority, registry authority, trust authority, deployment authority,
+   distribution authority, kernel ABI authority, syscall authority,
+   workflow-threshold authority, baseline authority, dependency
+   authority, or Ring0 authority still requires its own separate
+   reviewed record and its own exact-main evidence.
+
+This document does not accept receipt evidence.
+
+This document does not authorize source merge, package loading, runtime
+execution, capability issuance, registry publication, trust assignment,
+deployment, distribution, kernel ABI expansion, syscall expansion,
+workflow-threshold change, baseline change, dependency change, or Ring0
+authority.
+
+## Non-Authority Boundary
+
+This document does not authorize:
+
+1. Receipt evidence acceptance.
+2. Runtime implementation procedure.
+3. Source modification.
+4. Code implementation.
+5. Code execution.
+6. Process start.
+7. Runtime state creation.
+8. Package installation.
+9. Package loading.
+10. Package execution.
+11. Source acceptance.
+12. Source merge.
+13. Source repository authority.
+14. Module loading.
+15. Workspace runtime.
+16. Plugin loading.
+17. Capability token minting.
+18. Capability issuance.
+19. Trust assignment.
+20. Trust issuer authority.
+21. Registry authority.
+22. Registry publication.
+23. Publication authority beyond this document.
+24. Deployment authority.
+25. Distribution authority.
+26. Distribution execution.
+27. Semantic CLI authority.
+28. AI Runtime authority.
+29. Kernel ABI expansion.
+30. Syscall expansion.
+31. Workflow-threshold changes.
+32. Baseline changes.
+33. Dependency changes.
+34. Ring0 authority.
+35. Observability-as-authority.
+
+Unknown authority readings fail closed.
+
+## Publication Boundary
+
+If this validator output acceptance boundary is published, the
+publication may change only this file:
+
+```text
+PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_VALIDATOR_OUTPUT_ACCEPTANCE.md
+```
+
+The publication must not change:
+
+1. `docs/roadmap/CURRENT_PHASE`.
+2. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_EVIDENCE_ITEM_ACCEPTANCE.md`.
+3. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE.md`.
+4. `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_ACCEPTED_EVIDENCE_SET_MEMBERSHIP.md`.
+5. CI workflows.
+6. Baselines.
+7. Dependencies.
+8. Runtime source or kernel source.
+9. Syscalls or kernel ABI.
+10. Package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment,
+    or distribution execution paths.
+11. `PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md`.
+
+Any changed-file expansion beyond this validator output acceptance
+boundary requires separate review and fails this document scope.
+
+## Post-Merge Exact-Main Evidence Rule
+
+If this validator output acceptance boundary is later published, the
+validator-output-acceptance publication subject must receive its own
+post-merge exact-main verification:
+
+1. `ci-freeze` PASS for the exact validator-output-acceptance
+   publication SHA.
+2. Dev Loop Validation PASS for the exact validator-output-acceptance
+   publication SHA.
+3. AykenOS Dev Loop CI PASS for the exact validator-output-acceptance
+   publication SHA.
+4. smoke PASS.
+5. contract PASS.
+6. full PASS.
+7. isolation PASS.
+8. performance PASS.
+9. Exact changed-file list confirmation.
+10. No `docs/roadmap/CURRENT_PHASE` change.
+11. No
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_EVIDENCE_ITEM_ACCEPTANCE.md`
+    change.
+12. No receipt evidence acceptance.
+13. No CI workflow change.
+14. No baseline change.
+15. No dependency change.
+16. No runtime source or kernel source change.
+17. No syscall or kernel ABI change.
+18. No package loader, module loader, workspace runtime, plugin host,
+    capability issuer, registry publication, trust issuer, deployment,
+    or distribution execution change.
+
+Until that exact-main post-merge verification exists, this validator
+output acceptance boundary must not be recorded as clean-fixed.
+
+Historical PASS results may be cited as context only.
+
+Failed attempts may be cited as transparent non-clean context only.
+
+They cannot be inherited as receipt evidence acceptance, runtime
+authority, package loading authority, package execution authority,
+source merge authority, capability authority, registry authority, trust
+authority, kernel ABI authority, syscall authority, workflow-threshold
+authority, baseline authority, dependency authority, or Ring0 authority.
+
+## Later Receipt Evidence Dependency
+
+This validator output acceptance boundary is a prerequisite input for a
+possible later bounded receipt-evidence acceptance path.
+
+A later receipt evidence acceptance record, if ever proposed, must
+define:
+
+1. Exact receipt evidence subject.
+2. Exact Phase-23 post-sync validator output acceptance prerequisite.
+3. Exact Phase-23 post-sync evidence item acceptance prerequisite.
+4. Exact changed-file boundary.
+5. Exact receipt-evidence acceptance grant, denial, or separate
+   receipt-evidence acceptance scope.
+6. Exact runtime implementation procedure denial.
+7. Exact package loading and package execution denials.
+8. Exact source acceptance and source merge denials.
+9. Exact capability, registry, trust, deployment, distribution, kernel
+   ABI, syscall, workflow-threshold, baseline, dependency, and Ring0
+   denials.
+10. Exact post-merge verification requirements.
+
+Until such a later reviewed receipt-evidence acceptance record is
+published, no receipt evidence acceptance exists from this validator
+output acceptance boundary.
+
+## Excluded Local Draft
+
+This validator output acceptance boundary does not consume:
+
+```text
+PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md
+```
+
+If that file exists locally as an untracked file, it remains:
+
+```text
+untracked
+PR-disjoint
+not validator output acceptance input
+not receipt evidence
+not runtime authority
+not package acceptance
+not source authority
+```
+
+It must not be staged, committed, or included in any Phase-23 post-sync
+validator output acceptance PR unless a separate reviewed scope
+explicitly authorizes that file.
+
+## Governance Boundary Invariants
+
+Every later RFC must preserve these Phase-23 post-sync validator output
+acceptance invariants:
+
+1. This document is bounded post-sync validator output acceptance
+   boundary only.
+2. This document is not receipt evidence acceptance.
+3. Validator output acceptance is not receipt evidence acceptance unless
+   separately reviewed.
+4. Receipt evidence is not accepted evidence unless separately reviewed.
+5. Receipt evidence is not evidence item acceptance unless separately
+   reviewed.
+6. Receipt evidence is not validator output acceptance unless separately
+   reviewed.
+7. This document is not runtime implementation procedure.
+8. This document is not source modification.
+9. This document is not code implementation.
+10. This document is not code execution.
+11. This document is not process start.
+12. This document is not runtime state creation.
+13. This document is not package installation.
+14. This document is not package loading.
+15. This document is not package execution.
+16. This document is not capability issuance.
+17. This document is not registry publication.
+18. This document is not trust assignment.
+19. This document is not deployment.
+20. This document is not distribution authority.
+21. This document is not source acceptance.
+22. This document is not source merge authority.
+23. This document does not modify `docs/roadmap/CURRENT_PHASE`.
+24. This document does not modify
+    `PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_EVIDENCE_ITEM_ACCEPTANCE.md`.
+25. `CURRENT_PHASE=23` is not receipt evidence acceptance.
+26. `CURRENT_PHASE=23` is not runtime implementation procedure.
+27. `CURRENT_PHASE=23` is not source modification.
+28. `CURRENT_PHASE=23` is not execution authority.
+29. `CURRENT_PHASE=23` is not package loading.
+30. `CURRENT_PHASE=23` is not source merge authority.
+31. This document does not broaden Phase-19 runtime authority.
+32. This document does not reopen Phase-20.
+33. This document does not reopen Phase-21.
+34. This document does not reopen Phase-22.
+35. This document does not expand kernel ABI or syscalls.
+36. This document does not change workflow thresholds, baselines, or
+    dependencies.
+37. Ambiguity fails closed.
+
+Violation of any invariant fails closed.
+
+## Conclusion
+
+This Phase-23 concrete accepted-evidence set membership assignment
+post-sync validator output acceptance is based on the clean-fixed
+Phase-23 concrete accepted-evidence set membership assignment post-sync
+evidence item acceptance publication subject:
+
+```text
+1e14761675b02c149743671c035399dd2310d0f2
+```
+
+It records only the bounded post-sync validator output acceptance
+boundary.
+
+It does not accept receipt evidence.
+
+It does not authorize runtime implementation procedure, source
+modification, code implementation, code execution, process start,
+runtime state creation, package installation, package loading, package
+execution, capability issuance, registry publication, trust assignment,
+deployment, distribution, source acceptance, source merge, kernel ABI
+expansion, syscall expansion, workflow-threshold changes, baseline
+changes, dependency changes, or Ring0 authority.
+
+Any later Phase-23 receipt-evidence-acceptance, package-review,
+source-review, runtime-implementation-procedure, or non-authorization
+boundary record requires its own exact-SHA evidence, changed-file scope,
+non-authorization boundary, and reviewed decision path.
+
+## Architecture Signature
+
+**Prepared by:** Kenan AY
+**Role:** AykenOS Architecture Steward
+**Document type:** Phase-23 concrete accepted-evidence set membership
+assignment post-sync validator output acceptance
+**Architecture status:** Local draft post-sync validator output
+acceptance / pending separate reviewed publication
+**Authority notice:** This signature identifies the architectural
+authorship of this validator output acceptance boundary. If separately
+reviewed and published, this document grants only the bounded post-sync
+validator output acceptance boundary defined in this document. It grants
+no receipt evidence acceptance authority, no runtime implementation
+procedure authority, no source modification authority, no code
+implementation authority, no code execution authority, no process start
+authority, no runtime state creation authority, no package authority, no
+package installation authority, no package loading authority, no package
+execution authority, no source acceptance authority, no source merge
+authority, no capability authority, no registry authority, no trust
+authority, no kernel ABI authority, no syscall authority, no
+workflow-threshold authority, no baseline authority, no dependency
+authority, and no Ring0 authority.


### PR DESCRIPTION
This PR changes only PHASE23_CONCRETE_ACCEPTED_EVIDENCE_SET_MEMBERSHIP_ASSIGNMENT_POST_SYNC_VALIDATOR_OUTPUT_ACCEPTANCE.md and records only a governance-only bounded post-sync validator output acceptance boundary after the clean-fixed post-sync evidence item acceptance boundary at 1e14761675b02c149743671c035399dd2310d0f2. It does not accept receipt evidence or authorize runtime/source/package/source-merge/capability/registry/trust/deployment/distribution/kernel ABI/syscall/workflow-threshold/baseline/dependency/Ring0 authority. PHASE21_FIRST_BOUNDED_IMPLEMENTATION_ACTUAL_SKELETON_PR_DESIGN.md remains untracked and PR-disjoint.